### PR TITLE
fix(cloud): don't abort key fetch on a /meshes 401/403 — fall through to the other endpoints

### DIFF
--- a/custom_components/orbit_bhyve/cloud.py
+++ b/custom_components/orbit_bhyve/cloud.py
@@ -103,7 +103,16 @@ class OrbitCloudClient:
             raise CloudConnectionError(str(err)) from err
 
     async def get_mesh(self, mesh_id: str) -> dict[str, Any]:
-        """Try /meshes/<id> first; fall back to legacy paths on 404."""
+        """Try /meshes/<id> first; fall back to the other paths on 401/403/404.
+
+        A 401/403 here is NOT an expired session: login and /devices already
+        succeeded with this token before get_mesh runs, so an auth-style
+        rejection means the endpoint simply doesn't apply to this account's
+        schema (newer-schema accounts return 401 for /meshes and serve keys
+        from /network_topologies). Treat it like 404 and try the next path,
+        rather than aborting discovery — which config_flow would otherwise
+        surface to the user as "invalid email or password".
+        """
         last_status = None
         for path_tmpl in CLOUD_KEY_PATHS:
             path = path_tmpl.format(mesh_id=mesh_id)
@@ -114,10 +123,8 @@ class OrbitCloudClient:
                     headers=self._headers(),
                     timeout=aiohttp.ClientTimeout(total=20),
                 ) as resp:
-                    if resp.status == 401:
-                        raise CloudAuthError("session expired")
-                    if resp.status == 404:
-                        last_status = 404
+                    if resp.status in (401, 403, 404):
+                        last_status = resp.status
                         continue
                     resp.raise_for_status()
                     return await resp.json()


### PR DESCRIPTION
## Problem

`OrbitCloudClient.get_mesh()` tries the key endpoints in order
(`/meshes/<id>` → `/network_topologies/<id>` → `/networks/<id>`) but **aborts on
the first `401`** by raising `CloudAuthError("session expired")`. Only a `404`
falls through to the next path.

On some accounts the network key does **not** live under `/meshes` — that path
returns **401** while the key is actually served from `/network_topologies`.
For those accounts setup fails to find any key even though auth is fine and the
key is one endpoint away.

This complements #6 (the WAF User-Agent fix): #6 gets the request past the WAF
to the application layer; this lets key discovery survive a non-matching
endpoint's 401/403 and reach the one that has the key.

## Fix

In `get_mesh()`, treat `401`/`403` like `404` — record `last_status` and
continue to the next candidate path. Only a genuine error (`raise_for_status`)
or exhausting all paths raises. One-line behavior change, no new endpoints.

## Verification

Live, on a real account whose keys are on `/network_topologies` (the `/meshes`
path 401s): with this change, setup completes and discovers the full account
(4× HT25G2 valves + an HT34A XD + hub). Without it, discovery aborts on the
`/meshes` 401.

---

Context: we've been doing hardware-verified BLE work on this integration across a
6-device fleet and have a few more small, individually-verified fixes queued
(Gen2 protobuf routing, live RX battery/state telemetry, a bounded-handshake
connect retry). Happy to send them one at a time at whatever cadence works for
you, and to coordinate with @stuartdenne so we're not duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
