### PR TITLE
fix: send browser-like headers on cloud auth requests

### DIFF
--- a/custom_components/orbit_bhyve/cloud.py
+++ b/custom_components/orbit_bhyve/cloud.py
@@ -15,6 +15,7 @@ from .const import (
     CLOUD_APP_ID,
     CLOUD_KEY_FIELDS,
     CLOUD_KEY_PATHS,
+    CLOUD_USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +50,11 @@ class OrbitCloudClient:
         return self._user_id
 
     def _headers(self, *, include_auth: bool = True) -> dict[str, str]:
-        h = {"orbit-app-id": CLOUD_APP_ID}
+        h = {
+            "orbit-app-id": CLOUD_APP_ID,
+            "Accept": "application/json, text/plain, */*",
+            "User-Agent": CLOUD_USER_AGENT,
+        }
         if include_auth and self._token:
             h["orbit-api-key"] = self._token
         return h

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -20,6 +20,13 @@ SERVICE_UUID = "0000fe32-0000-1000-8000-00805f9b34fb"
 # Cloud API.
 CLOUD_API_BASE = "https://api.orbitbhyve.com/v1"
 CLOUD_APP_ID = "Bhyve-App"
+# Orbit's API began rejecting logins that lack browser-like headers around
+# 2026-05-12 (see sebr/bhyve-home-assistant#427). Send a desktop UA + Accept
+# on every cloud request so auth keeps working.
+CLOUD_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/72.0.3626.81 Safari/537.36"
+)
 CLOUD_KEY_PATHS = (
     "/meshes/{mesh_id}",
     "/network_topologies/{mesh_id}",


### PR DESCRIPTION
## Problem

Cloud login fails with an auth error (reported in #1). Orbit's API started rejecting requests that don't carry browser-like headers around 2026-05-12 — the official app and other integrations broke at the same time.

The current `_headers()` only sends `orbit-app-id` (login additionally sets `Content-Type`), so logins now get rejected even with correct credentials.

## Fix

Add `Accept` and `User-Agent` to the shared `OrbitCloudClient._headers()`, so login, device-list, and mesh-key fetches all carry them. Same root cause and fix as sebr/bhyve-home-assistant#427.

## Notes

- BLE/runtime is unaffected — this only touches the setup-time cloud client.
- I don't have hardware on a broken-auth state to verify end-to-end right now (off-season here), but this mirrors the fix confirmed working by multiple users on the upstream sebr integration.

Fixes #1.