### PR TITLE
Port worthwhile improvements from the stuartdenne fork (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ when the WAN goes down.
 | Hose-tap timer    | `HT25-0000`    | `0085`           | ✅ Actuated end-to-end                   |
 | Hose-tap timer    | `HT25-0000`    | `0041`           | ✅ Actuated end-to-end (per-device mesh-ID addressing) |
 | Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
-| 4-port XD         | `HT34A-0001`   | `0107`           | ⚠️ Ported from upstream; not tested here|
+| 4-port XD         | `HT34A-0001`   | `0107`           | ⚠️ Protobuf control + battery/status decode; not tested here |
+| 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
 
 > ⚠️ **Do NOT update your B-Hyve device firmware.** This integration was
 > reverse-engineered against the firmware versions above. A firmware update
@@ -39,7 +40,7 @@ when the WAN goes down.
 
 Per discovered sprinkler device:
 
-- **Valve** per physical station (HT25 = 1, HT34A = up to 4) — uses
+- **Valve** per physical station (HT25 = 1, HT34A/HT34 = up to 4) — uses
   `valve.open_valve` / `valve.close_valve`. Open/closed state is
   **optimistic** (derived from the last command, not from a decoded
   device status).
@@ -48,6 +49,12 @@ Per discovered sprinkler device:
 - **Battery voltage (mV)** sensor — same source as the percent sensor;
   disabled by default, enable it from the entity's settings if you want
   the raw reading.
+- **Signal strength (RSSI)** sensor — the BLE advertisement RSSI from
+  Home Assistant's bluetooth manager (works even while disconnected);
+  disabled by default.
+- **Connected** and **Watering** binary sensors — device connectivity
+  (diagnostic) and whether a station is currently running, for automations
+  and dashboards.
 - **Default watering duration** (`number` entity, minutes) — per device.
   The valve uses this when `start_watering` is called without an
   explicit duration. Restored across HA restarts.
@@ -87,9 +94,11 @@ registry.
    does an AES handshake, runs the model-specific init sequence on first
    connect, then sends one encrypted frame per command and reads back
    notifications
-3. **Reuse**: the connection stays open across commands until idle timeout;
-   subsequent commands skip the handshake and init, going directly to the
-   command frame
+3. **Reuse**: the connection stays open across commands until idle timeout.
+   Watering commands re-run the model init/bind first — the device silently
+   ignores a watering frame sent on a stale bind — while reads reuse the
+   pooled session directly. Marginal proxy links get a bounded handshake with
+   a few clean retries instead of a wedged connection.
 
 The cipher (AES-128-ECB used as a CTR-style keystream, frame trailer =
 `sum(plaintext) + magic + len`) was reverse-engineered against captured
@@ -97,6 +106,14 @@ phone-app traffic. Different hardware families (HT25 vs HT34A) use different
 inner plaintext formats and different magic bytes; the per-model device
 classes encode that. Adding a new model = drop a `devices/htXX.py` and
 register it.
+
+## Credits
+
+The marginal-link connection hardening (bounded handshake + retry, capped
+write-ack), the per-command re-bind for HT25 actuation, the RSSI and
+connectivity/watering sensors, and the HT34/HT34A battery + watering-status
+decode were ported from
+[@stuartdenne](https://github.com/stuartdenne/ha-orbit-bhyve-ble-old)'s fork.
 
 ## Legal & ethical notice
 

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -37,7 +37,13 @@ from .devices import UnsupportedModel, build_device
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.VALVE, Platform.SENSOR, Platform.NUMBER, Platform.BUTTON]
+PLATFORMS: list[Platform] = [
+    Platform.VALVE,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.BUTTON,
+]
 
 
 class EntryRuntime:
@@ -230,4 +236,51 @@ def _register_services(hass: HomeAssistant) -> None:
         "probe_status",
         probe_status,
         schema=vol.Schema({vol.Required("mac"): str}),
+    )
+
+    async def probe_send(call: ServiceCall) -> None:
+        """Debug-only: send an arbitrary inner-plaintext frame to a device and
+        let _on_notify decrypt+log the replies. For reverse-engineering — e.g.
+        a protobuf getDeviceInfo query to the quad. The `plaintext` hex is the
+        inner frame (for HT34A: AA775A0F + len + 00 + protobuf + CRC16);
+        connection.encrypt() adds the [magic][len]..[trailer] wrapper. Optional
+        `magic` overrides frame_magic/trailer_const (forces a reconnect). A
+        reply that decodes is logged as 'notif pt=...'; one with a mismatched
+        magic logs 'notif decrypt failed: bad frame magic raw=...', which
+        reveals the device's actual magic byte."""
+        mac = call.data["mac"].upper()
+        plaintext = bytes.fromhex(call.data["plaintext"])
+        magic = call.data.get("magic")
+        drain = int(call.data.get("drain_ms", 2000))
+        for runtime in hass.data.get(DOMAIN, {}).values():
+            for coord in runtime.coordinators.values():
+                if (coord.device.mac or "").upper() != mac:
+                    continue
+                conn = coord.device.connection
+                if conn is None:
+                    _LOGGER.warning("probe_send: %s has no BLE connection", mac)
+                    return
+                if magic is not None:
+                    m = int(magic) & 0xFF
+                    _LOGGER.warning("probe_send: %s magic->0x%02x; reconnecting", mac, m)
+                    conn._frame_magic = m
+                    conn._trailer_const = m
+                    await conn.disconnect()
+                _LOGGER.warning("probe_send: %s -> %s", mac, plaintext.hex())
+                notifs = await conn.send(plaintext, drain_ms=drain)
+                _LOGGER.warning("probe_send: %s got %d notification(s)", mac, len(notifs))
+                return
+        _LOGGER.warning("probe_send: no device with mac=%s", mac)
+
+    hass.services.async_register(
+        DOMAIN,
+        "probe_send",
+        probe_send,
+        schema=vol.Schema({
+            vol.Required("mac"): str,
+            vol.Required("plaintext"): str,
+            vol.Optional("magic"): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+            vol.Optional("drain_ms", default=2000):
+                vol.All(vol.Coerce(int), vol.Range(min=100, max=10000)),
+        }),
     )

