### PR TITLE
Fix fw0085 path: hardcoded developer mesh_id (d747) silently drops all commands

### DIFF
--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -4,6 +4,8 @@ d7-47 protocol family. Verified against fw0085 (Deck) 2026-05-03 and
 fw0041 (Hill) 2026-05-05 — same protocol, the 2-byte frame prefix is the
 device's own mesh_device_id in little-endian (Deck's old "D747_MAGIC"
 constant was just Deck's mesh_id 18391 = 0x47D7 LE).
+
+Firmware variants subclass this and override _rebind_sid_delta only.
 """
 from __future__ import annotations
 
@@ -48,6 +50,11 @@ class BHyveHT25Device(BHyveBleDeviceBase):
     frame_magic = 0x10
     trailer_const = 0x10
 
+    # Session-id increment between the `bind` and `rebind` init steps.
+    # fw0041 (Hill) confirmed +2 via BTSnoop 2026-05-05. Firmware variants
+    # override this attribute in a subclass rather than branching in code.
+    _rebind_sid_delta: int = 2
+
     @property
     def mesh_address(self) -> bytes:
         """The 2-byte device-address prefix on every command frame.
@@ -64,7 +71,15 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         """The 2-byte hub-address embedded in the magic2 init step."""
         hub_id = self.hub_mesh_device_id
         if hub_id is None:
-            hub_id = _HUB_MESH_BY_NETWORK_KEY.get(self.network_key.lower(), 0)
+            hub_id = _HUB_MESH_BY_NETWORK_KEY.get(self.network_key.lower())
+            if hub_id is None:
+                _LOGGER.warning(
+                    "%s: hub_mesh_device_id unresolved (network_key not in fallback "
+                    "table); using 0x0000 in magic2. Init still completes with a "
+                    "placeholder hub id, but if START is dropped this is a suspect.",
+                    self.mac,
+                )
+                hub_id = 0
         return hub_id.to_bytes(2, "little")
 
     def _build(self, type_byte: int, seq: int, payload: bytes = b"") -> bytes:
@@ -84,11 +99,17 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         watering command without it produces a silent drop. Only `bind`,
         `status`, and `info` are confirmed required; the others may be
         prunable but are kept for safety until empirically tested."""
+        # Surface resolved addresses so a test run self-verifies the prefix is
+        # the device's own id and NOT the legacy hardcoded d747.
+        _LOGGER.debug(
+            "%s: frames mesh_address=%s hub_mesh_address=%s",
+            self.mac, self.mesh_address.hex(), self.hub_mesh_address.hex(),
+        )
+
         sid = os.urandom(2)
-        # fw0041 (Hill, BTSnoop 2026-05-05): bind sid=0x48fd → rebind sid=0x48ff = +2.
-        # fw0085 has its own pre-fix code path in ht25_fw0085.py — don't add
-        # firmware branching here.
-        sid2 = ((int.from_bytes(sid, "little") + 2) & 0xFFFF).to_bytes(2, "little")
+        # Rebind reuses the session id incremented by a firmware-specific delta
+        # (fw0041=+2; see _rebind_sid_delta / subclasses).
+        sid2 = ((int.from_bytes(sid, "little") + self._rebind_sid_delta) & 0xFFFF).to_bytes(2, "little")
 
         # magic1 payload: 0x01 || self mesh_id LE || 4 zero bytes
         # magic2 payload: 0x00 || hub  mesh_id LE || 4 zero bytes
@@ -118,6 +139,7 @@ class BHyveHT25Device(BHyveBleDeviceBase):
             return False
         # HT25 is single-station; `station` is a no-op placeholder for API parity.
         plaintext = self._build_start(0xB6, duration_sec)
+        _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
         notifs = await self.connection.send(plaintext, drain_ms=1500)
         _LOGGER.debug("%s: START got %d notifications", self.mac, len(notifs))
         self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
@@ -134,6 +156,7 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         if self.connection is None:
             return False
         plaintext = self._build_stop(0xB7)
+        _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
         notifs = await self.connection.send(plaintext, drain_ms=1500)
         _LOGGER.debug("%s: STOP got %d notifications", self.mac, len(notifs))
         self._stamp_command("stop", len(notifs))

--- a/custom_components/orbit_bhyve/devices/ht25_fw0085.py
+++ b/custom_components/orbit_bhyve/devices/ht25_fw0085.py
@@ -1,108 +1,24 @@
-"""HT25-0000 fw0085 — Deck's pre-fix code path.
+"""HT25-0000 fw0085 — thin variant of the base HT25 d7-47 device class.
 
-This is the byte-for-byte pre-fix code that empirically actuated Deck on
-2026-05-03. After the fix that parameterized frame addressing for fw0041
-(Hill/Corner), Deck stopped physically actuating even though the new code
-produces byte-identical frames (mesh_address=d747 = D747_MAGIC, hub_mesh
-fallback=42eb). Splitting it back out as its own class so fw0085 keeps a
-known-working code path independent of fw0041 evolution.
-
-DO NOT touch this file unless you have a phone-app BTSnoop capture against
-fw0085 to validate the change.
+The original standalone fw0085 implementation hardcoded the developer's own
+timer mesh_id (0x47D7 → on-wire prefix "d747") into every frame, so the timer's
+application parser silently dropped commands whose prefix didn't match its own
+id — while the BLE link layer still ack'd every write, masking the fault during
+init. That fix already lives in ht25.BHyveHT25Device (dynamic per-device
+mesh_address). This class now INHERITS that single source of truth and overrides
+only the one value that is claimed to differ for fw0085.
 """
 from __future__ import annotations
 
