### PR TITLE
feat(devices): support Gen2 HT25G2 hose-tap valves (protobuf protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ when the WAN goes down.
 |-------------------|----------------|------------------|------------------------------------------|
 | Hose-tap timer    | `HT25-0000`    | `0085`           | ✅ Actuated end-to-end                   |
 | Hose-tap timer    | `HT25-0000`    | `0041`           | ✅ Actuated end-to-end (per-device mesh-ID addressing) |
+| Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
 | 4-port XD         | `HT34A-0001`   | `0107`           | ⚠️ Ported from upstream; not tested here|
 
 > ⚠️ **Do NOT update your B-Hyve device firmware.** This integration was

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -10,6 +10,7 @@ from .base import BHyveBleDeviceBase, DeviceState, UnsupportedModel
 from .hub import BHyveHubDevice
 from .ht25 import BHyveHT25Device
 from .ht25_fw0085 import BHyveHT25Fw0085Device
+from .ht25g2 import BHyveHT25G2Device
 from .ht34a import BHyveHT34ADevice
 
 __all__ = [
@@ -19,6 +20,7 @@ __all__ = [
     "BHyveHubDevice",
     "BHyveHT25Device",
     "BHyveHT25Fw0085Device",
+    "BHyveHT25G2Device",
     "BHyveHT34ADevice",
     "resolve_device_class",
     "build_device",
@@ -29,6 +31,13 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
     if type_ == "bridge":
         return BHyveHubDevice
     if (hardware or "").startswith("HT25"):
+        # Gen2 HT25G2 valves (fw0111) share the "HT25" hardware prefix but
+        # speak the protobuf protocol (frame magic 0x11) like the HT34A XD,
+        # NOT the d7-47 mesh protocol of the HT25-0000 hose timers. Route
+        # them away from the mesh classes before falling through. Match on
+        # the hardware suffix or fw so HT25-0000 (fw0041/0085) is untouched.
+        if (hardware or "").startswith("HT25G2") or firmware == "0111":
+            return BHyveHT25G2Device
         # fw0085 (Deck) keeps the pre-fix code path that empirically actuated
         # on 2026-05-03. fw0041 (Hill, Corner) and any future fw use the
         # parameterized BHyveHT25Device.

--- a/custom_components/orbit_bhyve/devices/ht25g2.py
+++ b/custom_components/orbit_bhyve/devices/ht25g2.py
@@ -1,0 +1,62 @@
+"""HT25G2 (Gen2 single-station hose timer) device class.
+
+Protobuf protocol family — the SAME framing, cipher, and timerMode start
+message as the HT34A XD timer (frame magic 0x11), NOT the d7-47 mesh
+protocol the older HT25-0000 hose timers (fw0041/0085) speak. Sharing a
+"HT25" hardware prefix with those mesh devices is the only thing they have
+in common; the dispatcher in __init__.py disambiguates by hardware-suffix /
+firmware so these land here instead of on BHyveHT25Device.
+
+Sibling of BHyveHT34ADevice (not a subclass): both are single, independent
+BHyveBleDeviceBase classes that reuse the shared protobuf builder functions
+from ht34a. This keeps the device classes decoupled — matching the pattern
+the rest of devices/ follows — so XD-specific changes can't silently alter
+the Gen2 path.
+
+Hardware-verified start AND stop on fw0111 valves (BTValve01-04) via the
+standalone CLI, which drives byte-identical protobuf frames. Single station:
+the device exposes one valve, addressed as wire station_id 0 (station 1 - 1).
+"""
+from __future__ import annotations
+
+import logging
+
+from .base import BHyveBleDeviceBase
+from .ht34a import _STOP_PB, _build_message, _build_start_pb
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BHyveHT25G2Device(BHyveBleDeviceBase):
+    """Gen2 single-station valve (fw0111), protobuf protocol family."""
+
+    frame_magic = 0x11
+    trailer_const = 0x11
+
+    async def start_watering(self, station: int, duration_sec: int) -> bool:
+        if self.connection is None:
+            return False
+        # Single-station device: wire station_id is 0-indexed (station 1 -> 0).
+        plaintext = _build_message(_build_start_pb(station - 1, duration_sec))
+        notifs = await self.connection.send(plaintext, drain_ms=2000)
+        _LOGGER.debug("%s: HT25G2 START station=%d got %d notifications",
+                      self.mac, station, len(notifs))
+        self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+        if notifs:
+            self.state.is_watering = True
+            self.state.active_zone = station
+            self.state.seconds_remaining = duration_sec
+        return bool(notifs)
+
+    async def stop_watering(self, station: int | None = None) -> bool:
+        if self.connection is None:
+            return False
+        plaintext = _build_message(_STOP_PB)
+        notifs = await self.connection.send(plaintext, drain_ms=2000)
+        _LOGGER.debug("%s: HT25G2 STOP got %d notifications", self.mac, len(notifs))
+        self._stamp_command("stop", len(notifs))
+        if notifs:
+            self.state.is_watering = False
+            self.state.active_zone = None
+            self.state.seconds_remaining = None
+        return bool(notifs)


### PR DESCRIPTION
## Summary

Adds support for the **Gen2 single-station hose-tap valve**, hardware
`HT25G2-0001`, firmware `0111`. These units carry an `HT25`-prefixed hardware
string but **speak the protobuf control protocol (frame magic `0x11`) — the same
as the HT34A XD — not the d7-47 mesh protocol** used by the original
`HT25-0000` (fw0041/0085) hose timers. Routing them to the existing HT25 mesh
classes can't actuate them.

## Changes

- **New `devices/ht25g2.py` → `BHyveHT25G2Device`** (`frame_magic = trailer_const
  = 0x11`), reusing the shared protobuf builders from `ht34a`. Single station,
  addressed as wire `station_id 0` (`station 1 - 1`) — byte-identical frames to
  the standalone CLI that drives these units.
- **Routing in `devices/__init__.py`:** inside the existing `HT25`-prefix block,
  route to the protobuf class **before** the mesh paths, matching on the
  `HT25G2` hardware suffix or `fw0111`:

  ```python
  if hardware.startswith("HT25"):
      if hardware.startswith("HT25G2") or firmware == "0111":   # new
          return BHyveHT25G2Device
      if firmware == "0085":
          return BHyveHT25Fw0085Device                          # unchanged
      return BHyveHT25Device                                    # unchanged
  ```
- **README:** added an `HT25G2-0001` / `0111` row to the supported-hardware table.

## Backwards compatibility

Strictly additive. The new clause is **nested under the `HT25` prefix and runs
first**, but the existing branches are untouched: `HT25-0000` on `0041` → still
`BHyveHT25Device`, on `0085` → still `BHyveHT25Fw0085Device`. No existing device
is rerouted — within the HT25 family, `fw0111` is the Gen2 signature; `fw0041`/
`0085` never match the new clause.

## Testing — hardware-validated

Four `HT25G2-0001` (fw0111) valves on one account: **open and close actuate
end-to-end over Home Assistant**, both via an ESPHome Bluetooth proxy and a
direct adapter. The devices return decodable protobuf status notifications
(`aa775a0f…` carrying the device MAC + run-state), confirming correct routing —
a mesh-class misroute could not produce those frames.
