### PR TITLE
fix(ht34a): read seconds-remaining from #16.#6.#5, not #16.#6.#7

### DIFF
--- a/custom_components/orbit_bhyve/devices/ht34a.py
+++ b/custom_components/orbit_bhyve/devices/ht34a.py
@@ -153,7 +153,10 @@ class BHyveHT34ADevice(BHyveBleDeviceBase):
     def _parse_status(self, val: bytes) -> None:
         """deviceStatusInfo: field 1 is the run state (1=idle, 4=watering),
         field 6 is the active-watering block (present only while watering) with
-        field 7 = seconds remaining. Decoded from idle-vs-watering captures."""
+        field 5 = seconds remaining (counts down) and field 7 = total run time
+        (constant). Hardware-verified on a timed run (HT34A fw0107 + HT25G2 fw0111):
+        6.5 counted 174->138->102 over a 180s run while 6.7 held at 180. These
+        match the vendor names currentTimeRemainingSec / totalRunTimeSec."""
         status = None
         remaining = None
         for fn, wt, v in _pb_fields(val):
@@ -161,7 +164,7 @@ class BHyveHT34ADevice(BHyveBleDeviceBase):
                 status = v
             elif fn == 6 and wt == 2:  # active watering block
                 for sfn, swt, sv in _pb_fields(v):
-                    if sfn == 7 and swt == 0:
+                    if sfn == 5 and swt == 0:  # field 5 = seconds remaining
                         remaining = sv
         if status is not None:
             self.state.is_watering = status == 4


### PR DESCRIPTION
### The bug
`HT34ADevice._parse_status` reads the active-watering block's **field 7** (`#16.#6.#7`) as `seconds_remaining`. On hardware `#16.#6.#7` is the **constant total run time**, not remaining — so the XD's `seconds_remaining` sits static at the full duration for the whole run, and the countdown / wall-clock auto-close never decrements.

### The fix
The counting-down remaining is **`#16.#6.#5`**. One-line change (`sfn == 7` → `sfn == 5`) plus docstring.

### Hardware verification (2026-07-05)
Timed a live 180 s run and read status a few times, dumping the raw `#16.#6` sub-fields:

| t | `#16.#6.#5` | `#16.#6.#7` |
|---|---|---|
| +6 s | **174** | 180 |
| +42 s | **138** | 180 |
| +78 s | **102** | 180 |

`#5` counts down once per second; `#7` is constant. Identical on an **HT34A (fw `0107`)** and an **HT25G2 (fw `0111`)**. These match the vendor field names in knobunc's schema — `currentTimeRemainingSec` (`#5`) and `totalRunTimeSec` (`#7`).

### Scope
Surgical and additive; only the corrected field changes. The Gen2 `ht25g2.py` path is unaffected (it doesn't decode `#16`; it sets `seconds_remaining` optimistically from the command duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)