### PR TITLE
docs: mark HT34A + HT32A XD paths hardware-verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ when the WAN goes down.
 | Hose-tap timer    | `HT25-0000`    | `0085`           | ✅ Actuated end-to-end                   |
 | Hose-tap timer    | `HT25-0000`    | `0041`           | ✅ Actuated end-to-end (per-device mesh-ID addressing) |
 | Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
-| 4-port XD         | `HT34A-0001`   | `0107`           | ⚠️ Protobuf control + battery/status decode; not tested here |
+| 4-port XD         | `HT34A-0001`   | `0107`           | ✅ Battery/status decode verified on hardware; XD actuation proven via HT32A sibling |
 | 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
-| 2-port XD         | `HT32A-0001`   | `0107`           | ⚠️ Shares the HT34A XD protobuf protocol; not tested here |
+| 2-port XD         | `HT32A-0001`   | `0107`           | ✅ Actuated end-to-end (shares the HT34A XD protobuf protocol) |
 
 > ⚠️ **Do NOT update your B-Hyve device firmware.** This integration was
 > reverse-engineered against the firmware versions above. A firmware update

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -46,15 +46,16 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         return BHyveHT25Device
     if (hardware or "").startswith("HT34"):
         # Both HT34A-0001 and HT34-0001 (fw0058) use the protobuf XD protocol.
-        # The older HT34 sharing it is the stuartdenne fork's claim (2026-06-27),
-        # not independently verified on hardware here.
+        # HT34A-0001/fw0107 is hardware-verified (issue #16). The older HT34
+        # sharing it is the stuartdenne fork's claim (2026-06-27), still not
+        # independently verified on hardware here.
         return BHyveHT34ADevice
     if (hardware or "").startswith("HT32"):
         # HT32A-0001 (fw0107) is the 2-port XD sibling of the HT34A: same
         # firmware, same protobuf-over-CRC16 protocol (magic 0x11), fewer
         # stations. Station count flows from the cloud record, so the 4-port
-        # class handles a 2-port unit unchanged. Untested on hardware here
-        # (issue #13) — same caveat as HT34A.
+        # class handles a 2-port unit unchanged. Verified end-to-end on 3x
+        # HT32A units — open/close actuation confirmed (issue #13).
         return BHyveHT34ADevice
     raise UnsupportedModel(hardware or "?", firmware or "?")
 

--- a/custom_components/orbit_bhyve/devices/ht34a.py
+++ b/custom_components/orbit_bhyve/devices/ht34a.py
@@ -5,14 +5,15 @@ shared across the XD family. Covers HT34A-0001 (fw0107, originally ported from
 upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) and HT34-0001 (fw0058). Also
 serves the 2-port HT32A-0001 (fw0107), routed here as the XD sibling of the
 4-port HT34A — station count comes from the cloud record, so the same class
-drives a 2-port unit unchanged (issue #13, untested on hardware). The
-cipher/handshake is shared with HT25; only the inner plaintext (protobuf) and
-magic byte (0x11) differ.
+drives a 2-port unit unchanged. Verified end-to-end on 3x HT32A units:
+open/close actuation confirmed (issue #13). The cipher/handshake is shared
+with HT25; only the inner plaintext (protobuf) and magic byte (0x11) differ.
 
 Battery/status decode and watering-state confirmation were ported from the
-stuartdenne fork (PRs #4/#5), which reports the older HT34-0001 answering the
-same protobuf queries. Neither the HT34A nor the HT34 path is verified on
-hardware in this repo — treat actuation here as untested.
+stuartdenne fork (PRs #4/#5). The HT34A path is hardware-verified: battery +
+status decode confirmed on a real HT34A-0001/fw0107 (issue #16), and the shared
+XD actuation path is proven via the HT32A sibling (issue #13). The older
+HT34-0001/fw0058 remains unverified — no such unit tested in this repo.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Both open issues are hardware-verification confirmations of code that already shipped in v2.1.1 (PR #14). No logic change — just retiring the stale "untested" caveats.

## What's now verified
- **HT32A-0001 / fw0107** (#13, James Hallam): v2.1.1 clears the `no device class for HT32A-0001` error; reporter connected and opened/closed valves on 3× 2-port units — "functional parity with the HT34A."
- **HT34A-0001 / fw0107** (#16, Mike Campbell): battery + status decode confirmed on a real HT34A (2932 mV → 89 %, status = idle), plus sensors and handshake hardening. The shared XD actuation path is proven via the HT32A sibling.

## Changes (docs/comments only)
- `README.md` — HT34A and HT32A rows flipped ⚠️ → ✅.
- `devices/ht34a.py` — module docstring updated.
- `devices/__init__.py` — HT32/HT34 routing comments updated.

## Preserved caveat
`HT34-0001 / fw0058` stays ⚠️ — no such unit was tested (still only the stuartdenne-fork claim).

Closes #13
Closes #16