### PR TITLE
fix(cloud): send a browser User-Agent so Orbit's WAF doesn't 403 setup

### DIFF
--- a/custom_components/orbit_bhyve/cloud.py
+++ b/custom_components/orbit_bhyve/cloud.py
@@ -15,6 +15,7 @@ from .const import (
     CLOUD_APP_ID,
     CLOUD_KEY_FIELDS,
     CLOUD_KEY_PATHS,
+    CLOUD_USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +50,17 @@ class OrbitCloudClient:
         return self._user_id
 
     def _headers(self, *, include_auth: bool = True) -> dict[str, str]:
-        h = {"orbit-app-id": CLOUD_APP_ID}
+        # Orbit's WAF returns 403 to requests whose User-Agent contains
+        # "HomeAssistant" — which is exactly what HA's shared aiohttp session
+        # (async_get_clientsession) stamps on every request. Without an
+        # override, every cloud call here is forbidden and config_flow
+        # mislabels it "invalid email or password". Send a browser User-Agent
+        # (matching the wider B-Hyve HA ecosystem's fix) so setup works.
+        h = {
+            "orbit-app-id": CLOUD_APP_ID,
+            "User-Agent": CLOUD_USER_AGENT,
+            "Accept": "application/json, text/plain, */*",
+        }
         if include_auth and self._token:
             h["orbit-api-key"] = self._token
         return h

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -20,6 +20,13 @@ SERVICE_UUID = "0000fe32-0000-1000-8000-00805f9b34fb"
 # Cloud API.
 CLOUD_API_BASE = "https://api.orbitbhyve.com/v1"
 CLOUD_APP_ID = "Bhyve-App"
+# Orbit's WAF 403s any request whose User-Agent contains "HomeAssistant"
+# (which HA's shared aiohttp session sets by default). Send a browser UA on
+# cloud calls so setup isn't rejected. See sebr/bhyve-home-assistant#427.
+CLOUD_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/72.0.3626.81 Safari/537.36"
+)
 CLOUD_KEY_PATHS = (
     "/meshes/{mesh_id}",
     "/network_topologies/{mesh_id}",


### PR DESCRIPTION
## Summary

Setup fails with **"invalid email or password"** even when the credentials are
correct. The real cause isn't auth at all: Orbit's API gateway (WAF) returns
**HTTP 403** to any request whose `User-Agent` contains `HomeAssistant` — which
is exactly what Home Assistant's shared aiohttp session
(`async_get_clientsession`) stamps on every outbound request by default. So
*every* cloud call the integration makes at setup is rejected before it's even
evaluated, and `config_flow` mislabels the 403 as bad credentials.

This is the same ecosystem-wide event that hit the cloud-based B-Hyve
integration ([sebr/bhyve-home-assistant#427](https://github.com/sebr/bhyve-home-assistant/issues/427), fixed there in 4.1.1).

## Root cause

`OrbitCloudClient._headers()` sent only `{"orbit-app-id": ...}`, so requests
inherited HA's default `User-Agent: HomeAssistant/<ver> aiohttp/<ver>`. The WAF
403s on that substring. Verified against the live API with dummy credentials:

| User-Agent | Result |
|---|---|
| `HomeAssistant/... aiohttp/...` | **403 Forbidden** (WAF block) |
| `python-requests/...` | 401 (reaches the app — normal "bad creds") |
| `Mozilla/5.0 ...` | 401 (reaches the app) |
| *(empty)* | 401 (reaches the app) |

The 401s prove the request *reaches* the application layer once the UA isn't
`HomeAssistant`; only the WAF-403 path is the bug.

## Fix

Send a browser `User-Agent` (and a normal `Accept`) on cloud calls, via a new
`const.CLOUD_USER_AGENT`:

```python
def _headers(self, *, include_auth: bool = True) -> dict[str, str]:
    h = {
        "orbit-app-id": CLOUD_APP_ID,
        "User-Agent": CLOUD_USER_AGENT,
        "Accept": "application/json, text/plain, */*",
    }
    if include_auth and self._token:
        h["orbit-api-key"] = self._token
    return h
```

## Scope & backwards compatibility

- **One place, additive.** Only the cloud REST `_headers()` changes.
- This integration contacts the cloud **only at setup** (no websocket, no
  background polling), so the change touches the setup path exclusively and has
  no effect on the BLE/runtime side.
- No behavior change for any already-working account beyond no longer being
  WAF-blocked.

## Testing

- Before: config flow fails immediately with "invalid email or password" on a
  known-good account.
- After: config flow logs in, discovers all devices on the account, and fetches
  each device's BLE network key — setup completes and entities appear.

## Related / follow-up

A second, independent issue can also surface the same "invalid email or
password" message on **newer-schema accounts** (key fetch aborting on a 401 from
`/meshes`). That's addressed in a separate PR so this universal WAF fix can land
on its own.

Fixes #1
