### PR TITLE
feat(ht32): route HT32A-0001 to the HT34A XD class

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ when the WAN goes down.
 | Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
 | 4-port XD         | `HT34A-0001`   | `0107`           | ⚠️ Protobuf control + battery/status decode; not tested here |
 | 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
+| 2-port XD         | `HT32A-0001`   | `0107`           | ⚠️ Shares the HT34A XD protobuf protocol; not tested here |
 
 > ⚠️ **Do NOT update your B-Hyve device firmware.** This integration was
 > reverse-engineered against the firmware versions above. A firmware update

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -49,6 +49,13 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         # The older HT34 sharing it is the stuartdenne fork's claim (2026-06-27),
         # not independently verified on hardware here.
         return BHyveHT34ADevice
+    if (hardware or "").startswith("HT32"):
+        # HT32A-0001 (fw0107) is the 2-port XD sibling of the HT34A: same
+        # firmware, same protobuf-over-CRC16 protocol (magic 0x11), fewer
+        # stations. Station count flows from the cloud record, so the 4-port
+        # class handles a 2-port unit unchanged. Untested on hardware here
+        # (issue #13) — same caveat as HT34A.
+        return BHyveHT34ADevice
     raise UnsupportedModel(hardware or "?", firmware or "?")
 
 

--- a/custom_components/orbit_bhyve/devices/ht34a.py
+++ b/custom_components/orbit_bhyve/devices/ht34a.py
@@ -1,8 +1,11 @@
-"""HT34A / HT34 (4-port XD timer) device class.
+"""HT34A / HT34 (XD timer) device class.
 
 Protobuf-over-CRC16 protocol (the `OrbitPbApi_Message` schema from the APK),
 shared across the XD family. Covers HT34A-0001 (fw0107, originally ported from
-upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) and HT34-0001 (fw0058). The
+upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) and HT34-0001 (fw0058). Also
+serves the 2-port HT32A-0001 (fw0107), routed here as the XD sibling of the
+4-port HT34A — station count comes from the cloud record, so the same class
+drives a 2-port unit unchanged (issue #13, untested on hardware). The
 cipher/handshake is shared with HT25; only the inner plaintext (protobuf) and
 magic byte (0x11) differ.
 

--- a/custom_components/orbit_bhyve/manifest.json
+++ b/custom_components/orbit_bhyve/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ljmerza/orbit-bhyve-ble/issues",
   "requirements": ["bleak-retry-connector>=3.5.0", "aiohttp>=3.9.0"],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }


### PR DESCRIPTION
## Summary

Adds support for the **2-port HT32A-0001** timer (fw0107), reported in #13. It is the 2-port XD sibling of the already-supported 4-port HT34A (also fw0107): same firmware, same protobuf-over-CRC16 protocol (magic `0x11`), fewer stations. Station count flows from the cloud record, so the existing `BHyveHT34ADevice` class drives a 2-port unit unchanged — support is a **single routing clause**, no new protocol code.

## Changes
- `devices/__init__.py` — `resolve_device_class()` routes `HT32*` to `BHyveHT34ADevice`.
- `devices/ht34a.py` — docstring documents HT32A-0001 coverage and why the 4-port class serves a 2-port unit.
- `README.md` — supported-hardware table row for `HT32A-0001` / fw0107 (⚠️ not tested here).
- `manifest.json` — version bump `2.1.0` → `2.1.1`.

## Testing
Not verified on hardware — ships with the same experimental caveat as HT34A. The reporter (#13) has three units and will verify open/close; if actuation doesn't confirm, we fall back to a BLE snoop capture to diff the protobuf/magic against the HT34A path.

Refs #13