### PR TITLE
Mirror device timer locally so valves don't stay stuck-open

### DIFF
--- a/custom_components/orbit_bhyve/coordinator.py
+++ b/custom_components/orbit_bhyve/coordinator.py
@@ -7,7 +7,7 @@ cloud is never touched at runtime.
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -16,6 +16,11 @@ from .const import DEFAULT_POLL_IDLE, DEFAULT_POLL_WATERING
 from .devices import BHyveBleDeviceBase, DeviceState
 
 _LOGGER = logging.getLogger(__name__)
+
+# Grace window past expected_off_at before we declare the cycle finished
+# locally. Covers command-latency between our wall clock and the device's
+# internal timer, plus coordinator-tick jitter.
+EXPIRY_GRACE_SEC = 10
 
 
 class BHyveDeviceCoordinator(DataUpdateCoordinator[DeviceState]):
@@ -48,8 +53,38 @@ class BHyveDeviceCoordinator(DataUpdateCoordinator[DeviceState]):
             state = await self.device.refresh_state()
         except Exception as err:
             raise UpdateFailed(str(err)) from err
-        # Adjust polling cadence based on observed state.
-        target = self.poll_watering if state.is_watering else self.poll_idle
+        # The device's own timer auto-closes the valve after the duration we
+        # commanded; mirror that on the wall clock so the entity doesn't sit
+        # stuck-open forever once the BLE connection drops.
+        if state.is_watering and state.expected_off_at is not None:
+            now = datetime.now(timezone.utc)
+            if now >= state.expected_off_at + timedelta(seconds=EXPIRY_GRACE_SEC):
+                state.is_watering = False
+                state.active_zone = None
+                state.seconds_remaining = None
+                state.started_at = None
+                state.expected_off_at = None
+            else:
+                state.seconds_remaining = max(
+                    0, int((state.expected_off_at - now).total_seconds())
+                )
+        # Adjust polling cadence based on observed state. While watering, if
+        # we're inside the final stretch (expiry+grace lands sooner than the
+        # next watering-cadence tick would), shorten just enough to land the
+        # next tick on the expiry — so the entity flips closed promptly,
+        # not on the next 30s boundary.
+        if state.is_watering:
+            target = self.poll_watering
+            if state.expected_off_at is not None:
+                secs_until_off = (
+                    state.expected_off_at
+                    + timedelta(seconds=EXPIRY_GRACE_SEC)
+                    - datetime.now(timezone.utc)
+                ).total_seconds()
+                if 0 < secs_until_off < target:
+                    target = max(1, int(secs_until_off))
+        else:
+            target = self.poll_idle
         new_interval = timedelta(seconds=target)
         if new_interval != self.update_interval:
             self.update_interval = new_interval

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -25,6 +25,8 @@ class DeviceState:
     is_watering: bool = False
     active_zone: int | None = None
     seconds_remaining: int | None = None
+    started_at: datetime | None = None
+    expected_off_at: datetime | None = None
     last_command_at: datetime | None = None
     last_command_label: str | None = None
     is_connected: bool = False

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 
 from ..connection import BHyveBleConnection
 from .base import BHyveBleDeviceBase
@@ -121,9 +122,12 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         _LOGGER.debug("%s: START got %d notifications", self.mac, len(notifs))
         self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
         if notifs:
+            now = datetime.now(timezone.utc)
             self.state.is_watering = True
             self.state.active_zone = station
             self.state.seconds_remaining = duration_sec
+            self.state.started_at = now
+            self.state.expected_off_at = now + timedelta(seconds=duration_sec)
         return bool(notifs)
 
     async def stop_watering(self, station: int | None = None) -> bool:
@@ -137,6 +141,8 @@ class BHyveHT25Device(BHyveBleDeviceBase):
             self.state.is_watering = False
             self.state.active_zone = None
             self.state.seconds_remaining = None
+            self.state.started_at = None
+            self.state.expected_off_at = None
         return bool(notifs)
 
     async def refresh_state(self):


### PR DESCRIPTION
## Summary
- Stamp `started_at` / `expected_off_at` on `DeviceState` when `start_watering` succeeds; clear both on `stop_watering`.
- Coordinator mirrors the device's own timer on the wall clock: live `seconds_remaining` countdown each tick, flip `is_watering` off once `now >= expected_off_at + 10s` grace. **No extra BLE traffic.**
- Shorten the next coordinator interval during the final stretch so the off-flip lands at the grace boundary instead of waiting for the next `poll_watering_sec` (default 30s) tick.

## Why
After a watering command, the BLE connection idle-disconnects (`idle_disconnect_sec`, default 60s) while the valve's on-board timer keeps running. The integration had no polling for valve state (would drain the device's battery) and the `SEQ_STATUS` response is not yet decoded, so the entity sat "open" forever after the device auto-closed. The integration already knows the duration it commanded — this just makes HA act on that knowledge.

## Trade-off
HA-side state mirrors the device's internal timer; it does not observe ground truth. If someone presses the physical button mid-cycle, or a flow is cut short for any other reason, HA can drift until the next HA-initiated action. Acceptable because the integration is already optimistic today — this just makes the optimism eventually-correct instead of stuck-open-forever.

## Test plan
- [ ] Start a 120s cycle from HA UI on a Deck or Hill HT25.
- [ ] Watch the entity in Developer Tools → State: `seconds_remaining` decrements between coordinator ticks.
- [ ] Valve entity flips to closed at ~T+130s (duration + 10s grace).
- [ ] `dca logs -f home-assistant | grep orbit_bhyve`: exactly one connect at start, one disconnect after `idle_disconnect_sec`, **zero connects during countdown or at expiry**.
- [ ] Call `stop_watering` before expiry — entity flips off immediately and no late-expiry flip fires.

## Out of scope (follow-ups)
- Decode `SEQ_STATUS` response so `refresh_state()` returns real valve state.
- Passive BLE-advertisement listening (zero-cost ground truth, if the HT25 broadcasts state).
- One confirmation BLE poll at expiry to detect physical-button drift.