--- a/custom_components/orbit_bhyve/binary_sensor.py
+++ b/custom_components/orbit_bhyve/binary_sensor.py
@@ -1,0 +1,82 @@
+"""Binary sensor platform — BLE connectivity and watering state.
+
+One Connected (diagnostic) and one Watering binary sensor per non-hub device.
+Both read DeviceState, which the coordinator refreshes on each poll and which
+the device also updates out of band from its notification acks.
+"""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BHyveDeviceCoordinator
+from .devices import BHyveHubDevice
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    entities: list[BinarySensorEntity] = []
+    for coord in runtime.coordinators.values():
+        if isinstance(coord.device, BHyveHubDevice):
+            continue
+        if coord.device.connection is None:
+            continue
+        entities.append(BHyveConnectedBinarySensor(coord))
+        entities.append(BHyveWateringBinarySensor(coord))
+    async_add_entities(entities)
+
+
+class _BHyveBinarySensorBase(CoordinatorEntity[BHyveDeviceCoordinator], BinarySensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+
+class BHyveConnectedBinarySensor(_BHyveBinarySensorBase):
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_connected"
+        self._attr_name = "Connected"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.device.state.is_connected
+
+
+class BHyveWateringBinarySensor(_BHyveBinarySensorBase):
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_icon = "mdi:sprinkler-variant"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_watering"
+        self._attr_name = "Watering"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.device.state.is_watering

--- a/custom_components/orbit_bhyve/connection.py
+++ b/custom_components/orbit_bhyve/connection.py
@@ -10,7 +10,10 @@ Cipher (verified against 257 captured frames + actuated commands):
   TX counter = uint32_LE(init_tx[12:16]); RX counter = init_tx[16:20].
   Frame = [magic][len][ciphertext (len bytes)][trailer u16_LE].
   Trailer = sum(plaintext) + trailer_const + len.
-WRITE_REQ (response=True) is required — WRITE_CMD is silently dropped.
+WRITE_REQ (response=True) is required — WRITE_CMD is silently dropped. The
+device acks via NOTIFICATION, not an ATT Write Response; the ESPHome BLE proxy
+doesn't relay the (absent) write response, so writes are sent with a capped
+wait (WRITE_ACK_TIMEOUT_SEC) and the notification drain is the real ack.
 """
 from __future__ import annotations
 
@@ -27,6 +30,20 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from .const import AES_CHAR, READ_CHAR, WRITE_CHAR
 
 _LOGGER = logging.getLogger(__name__)
+
+# Cap on waiting for an ATT Write Response that the device never sends (it acks
+# via notification instead). Over a direct link the response arrives in <200ms;
+# over the ESPHome proxy it never comes, so we proceed after this. The device's
+# notification ack arrives in ~50-150ms, so this is a generous floor that still
+# keeps cold-start init (8 writes) under ~7s.
+WRITE_ACK_TIMEOUT_SEC = 0.8
+
+# The connect succeeds even on a weak proxy link, but the post-connect handshake
+# (subscribe + AES read/write) can stall on a marginal signal. Bound it so it
+# fails cleanly instead of wedging the connection, and retry the whole open a
+# few times — a clean retry often catches a good GATT window.
+HANDSHAKE_TIMEOUT_SEC = 10.0
+OPEN_MAX_ATTEMPTS = 3
 
 PostHandshakeHook = Callable[["BHyveBleConnection"], Awaitable[None]]
 PlaintextObserver = Callable[[bytes], None]
@@ -80,11 +97,30 @@ class BHyveBleConnection:
         self._plaintext_observer = observer
 
     async def ensure_connected(self) -> None:
-        """Connect + handshake if not already pooled. Call inside a lock if you
-        need exclusive access; this method itself is idempotent."""
+        """Connect + handshake if not already pooled, retrying the whole open a
+        few times. On a marginal proxy link the connect succeeds but the
+        handshake GATT exchange can stall; a clean retry usually gets through,
+        and the bounded handshake means we fail cleanly rather than wedging.
+        Call inside a lock if you need exclusive access; idempotent otherwise."""
         if self.is_connected and self._handshaken:
             return
-        await self._open()
+        last_err: Exception | None = None
+        for attempt in range(1, OPEN_MAX_ATTEMPTS + 1):
+            try:
+                await self._open()
+                return
+            except (BleHandshakeError, asyncio.TimeoutError) as err:
+                last_err = err
+                _LOGGER.debug(
+                    "%s: open attempt %d/%d failed: %s",
+                    self.mac, attempt, OPEN_MAX_ATTEMPTS, err,
+                )
+                await self.disconnect()
+                if attempt < OPEN_MAX_ATTEMPTS:
+                    await asyncio.sleep(0.5)
+        raise BleHandshakeError(
+            f"{self.mac}: handshake failed after {OPEN_MAX_ATTEMPTS} attempts: {last_err}"
+        )
 
     async def _open(self) -> None:
         from homeassistant.components.bluetooth import async_ble_device_from_address
@@ -102,6 +138,36 @@ class BHyveBleConnection:
         # device tested ("Write not permitted"). Confirmed not the actual
         # mechanism for fw0041 the v1 commit fad91eae assumed.
 
+        # The post-connect handshake (subscribe + AES read/write) is the part
+        # that stalls on a marginal link, so bound it — ensure_connected()
+        # retries the whole open on timeout.
+        try:
+            await asyncio.wait_for(self._handshake(), timeout=HANDSHAKE_TIMEOUT_SEC)
+        except asyncio.TimeoutError as err:
+            raise BleHandshakeError(
+                f"{self.mac}: handshake timed out after {HANDSHAKE_TIMEOUT_SEC}s"
+            ) from err
+
+        # One-shot GATT enumeration — looking for standard Battery Service
+        # (0x180F / 0x2A19) or anything else the device exposes that we
+        # haven't been using. Logged at INFO for reverse-engineering work.
+        try:
+            for service in self._client.services:
+                _LOGGER.info("%s: gatt svc %s", self.mac, service.uuid)
+                for char in service.characteristics:
+                    _LOGGER.info(
+                        "%s:   char %s props=%s",
+                        self.mac, char.uuid, list(char.properties),
+                    )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("%s: gatt enum failed: %s", self.mac, err)
+
+        if self._post_handshake_hook is not None:
+            await self._post_handshake_hook(self)
+
+    async def _handshake(self) -> None:
+        """Subscribe + AES handshake. Bounded by a timeout in _open() because
+        these GATT reads/writes are what stall on a weak link."""
         # Subscribe BEFORE writing — device may stay silent otherwise.
         self._notif_buf.clear()
         await self._client.start_notify(READ_CHAR, self._on_notify)
@@ -121,23 +187,6 @@ class BHyveBleConnection:
         self._rx_ctr = struct.unpack("<I", buf[16:20])[0]
         self._handshaken = True
         _LOGGER.debug("%s: handshake ok, iv=%s tx_ctr=0x%08x", self.mac, self._iv.hex(), self._tx_ctr)
-
-        # One-shot GATT enumeration — looking for standard Battery Service
-        # (0x180F / 0x2A19) or anything else the device exposes that we
-        # haven't been using.
-        try:
-            for service in self._client.services:
-                _LOGGER.info("%s: gatt svc %s", self.mac, service.uuid)
-                for char in service.characteristics:
-                    _LOGGER.info(
-                        "%s:   char %s props=%s",
-                        self.mac, char.uuid, list(char.properties),
-                    )
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("%s: gatt enum failed: %s", self.mac, err)
-
-        if self._post_handshake_hook is not None:
-            await self._post_handshake_hook(self)
 
     def _on_notify(self, _sender, data) -> None:
         """Bleak notification callback. Buffers the raw frame for the
@@ -232,7 +281,20 @@ class BHyveBleConnection:
         post-handshake hook (which runs inside _open() inside the lock)."""
         frame = self.encrypt(plaintext)
         assert self._client is not None
-        await self._client.write_gatt_char(WRITE_CHAR, frame, response=True)
+        # WRITE_CHAR (6c72) requires a Write Request (response=True) — the device
+        # silently drops Write Commands. But it answers via NOTIFICATION and, on
+        # some transports (notably the ESPHome Bluetooth proxy), the ATT Write
+        # Response is never relayed back, so a plain response=True write blocks
+        # ~30s. Issue the Write Request but cap the wait; the notification drain
+        # in send() is the real ack. Over a direct link the response arrives in
+        # <200ms so this returns immediately.
+        try:
+            await asyncio.wait_for(
+                self._client.write_gatt_char(WRITE_CHAR, frame, response=True),
+                timeout=WRITE_ACK_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError:
+            pass
 
     async def send(self, plaintext: bytes, *, drain_ms: int = 1500) -> list[bytes]:
         """Encrypt + WRITE_REQ + drain notifications for `drain_ms`. Returns
@@ -253,6 +315,29 @@ class BHyveBleConnection:
         async with self._lock:
             await self.ensure_connected()
             await self._write_locked(plaintext)
+
+    async def send_actuation(self, plaintext: bytes, *, drain_ms: int = 1500) -> list[bytes]:
+        """Re-run the per-device init sequence, then send a command — atomically.
+
+        HT25 only honours a watering command in a freshly-initialised session:
+        a pooled connection's bind goes stale, so the command is ack'd but
+        SILENTLY IGNORED (no actuation). Re-run the full init before every
+        actuation rather than trusting the pooled session."""
+        async with self._lock:
+            if self.is_connected and self._handshaken:
+                # Pooled connection — refresh the (possibly stale) bind in place.
+                if self._post_handshake_hook is not None:
+                    await self._post_handshake_hook(self)
+            else:
+                # Cold — ensure_connected() retries the open and runs the hook.
+                await self.ensure_connected()
+            self._notif_buf.clear()
+            await self._write_locked(plaintext)
+            await asyncio.sleep(drain_ms / 1000.0)
+            received = list(self._notif_buf)
+            self._notif_buf.clear()
+            self._arm_idle_timer()
+            return received
 
 
 class BleNotConnectable(Exception):

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -44,7 +44,10 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         if firmware == "0085":
             return BHyveHT25Fw0085Device
         return BHyveHT25Device
-    if (hardware or "").startswith("HT34A"):
+    if (hardware or "").startswith("HT34"):
+        # Both HT34A-0001 and HT34-0001 (fw0058) use the protobuf XD protocol.
+        # The older HT34 sharing it is the stuartdenne fork's claim (2026-06-27),
+        # not independently verified on hardware here.
         return BHyveHT34ADevice
     raise UnsupportedModel(hardware or "?", firmware or "?")
 

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -153,6 +153,18 @@ class BHyveBleDeviceBase(abc.ABC):
             self.state.is_connected = self.connection.is_connected
         return self.state
 
+    @property
+    def rssi(self) -> int | None:
+        """Latest RSSI from the bluetooth manager's most recent advertisement.
+        Works even while disconnected, and unlike bleak's BLEDevice.rssi (now
+        deprecated and always None) it actually returns a value."""
+        from homeassistant.components.bluetooth import async_last_service_info
+
+        if not self.mac:
+            return None
+        info = async_last_service_info(self.hass, self.mac, connectable=True)
+        return info.rssi if info is not None else None
+
     def _stamp_command(self, label: str, n_notifs: int) -> None:
         self.state.last_command_at = datetime.now(timezone.utc)
         self.state.last_command_label = label

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -213,12 +213,14 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         return not self.state.is_watering
 
     async def _send_command(self, plaintext: bytes, label: str) -> list[bytes]:
-        """Send a command frame, tolerating the ESPHome-proxy write-response
-        timeout. The device still receives the frame and acks via notification
-        (handled in _observe_plaintext), so a write timeout must not fail the
-        service call."""
+        """Send a command frame via send_actuation, which re-runs the bind/init
+        first — this device acks but SILENTLY IGNORES a watering command on a
+        stale pooled bind, so a fresh bind per actuation is what makes it take.
+        Tolerates the ESPHome-proxy write-response timeout: the device still
+        receives the frame and acks via notification (handled in
+        _observe_plaintext), so a write timeout must not fail the service call."""
         try:
-            notifs = await self.connection.send(plaintext, drain_ms=1500)
+            notifs = await self.connection.send_actuation(plaintext, drain_ms=1500)
         except TimeoutError:
             _LOGGER.warning(
                 "%s: %s write-response timed out; relying on the device ack to "

--- a/custom_components/orbit_bhyve/devices/ht34a.py
+++ b/custom_components/orbit_bhyve/devices/ht34a.py
@@ -1,16 +1,24 @@
-"""HT34A-0001 (4-port XD timer) device class.
+"""HT34A / HT34 (4-port XD timer) device class.
 
-Ported from upstream `wxfield/Orbit_B-Hyve_4Port_Controller`. Not
-hardware-tested in this repo (account doesn't have an HT34A); cipher
-math is shared with HT25 so handshake is verified, but the inner
-plaintext + magic byte differences are the upstream's empirical work.
+Protobuf-over-CRC16 protocol (the `OrbitPbApi_Message` schema from the APK),
+shared across the XD family. Covers HT34A-0001 (fw0107, originally ported from
+upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) and HT34-0001 (fw0058). The
+cipher/handshake is shared with HT25; only the inner plaintext (protobuf) and
+magic byte (0x11) differ.
+
+Battery/status decode and watering-state confirmation were ported from the
+stuartdenne fork (PRs #4/#5), which reports the older HT34-0001 answering the
+same protobuf queries. Neither the HT34A nor the HT34 path is verified on
+hardware in this repo — treat actuation here as untested.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import struct
+from datetime import datetime, timedelta, timezone
 
-from .base import BHyveBleDeviceBase
+from .base import BHyveBleDeviceBase, _mv_to_pct
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,38 +67,148 @@ def _build_start_pb(station_id: int, duration_sec: int) -> bytes:
 
 
 _STOP_PB = bytes.fromhex("720408021200")
+# Read-only request messages (empty sub-messages): getDeviceStatusInfo (field
+# 15) and getBatteryStatus (field 45). The device answers both with the cached
+# key, which is how HT34-0001 compatibility was reported by the fork.
+_GET_STATUS_PB = bytes.fromhex("7a00")
+_GET_BATTERY_PB = bytes.fromhex("ea0200")
+
+
+def _rd_varint(b: bytes, i: int) -> tuple[int, int]:
+    v = 0
+    s = 0
+    while True:
+        x = b[i]
+        i += 1
+        v |= (x & 0x7F) << s
+        if not x & 0x80:
+            return v, i
+        s += 7
+
+
+def _pb_fields(data: bytes):
+    """Yield (field_num, wire_type, value) for one protobuf message level.
+    value is an int for varints, bytes for length-delimited fields."""
+    i = 0
+    n = len(data)
+    while i < n:
+        try:
+            tag, i = _rd_varint(data, i)
+        except IndexError:
+            return
+        fn, wt = tag >> 3, tag & 7
+        if wt == 0:
+            v, i = _rd_varint(data, i)
+            yield fn, 0, v
+        elif wt == 2:
+            ln, i = _rd_varint(data, i)
+            yield fn, 2, data[i:i + ln]
+            i += ln
+        elif wt == 5:
+            yield fn, 5, data[i:i + 4]
+            i += 4
+        elif wt == 1:
+            yield fn, 1, data[i:i + 8]
+            i += 8
+        else:
+            return
 
 
 class BHyveHT34ADevice(BHyveBleDeviceBase):
-    """4-port XD timer. Ported from upstream — not hardware-tested here."""
+    """4-port XD timer (HT34A / HT34), protobuf protocol."""
 
     frame_magic = 0x11
     trailer_const = 0x11
+
+    async def _post_handshake(self, conn) -> None:
+        """After the handshake, query battery + status so every connect (sync,
+        command) refreshes them. Replies are parsed in _observe_plaintext."""
+        for pb in (_GET_BATTERY_PB, _GET_STATUS_PB):
+            try:
+                await conn._write_locked(_build_message(pb))
+                await asyncio.sleep(0.4)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("%s: HT34A post-handshake query failed: %s", self.mac, err)
+
+    def _observe_plaintext(self, pt: bytes) -> None:
+        """Parse protobuf notifications (OrbitPbApi_Message): battery mV from
+        batteryStatus (field 46 -> field 3) and watering state from
+        deviceStatusInfo (field 16)."""
+        if len(pt) < 8 or pt[:4] != MSG_HEADER:
+            return
+        body = pt[6:-2]  # strip AA775A0F + len + pad, and trailing CRC16
+        for fn, wt, val in _pb_fields(body):
+            if fn == 46 and wt == 2:  # batteryStatus
+                for sfn, swt, sval in _pb_fields(val):
+                    if sfn == 3 and swt == 0 and 1500 <= sval <= 4000:
+                        self.battery_mv = sval
+                        self.battery_pct = _mv_to_pct(sval)
+            elif fn == 16 and wt == 2:  # deviceStatusInfo
+                self._parse_status(val)
+
+    def _parse_status(self, val: bytes) -> None:
+        """deviceStatusInfo: field 1 is the run state (1=idle, 4=watering),
+        field 6 is the active-watering block (present only while watering) with
+        field 7 = seconds remaining. Decoded from idle-vs-watering captures."""
+        status = None
+        remaining = None
+        for fn, wt, v in _pb_fields(val):
+            if fn == 1 and wt == 0:
+                status = v
+            elif fn == 6 and wt == 2:  # active watering block
+                for sfn, swt, sv in _pb_fields(v):
+                    if sfn == 7 and swt == 0:
+                        remaining = sv
+        if status is not None:
+            self.state.is_watering = status == 4
+            if status != 4:
+                self.state.active_zone = None
+                self.state.seconds_remaining = None
+        if remaining is not None:
+            self.state.seconds_remaining = remaining
+
+    async def _refresh_status(self) -> None:
+        """Query device status; the reply updates state via _observe_plaintext."""
+        if self.connection is not None:
+            await self.connection.send(_build_message(_GET_STATUS_PB), drain_ms=1200)
 
     async def start_watering(self, station: int, duration_sec: int) -> bool:
         if self.connection is None:
             return False
         # Upstream uses 0-indexed stations on the wire.
         plaintext = _build_message(_build_start_pb(station - 1, duration_sec))
-        notifs = await self.connection.send(plaintext, drain_ms=2000)
-        _LOGGER.debug("%s: HT34A START station=%d got %d notifications",
-                      self.mac, station, len(notifs))
-        self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-        if notifs:
-            self.state.is_watering = True
-            self.state.active_zone = station
-            self.state.seconds_remaining = duration_sec
-        return bool(notifs)
+        for attempt in range(2):
+            notifs = await self.connection.send(plaintext, drain_ms=2000)
+            self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+            await self._refresh_status()
+            if self.state.is_watering:
+                now = datetime.now(timezone.utc)
+                self.state.active_zone = station
+                self.state.started_at = now
+                self.state.expected_off_at = now + timedelta(seconds=duration_sec)
+                if not self.state.seconds_remaining:
+                    self.state.seconds_remaining = duration_sec
+                _LOGGER.debug("%s: HT34A START confirmed watering", self.mac)
+                return True
+            _LOGGER.warning("%s: HT34A START not confirmed (attempt %d/2)", self.mac, attempt + 1)
+        _LOGGER.error("%s: HT34A START failed to confirm watering", self.mac)
+        return False
 
     async def stop_watering(self, station: int | None = None) -> bool:
         if self.connection is None:
             return False
         plaintext = _build_message(_STOP_PB)
-        notifs = await self.connection.send(plaintext, drain_ms=2000)
-        _LOGGER.debug("%s: HT34A STOP got %d notifications", self.mac, len(notifs))
-        self._stamp_command("stop", len(notifs))
-        if notifs:
-            self.state.is_watering = False
-            self.state.active_zone = None
-            self.state.seconds_remaining = None
-        return bool(notifs)
+        for attempt in range(2):
+            notifs = await self.connection.send(plaintext, drain_ms=2000)
+            self._stamp_command("stop", len(notifs))
+            await self._refresh_status()
+            if not self.state.is_watering:
+                self.state.active_zone = None
+                self.state.seconds_remaining = None
+                self.state.started_at = None
+                self.state.expected_off_at = None
+                _LOGGER.debug("%s: HT34A STOP confirmed idle", self.mac)
+                return True
+            _LOGGER.warning("%s: HT34A STOP not confirmed (attempt %d/2)", self.mac, attempt + 1)
+        _LOGGER.error("%s: HT34A STOP failed to confirm idle", self.mac)
+        return False

--- a/custom_components/orbit_bhyve/manifest.json
+++ b/custom_components/orbit_bhyve/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ljmerza/orbit-bhyve-ble/issues",
   "requirements": ["bleak-retry-connector>=3.5.0", "aiohttp>=3.9.0"],
-  "version": "2.0.6"
+  "version": "2.1.0"
 }

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform — battery percent + battery voltage.
+"""Sensor platform — battery percent, battery voltage, and BLE signal strength.
 
 Both sensors are populated from the device's BLE info-ack response on
 every connection: voltage in mV is read directly from payload bytes 4-5
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfElectricPotential
+from homeassistant.const import (
+    EntityCategory,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfElectricPotential,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -27,10 +32,15 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
     for coord in runtime.coordinators.values():
         device = coord.device
-        if device.battery_pct is not None:
-            entities.append(BHyveBatterySensor(coord))
-        if device.battery_mv is not None:
-            entities.append(BHyveBatteryVoltageSensor(coord))
+        if device.connection is None:
+            # Hubs / key-less records have no BLE battery or signal to report.
+            continue
+        # Battery comes from the device's info-ack at runtime, so create the
+        # sensors unconditionally rather than gating on the cloud-cached value
+        # (which is None for BT-only devices the cloud never primed).
+        entities.append(BHyveBatterySensor(coord))
+        entities.append(BHyveBatteryVoltageSensor(coord))
+        entities.append(BHyveRssiSensor(coord))
     async_add_entities(entities)
 
 
@@ -81,3 +91,21 @@ class BHyveBatteryVoltageSensor(_BHyveDeviceSensorBase):
     @property
     def native_value(self) -> int | None:
         return self.coordinator.device.battery_mv
+
+
+class BHyveRssiSensor(_BHyveDeviceSensorBase):
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_rssi"
+        self._attr_name = "Signal strength"
+
+    @property
+    def native_value(self) -> int | None:
+        return self.coordinator.device.rssi

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -38,3 +38,44 @@ probe_status:
       example: "44:67:55:52:99:01"
       selector:
         text:
+
+probe_send:
+  name: Probe send frame (debug)
+  description: Send an arbitrary inner-plaintext frame to a device; decoded replies land in the HA log via connection._on_notify. For reverse-engineering only — connection.encrypt() adds the [magic][len]..[trailer] wrapper around the hex you supply.
+  fields:
+    mac:
+      name: MAC address
+      description: Device MAC, e.g. 44:67:55:52:99:01.
+      required: true
+      example: "44:67:55:52:99:01"
+      selector:
+        text:
+    plaintext:
+      name: Plaintext (hex)
+      description: Inner frame as hex, e.g. an HT34A protobuf query AA775A0F....
+      required: true
+      example: "aa775a0f02007a0012cd"
+      selector:
+        text:
+    magic:
+      name: Magic byte override
+      description: Optional. Override frame_magic/trailer_const (0-255); forces a reconnect so the new magic takes effect.
+      required: false
+      example: 17
+      selector:
+        number:
+          min: 0
+          max: 255
+          mode: box
+    drain_ms:
+      name: Drain window (ms)
+      description: How long to collect notification replies after the write.
+      required: false
+      default: 2000
+      example: 2000
+      selector:
+        number:
+          min: 100
+          max: 10000
+          unit_of_measurement: milliseconds
+          mode: box


### PR DESCRIPTION
## What

Ports the genuinely-new, worthwhile work from the [stuartdenne fork](https://github.com/stuartdenne/ha-orbit-bhyve-ble-old) (a fork of a downstream copy of this repo) back into this repo. Each item was diff-checked against the current tree to confirm it isn't already solved here, and grafted onto our files rather than wholesale-copied (this repo is ahead on ack-driven HT25 off-timers and the cloud `/meshes` fallback, which are preserved).

Bumps `2.0.6 → 2.1.0`.

## Commits (logical, each revertable on its own)

1. **`feat(entities)`** — battery sensors created for every BLE timer (no longer gated on a cloud-cached value); new **Signal strength (RSSI)** sensor via HA's bluetooth manager (works while disconnected); **Connected** + **Watering** binary sensors; `probe_send` debug service. *(fork PR #2 + tooling)*
2. **`fix(ble)`** — bounded handshake + retry-the-open for marginal ESPHome-proxy links, and a capped ATT write-ack wait (the device acks via notification, not a write response). Adds an unused `send_actuation()` helper. *(fork PRs #1, #3)*
3. **`fix(ht25)`** — route HT25 actuation through `send_actuation` so a stale pooled bind can't silently drop a watering command. ⚠️ **This is the one change that alters the proven HT25 path** (re-init per command, ~1.2 s extra latency). Isolated to one file — revert this commit alone to restore the pooled-send path. *(fork PR #1)*
4. **`feat(ht34)`** — resolver matches `HT34*` (adds HT34-0001 / fw0058 alongside HT34A-0001); protobuf battery + watering-status decode and retry-with-confirmation start/stop. *(fork PRs #4, #5)*
5. **`chore`** — version bump + README (HT34 row, new sensors, corrected reuse/init note, credits).

## Testing status

- ✅ All Python compiles; `manifest.json` and `services.yaml` validate.
- ⚠️ **Needs hardware verification before relying on it:**
  - HT25 re-bind-per-command (commit 3) — confirm real timers still open/close cleanly.
  - Bounded handshake + write-ack cap (commit 2) — best exercised through an ESPHome BT proxy.
  - HT34 / HT34A (commit 4) — **untested here** (no such hardware); ships in the same untested state as the prior HT34A code.

## Intentionally not ported

- HT25 real-status decode (`refresh_state` status query + `seq=0x02` parsing) — would overwrite our deliberately optimistic, ack-driven HT25 state machine on an unverified-here protocol claim.
- Demoting the INFO-level GATT/notification reverse-engineering logging to DEBUG.
- The fork's redundant `connection.rssi` plumbing and its extra time-remaining / last-watering / water-volume sensors (depend on state this repo doesn't track).

Credit to [@stuartdenne](https://github.com/stuartdenne/ha-orbit-bhyve-ble-old) for the ported additions.
