### PR TITLE
chore: bump version to v2.0.2

### DIFF
--- a/custom_components/orbit_bhyve/manifest.json
+++ b/custom_components/orbit_bhyve/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ljmerza/orbit-bhyve-ble/issues",
   "requirements": ["bleak-retry-connector>=3.5.0", "aiohttp>=3.9.0"],
-  "version": "2.0.0"
+  "version": "2.0.2"
 }


### PR DESCRIPTION
Bump manifest.json version for the v2.0.2 release.

(manifest.json drifted at 2.0.0 since v2.0.1 didn't bump it; this catches it up and includes the v2.0.2 fix.)