-import asyncio
-import logging
-import os
-
-from ..connection import BHyveBleConnection
-from .base import BHyveBleDeviceBase
-
-_LOGGER = logging.getLogger(__name__)
-
-D747_MAGIC = bytes([0xD7, 0x47])
-D747_ROUTING = 0x40
-SEQ_BIND = 0x05
-SEQ_STATUS = 0x02
-SEQ_INFO = 0x03
-SEQ_SUBSYSTEM = 0x01
-SEQ_MAGIC_CHECK = 0x00
-SEQ_HEARTBEAT = 0x09
-SEQ_WATER_CTRL = 0x0D
-
-INIT_INTER_STEP_SEC = 0.15
-
-BIND_TAIL = bytes.fromhex("f66910ff")
+from .ht25 import BHyveHT25Device
 
 
-def _build(type_byte: int, seq: int, payload: bytes = b"") -> bytes:
-    return D747_MAGIC + bytes([type_byte & 0xFF, seq & 0xFF, D747_ROUTING]) + payload
+class BHyveHT25Fw0085Device(BHyveHT25Device):
+    """HT25 single-station timer, firmware 0085.
+    Identical to the base HT25 protocol in every frame, payload, and opcode.
+    """
 
-
-def _build_start(type_byte: int, duration_sec: int) -> bytes:
-    if not 0 < duration_sec <= 0xFFFF:
-        raise ValueError(f"duration_sec out of range (1..65535): {duration_sec}")
-    payload = bytes([0x04]) + duration_sec.to_bytes(2, "little") + b"\x00\x00\x00\x00"
-    return _build(type_byte, SEQ_WATER_CTRL, payload)
-
-
-def _build_stop(type_byte: int) -> bytes:
-    return _build(type_byte, SEQ_WATER_CTRL, b"\x02\x00\x00\x00")
-
-
-class BHyveHT25Fw0085Device(BHyveBleDeviceBase):
-    """HT25 single-station timer — pre-fix Deck code path (fw0085)."""
-
-    frame_magic = 0x10
-    trailer_const = 0x10
-
-    async def _post_handshake(self, conn: BHyveBleConnection) -> None:
-        sid = os.urandom(2)
-        sid2 = ((int.from_bytes(sid, "little") + 3) & 0xFFFF).to_bytes(2, "little")
-
-        steps: list[tuple[bytes, str]] = [
-            (_build(0x81, SEQ_BIND, sid + BIND_TAIL), "bind"),
-            (_build(0x02, SEQ_STATUS, b"\x00"), "status"),
-            (_build(0x03, SEQ_INFO, b"\x00" * 7), "info"),
-            (_build(0x04, SEQ_SUBSYSTEM, b"\x00" * 3), "subsystem"),
-            (_build(0x85, SEQ_MAGIC_CHECK, bytes.fromhex("01d74700000000")), "magic1"),
-            (_build(0x85, SEQ_MAGIC_CHECK, bytes.fromhex("0042eb00000000")), "magic2"),
-            (_build(0x85, SEQ_HEARTBEAT, b"\x00"), "heartbeat"),
-            (_build(0x86, SEQ_BIND, sid2 + BIND_TAIL), "rebind"),
-        ]
-        for plaintext, label in steps:
-            _LOGGER.debug("%s: init → %s pt=%s", self.mac, label, plaintext.hex())
-            await conn._write_locked(plaintext)
-            await asyncio.sleep(INIT_INTER_STEP_SEC)
-        await asyncio.sleep(0.3)
-
-    async def start_watering(self, station: int, duration_sec: int) -> bool:
-        if self.connection is None:
-            return False
-        plaintext = _build_start(0xB6, duration_sec)
-        notifs = await self.connection.send(plaintext, drain_ms=1500)
-        _LOGGER.debug("%s: START got %d notifications", self.mac, len(notifs))
-        self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-        if notifs:
-            self.state.is_watering = True
-            self.state.active_zone = station
-            self.state.seconds_remaining = duration_sec
-        return bool(notifs)
-
-    async def stop_watering(self, station: int | None = None) -> bool:
-        if self.connection is None:
-            return False
-        plaintext = _build_stop(0xB7)
-        notifs = await self.connection.send(plaintext, drain_ms=1500)
-        _LOGGER.debug("%s: STOP got %d notifications", self.mac, len(notifs))
-        self._stamp_command("stop", len(notifs))
-        if notifs:
-            self.state.is_watering = False
-            self.state.active_zone = None
-            self.state.seconds_remaining = None
-        return bool(notifs)
-
-    async def refresh_state(self):
-        await super().refresh_state()
-        return self.state
+    # Base = 2 (fw0041 Hill, BTSnoop-confirmed). 3 retained from the legacy
+    # fw0085 path purely to minimise change from the deployed version — NOT
+    # confirmed. Flip to 2 if START is dropped. See module docstring.
+    _rebind_sid_delta = 3


### PR DESCRIPTION
The ht25_fw0085.py path hardcodes the developer's own timer/hub mesh ids (0x47D7 → on-wire prefix d747, hub 0xEB42) into every frame. These are per-device cloud-assigned addresses, not protocol constants, so on any other user's hardware the timer's parser silently drops the watering command while BLE link-layer acks make init look healthy — START got 0 notifications, no actuation. ht25.py already resolves the prefix dynamically; the standalone fw0085 fork never got that fix. This collapses fw0085 to inherit the dynamic-address base class and override only the +3 rebind delta.

Verified on reference HW (HT25-0000 fw0085) across four timers, start and stop, fully local: prefix goes from d747 → each device's own id, and 0 notifications → working start/stop with the device echoing the duration back. Logs attached.

[log2.log](https://github.com/user-attachments/files/29426307/log2.log)

[log3.log](https://github.com/user-attachments/files/29426177/log3.log)

[log4.log](https://github.com/user-attachments/files/29426140/log4.log)