### PR TITLE
docs: BLE protocol reference & reverse-engineering notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Orbit B-Hyve BLE — protocol & reverse-engineering docs
+
+Reference documentation for the local BLE protocol this integration speaks, plus
+the reverse-engineering notes behind it. Useful if you want to understand the
+wire format, extend the integration, or reproduce the analysis on other Orbit
+hardware.
+
+There are **two device families** on this protocol:
+
+- **Protobuf "XD" family** — frame magic `0x11`, protobuf messages wrapped in an
+  `aa 77 5a 0f` header with a CRC-16. Covers HT34A, HT32A, and the Gen2 HT25G2.
+- **HT25 "d7-47" family** — frame magic `0x10`, custom binary frames prefixed
+  with a per-device mesh address (no protobuf, no CRC-16). Covers the older
+  HT25 hose-tap timers (fw0041/fw0085).
+
+The AES cipher, the 20-byte handshake, and the outer BLE frame are **shared** by
+both families (see `custom_components/orbit_bhyve/connection.py`).
+
+## Protocol reference (XD / protobuf family)
+
+| Doc | What it covers |
+|-----|----------------|
+| [`protocol.md`](protocol.md) | **Authoritative** wire spec: GATT layout, handshake, AES-CTR cipher, `0x11` frame + checksum, `aa 77 5a 0f` app message, command/status catalog. |
+| [`ble-messages.md`](ble-messages.md) | Full per-message field/enum tables with example hex (the message catalog). |
+| [`hermes-findings.md`](hermes-findings.md) | Cipher, key architecture, and handshake as recovered from the vendor Android app's Hermes bundle. |
+| [`encryption.md`](encryption.md) | Cipher + trailer deep-dive: the AES-ECB-as-CTR construction and why the byte-sum trailer matters. |
+| [`ble-protocol.md`](ble-protocol.md) | GATT/connection-sequence walkthrough and behavioral notes (bonding, MAC enforcement, replay, ATT opcodes). Superseded by `protocol.md` where they differ. |
+| [`protobuf-schema.md`](protobuf-schema.md) | How the protobuf schema was reconstructed by observation. |
+
+## HT25 "d7-47" family
+
+| Doc | What it covers |
+|-----|----------------|
+| [`findings/d7-47-protocol.md`](findings/d7-47-protocol.md) | The `0x10`/mesh-address binary protocol: frame layout, command catalog, init sequence, status/battery decode. |
+
+## How it was reverse-engineered
+
+| Doc | What it covers |
+|-----|----------------|
+| [`reverse-engineering-journey.md`](reverse-engineering-journey.md) | The full narrative — reconnaissance, cracking the cipher, the trailer-checksum breakthrough, and lessons for BLE RE. |
+| [`network-key-extraction.md`](network-key-extraction.md) | How the per-account AES `network_key` is obtained (the integration does this for you at setup). |
+| [`findings/bundle-decompile.md`](findings/bundle-decompile.md) | Hermes bytecode decompile + Frida toolchain; the cipher derivation. |
+| [`findings/apk-findings.md`](findings/apk-findings.md) | APK decompile methodology and the GATT characteristic map. |
+| [`findings/phone-ground-truth.md`](findings/phone-ground-truth.md) | Capturing btsnoop ground truth from the phone; the failed-decryption attempts. |
+| [`findings/nrf-sniffer-setup.md`](findings/nrf-sniffer-setup.md) | Building an nRF52840 BLE sniffer capture rig. |
+| [`findings/mesh-analysis.md`](findings/mesh-analysis.md) | BLE5 extended-advertising analysis (contains a **superseded** broadcast-only hypothesis). |
+| [`findings/wrong-hypotheses.md`](findings/wrong-hypotheses.md) | Dead ends and falsified hypotheses — the most instructive part. |
+
+## Provenance & attribution
+
+- **`protocol.md`, `ble-messages.md`, `hermes-findings.md`** were contributed by
+  **@anahnymous** in [issue #19](https://github.com/ljmerza/orbit-bhyve-ble/issues/19).
+  Code references have been adapted to this repository's layout; this integration
+  implements a subset of the documented catalog (run-zone, stop, status, battery).
+- **Everything else** is imported from the maintainer's own reverse-engineering
+  project and has been scrubbed of device-specific identifiers (MAC addresses,
+  network keys, home device names).
+
+## Scope
+
+This is original research against devices lawfully owned by the authors,
+conducted by observing the devices' own wire-level behavior and the publicly
+distributed companion mobile application. No proprietary firmware or vendor
+source code is reproduced here. AES `network_key`s, MAC addresses, and other
+device-specific secrets have been removed from these notes — never commit yours.

--- a/docs/ble-messages.md
+++ b/docs/ble-messages.md
@@ -1,0 +1,872 @@
+*Contributed by @anahnymous in [issue #19](https://github.com/ljmerza/orbit-bhyve-ble/issues/19); code references adapted to this repository's layout.*
+
+# B-hyve BLE Message Catalog
+
+This document is the authoritative reference for all known BLE application messages in the B-hyve timer protocol.
+For the outer BLE framing and encryption details -- including the `0x11` frame format, the 16-bit additive checksum trailer, the AES-128 CTR cipher, and the GATT handshake -- see [`protocol.md`](protocol.md).
+
+> **Scope:** This catalog covers the protobuf **"XD" family** (BLE frame magic
+> `0x11`: HT34A / HT32A / HT25G2). The older HT25 **"d7-47" family** (frame magic
+> `0x10`) is documented separately in
+> [`findings/d7-47-protocol.md`](findings/d7-47-protocol.md). This integration
+> implements a subset of the catalog (run-zone, stop, status request, battery
+> request, and status/battery decode); the other commands below are documented for
+> completeness.
+
+Each decrypted `0x11` frame stream reassembles into application messages with the structure:
+
+```
+aa 77 5a 0f  <type:LE16 LE>  <OrbitPbApi_Message protobuf>  <crc16_xmodem:LE16>
+```
+
+**Key rule (CORRECTED 2026-06-28):** the 16-bit field after the `aa775a0f` magic -- labeled "Type code" in the tables below -- is the frame **LENGTH** = `len(payload) + 2` (payload + the 2-byte crc16), verified **51/51** frames across captures. It is **NOT** a message type, opcode, channel, or protobuf field number. The device **dispatches purely on the protobuf field** inside the `OrbitPbApi_Message` body (exactly one field set). The "Type code" column values below are therefore just `len(payload)+2` for each captured example -- identify a message by its **protobuf field**, not by that number. (Older revisions of this doc called it a "category/channel"; that model is superseded. Messages with the same payload length collide on this value purely by coincidence -- e.g. several short get requests share `0x05` because their bodies are all 3 bytes.)
+
+> WARNING **Probing hazard:** sending a message with a **malformed or unrecognized protobuf field** makes the device stop answering for the rest of the connection -- an AES-CTR counter desync (it does not advance its RX counter on a rejected frame). When probing unknown messages, use **one fresh connection per probe attempt**. (A wrong length field alone does not desync -- the device simply ignores the message silently, which is what masked the schedule bug for so long.)
+
+---
+
+## Section L -- Live-verified GET requests (Timer-NW, 2026-06-27)
+
+Confirmed against live hardware (Timer-NW `44:67:55:D7:4B:F9`), not just the capture. All queries below are sent on channel **`0x05`** with an empty body except `getDeviceStatusInfo` (channel `0x04`). The "get" returns the matching data/`set*` message -- often `request_field + 1`. Of these, only `getDeviceStatusInfo` and `getBatteryStatus` are implemented in this integration (as the `_GET_STATUS_PB` and `_GET_BATTERY_PB` constants in `devices/ht34a.py`); the other `get*` request forms below are documented for completeness and are not implemented.
+
+| get (request field) | req channel | request frame | response | response field |
+|---|---|---|---|---|
+| `getDeviceStatusInfo` (f15) | `0x04` | `aa775a0f04007a00bc34` | `0x3E` | f16 `deviceStatusInfo` |
+| `getBatteryStatus` (f45) | `0x05` | `aa775a0f0500ea0200dd7e` | `0x16` | f46 `batteryStatus` |
+| `getDeviceInfo` (f22) | `0x05` | `aa775a0f0500b20100e1dc` | `0x2F` | f23 `deviceInfo` |
+| `getActivePrograms` (f77) | `0x05` | `aa775a0f0500ea04007bd4` | `0x19` | f20 `SetActivePrograms` |
+| `getSettings` (f28) | `0x05` | `aa775a0f0500e201002f82` | `0x13` | f29 `SetSettings` |
+| `getManualPresetRunTime` (f48) | `0x05` | `aa775a0f0500820300267f` | `0x16` | f49 `manualPresetRunTime` (600 s) |
+| `getNextStartTime` (f26) | `0x05` | `aa775a0f0500d201008a47` | `0x3E` | f16 `deviceStatusInfo` |
+
+**Real negatives (empty body, isolated connections, no reply under `0x05`/`0x04`/`0x07`):**
+- `getWateringStatus` (f110) -- not a standalone request; `wateringStatus` (0x15/f30) is emitted inside the `timerMode`-triggered status burst.
+- `getNetworkStatus` (f36) -- no BLE reply; network status is a cloud/aggregator concern, excluded from the direct-BLE surface.
+- `getStationCfg` (f97) -- no reply with an empty body; very likely requires a station-id parameter (untested).
+- `getProgramSchedule` (f69) -- **no schedule read exists over BLE.** Probed live 2026-06-27 with a valid `programId` on channels `0x05`/`0x04`/`0x07` (two clean runs): the device returned **nothing** on any of them; an earlier empty-body probe also got no reply. `getActivePrograms` does **not** fill the gap -- `SetActivePrograms` is only the `activeProgramFlags` bitmask + change metadata (schema-confirmed); schedules live in `SetProgramSchedule`/`ProgramSchedules`. The app reads schedules from the cloud. The `getProgramSchedule` request form (`0x05`/f69 + `programId` f1) is recorded here only for the encoding + the negative result; it is not implemented in this integration. **To read a schedule back, WRITE it (`0x5F`) and parse the `0x0067` echo** -- capture-verified (frames 44->59): the echo is a full `OrbitPbApi_Message` (`id` + `timestamp` + f19 `setProgramSchedule`); parsing that echo back into a schedule is not implemented in this integration.
+
+**Note on the catalog below:** the capture-derived "Section A" lists 13 messages but the real h2d count is >=14 -- the capture also contains a `getDeviceInfo` request (h2d `0x05`/f22, capture frame 38) that the original inventory collapsed against the `0x05`/f45 battery request. The request forms above are the authoritative encoding.
+
+---
+
+## Section A -- Captured BLE messages (authoritative, 13)
+
+These 13 messages were observed in `bluetooth_logs/btsnoop_hci.log.last` (Timer_SE session) and in live hardware tests.
+Type codes are known from wire traffic; all field names and enum values are from the reconstructed schema (see [`protobuf-schema.md`](protobuf-schema.md)).
+
+### Master table
+
+| Type code | Dir | OrbitPbApi_Message field | Message class | Captured |
+|-----------|-----|--------------------------|---------------|----------|
+| `0x0004` | h2d | f15 `getDeviceStatusInfo` | `OrbitPbApi_GetDeviceStatusInfo` | yes |
+| `0x0005` | h2d | f45 `getBatteryStatus` | `OrbitPbApi_GetBatteryStatus` | yes |
+| `0x0007` | h2d | f20 `setActivePrograms` | `OrbitPbApi_SetActivePrograms` | yes |
+| `0x000E` | h2d | f14 `timerMode` | `OrbitPbApi_TimerMode` | yes |
+| `0x0016` | h2d | f75 `setEpochTime` | `OrbitPbApi_SetEpochTime` | yes |
+| `0x0020` | h2d | f18 `setDateTime` | `OrbitPbApi_SetDateTime` | yes |
+| `0x005F` | h2d | f19 `setProgramSchedule` | `OrbitPbApi_SetProgramSchedule` | yes |
+| `0x0015` | d2h | f30 `wateringStatus` | `OrbitPbApi_WateringStatus` | yes |
+| `0x0016` | d2h | f46 `batteryStatus` | `OrbitPbApi_BatteryStatus` | yes |
+| `0x002F` | d2h | f23 `deviceInfo` | `OrbitPbApi_DeviceInfo` | yes |
+| `0x003E` | d2h | f16 `deviceStatusInfo` | `OrbitPbApi_DeviceStatusInfo` | yes |
+| `0x005E` | d2h | f16 `deviceStatusInfo` | `OrbitPbApi_DeviceStatusInfo` | yes |
+| `0x0067` | d2h | f19 `setProgramSchedule` | `OrbitPbApi_SetProgramSchedule` | yes |
+
+Note: `0x003E` and `0x005E` carry the same protobuf class (`deviceStatusInfo`); `0x005E` appears to be a watering-status-summary variant (it consistently carries an `OrbitPbApi_WateringStatusSummary` in `f18` of the `DeviceStatusInfo`).
+Note: `0x0016` is used for **both** `h2d setEpochTime` and `d2h batteryStatus` -- direction disambiguates.
+Note: `0x0067` is d2h only in the capture (device echoes the program schedule); `0x005F` is the h2d set direction.
+
+---
+
+### A.1 -- `0x0004` h2d `getDeviceStatusInfo`
+
+**Direction:** host -> device  
+**Frame type:** `0x0004`  
+**OrbitPbApi_Message field:** f15 `getDeviceStatusInfo`  
+**Class:** `OrbitPbApi_GetDeviceStatusInfo`  
+**Encoder:** the `_GET_STATUS_PB` constant in `devices/ht34a.py`
+
+#### Fields
+
+_(no fields -- empty request message)_
+
+#### Captured example
+
+```
+aa 77 5a 0f 04 00 7a 00 bc 34
+```
+
+Decoded: empty `getDeviceStatusInfo` request -- triggers a `deviceStatusInfo` response burst from the device.
+
+---
+
+### A.2 -- `0x0005` h2d `getBatteryStatus`
+
+**Direction:** host -> device  
+**Frame type:** `0x0005`  
+**OrbitPbApi_Message field:** f45 `getBatteryStatus`  
+**Class:** `OrbitPbApi_GetBatteryStatus`
+
+#### Fields
+
+_(no fields -- empty request message)_
+
+#### Captured example
+
+```
+aa 77 5a 0f 05 00 ea 02 00 dd 7e
+```
+
+Decoded: empty `getBatteryStatus` request -- triggers a `batteryStatus` response.
+
+---
+
+### A.3 -- `0x0007` h2d `setActivePrograms`
+
+**Direction:** host -> device  
+**Frame type:** `0x0007`  
+**OrbitPbApi_Message field:** f20 `setActivePrograms`  
+**Class:** `OrbitPbApi_SetActivePrograms`
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `activeProgramFlags` | uint32 | required; bitmask of active programs |
+| f2 | `lastChangeDateSecEpochUtc` | uint32 | |
+| f3 | `lastChangeId` | `OrbitPbApi_InterfaceId` | see enum below |
+
+**OrbitPbApi_InterfaceId enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `localInterface` |
+| 1 | `bleInterface` |
+| 2 | `wifiInterface` |
+| 3 | `cellularInterface` |
+| 4 | `ethernetInterface` |
+| 5 | `lorawanInterface` |
+
+#### Captured example
+
+```
+aa 77 5a 0f 07 00 a2 01 02 08 00 35 3e
+```
+
+Decoded: `setActivePrograms { activeProgramFlags: 0 }` -- disables all program schedules (sets device to manual-only mode).
+
+---
+
+### A.4 -- `0x000E` h2d `timerMode`
+
+**Direction:** host -> device  
+**Frame type:** `0x000E`  
+**OrbitPbApi_Message field:** f14 `timerMode`  
+**Class:** `OrbitPbApi_TimerMode`  
+**Encoders:** `_build_start_pb(station_id, duration_sec)` (run-zone) and the `_STOP_PB` constant (stop) in `devices/ht34a.py`
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `mode` | `Mode` | required |
+| f2 | `manualModeParams` | `OrbitPbApi_ManualModeParams` | populated for manualMode; **must still be present as an EMPTY message (`12 00`) for offMode and autoMode** -- the device silently ignores a timerMode write that omits f2 (live-verified, both modes) |
+
+**Mode enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `offMode` |
+| 1 | `autoMode` |
+| 2 | `manualMode` |
+
+**References: OrbitPbApi_ManualModeParams** (top-level schema class, referenced by `timerMode` f2)
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `startTimeIso8601` | string | |
+| f2 | `activeProgramFlags` | uint32 | |
+| f3 | `stationInfo` | `OrbitPbApi_StationInfo` | repeated |
+| f4 | `startTimeSecEpochUtc` | uint32 | |
+| f5 | `groupWateringPreDelaySec` | uint32 | |
+| f6 | `groupWateringPostDelaySec` | uint32 | |
+
+**Nested: OrbitPbApi_StationInfo**
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `stationId` | uint32 | required; 0-indexed |
+| f2 | `runTimeSec` | uint32 | required |
+| f3 | `groupId` | uint32 | |
+| f4 | `bridgeId` | bytes | |
+| f5 | `meshDeviceId` | uint32 | |
+| f10 | `type` | `Type` | |
+| f11 | `sequenceId` | uint32 | |
+
+**OrbitPbApi_StationInfo.Type enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `station` |
+| 1 | `soak` |
+| 2 | `scheduleSyncDelay` |
+
+#### Captured example (run-zone)
+
+```
+aa 77 5a 0f 0e 00 72 0a 08 02 12 06 1a 04 08 00 10 1e e6 05
+```
+
+Decoded: `timerMode { mode: manualMode, manualModeParams { stationInfo[0] { stationId: 0, runTimeSec: 30 } } }` -- run station 0 for 30 seconds. **Byte-verified against captured frame 96 and live-verified on Timer-NW.**
+
+---
+
+### A.5 -- `0x0016` h2d `setEpochTime`
+
+**Direction:** host -> device  
+**Frame type:** `0x0016`  
+**OrbitPbApi_Message field:** f75 `setEpochTime`  
+**Class:** `OrbitPbApi_SetEpochTime`  
+**Encoder:** (not implemented in this integration)
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `timeSecEpochUTC` | uint32 | |
+| f2 | `timezoneOffsetSec` | int32 | |
+
+#### Captured example
+
+```
+aa 77 5a 0f 16 00 da 04 11 08 ce d6 f0 d0 06 10 c0 8f ff ff ff ff ff ff 01 25 dc
+```
+
+Decoded: `setEpochTime { timeSecEpochUTC: <timestamp>, timezoneOffsetSec: -14400 }` -- sets epoch time with UTC-4 offset. **Required to trigger the first status burst from the device.**
+
+---
+
+### A.6 -- `0x0020` h2d `setDateTime`
+
+**Direction:** host -> device  
+**Frame type:** `0x0020`  
+**OrbitPbApi_Message field:** f18 `setDateTime`  
+**Class:** `OrbitPbApi_SetDateTime`  
+**Encoder:** (not implemented in this integration)
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `currentTimeIso8601` | string | required; ISO-8601 with UTC offset |
+
+#### Captured example
+
+```
+aa 77 5a 0f 20 00 92 01 1b 0a 19 32 30 32 36 2d 30 35 2d 33 31 54 30 38 3a 33 36 3a 33 30 2d 30 34 3a 30 30 00 eb
+```
+
+Decoded: `setDateTime { currentTimeIso8601: "2026-05-31T08:36:30-04:00" }` -- syncs the device clock to local time with UTC offset.
+
+---
+
+### A.7 -- `0x005F` h2d `setProgramSchedule`
+
+**Direction:** host -> device  
+**Frame type:** `0x005F`  
+**OrbitPbApi_Message field:** f19 `setProgramSchedule`  
+**Class:** `OrbitPbApi_SetProgramSchedule`
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `programId` | `OrbitPbApi_ProgramId` | required |
+| f2 | `programTypeNotSet` | `OrbitPbApi_ProgramType_NotSet` | oneof program type |
+| f3 | `programTypeDayOfWeek` | `OrbitPbApi_ProgramType_DayOfWeek` | oneof program type |
+| f4 | `programTypeInterval` | `OrbitPbApi_ProgramType_Interval` | oneof program type |
+| f5 | `programTypeOdd` | `OrbitPbApi_ProgramType_Odd` | oneof program type |
+| f6 | `programTypeEven` | `OrbitPbApi_ProgramType_Even` | oneof program type |
+| f7 | `programTypeRunOnce` | `OrbitPbApi_ProgramType_RunOnce` | oneof program type |
+| f8 | `startTimesMinsFromMidnight` | uint32 | repeated |
+| f9 | `stationInfo` | `OrbitPbApi_StationInfo` | repeated |
+| f10 | `budgetPercent` | uint32 | |
+| f11 | `startDateSecEpochUtc` | uint32 | |
+| f12 | `stopDateSecEpochUtc` | uint32 | |
+| f13 | `lastChangeDateSecEpochUtc` | uint32 | |
+| f14 | `lastChangeId` | `OrbitPbApi_InterfaceId` | |
+| f15 | `groupWateringPreDelaySec` | uint32 | |
+| f16 | `groupWateringPostDelaySec` | uint32 | |
+| f17 | `programName` | string | |
+| f18 | `intervalHours` | uint32 | |
+| f19 | `basicProgramMode` | bool | |
+| f20 | `databaseId` | uint32 | |
+| f21 | `originDateSecEpochUtc` | uint32 | |
+| f22 | `endDateSecEpochUtc` | uint32 | |
+
+**OrbitPbApi_ProgramId enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `manual` |
+| 1 | `a` |
+| 2 | `b` |
+| 3 | `c` |
+| 4 | `d` |
+| 5 | `e` |
+| 6 | `f` |
+
+**Nested: OrbitPbApi_ProgramType_DayOfWeek**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `dayFlags` | uint32 (required) |
+
+**Nested: OrbitPbApi_ProgramType_Interval**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `intervalDays` | uint32 (required) |
+| f2 | `intervalStartTimeIso8601` | string |
+
+**Nested: OrbitPbApi_ProgramType_RunOnce**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `programFlags` | uint32 |
+
+_(OrbitPbApi_ProgramType_NotSet, _Odd, _Even have no fields in schema)_
+
+`OrbitPbApi_StationInfo` fields: see [A.4](#a4--0x000e-h2d-timermode).
+
+#### Captured example
+
+```
+aa 77 5a 0f 5f 00 9a 01 5a 08 01 22 1d 08 01 12 19 32 30 32 36 2d 30 34 2d 31 37 54 30 30 3a 30 30 3a 30 30 2d 30 34 3a ...
+```
+
+Decoded (partial): `setProgramSchedule { programId: a, programTypeInterval { ... }, stationInfo [...] }` -- programs schedule A with interval-based watering.
+
+#### Encoder (not implemented in this integration)
+
+Encoding `setProgramSchedule` is not implemented in this integration. For protocol
+reference, the frame is built by emitting every present field in ascending protobuf
+field-number order, which reproduces the on-wire byte order exactly. A `program_type`
+discriminator key is always present. A representative field set (matching the structure
+recovered from a `0x0067` echo):
+
+```python
+{
+    "program_id": 1,                         # OrbitPbApi_ProgramId enum (0=manual,1=a,...)
+    "program_name": "Program A",             # optional string
+    "program_type": {                        # oneof discriminator
+        "kind": "interval",                  # "not_set"|"day_of_week"|"interval"|"odd"|"even"|"run_once"
+        "interval_days": 3,                  # interval only
+        "interval_start_time_iso8601": "...",  # interval only
+        # "day_flags": int                   # day_of_week only
+        # "program_flags": int               # run_once only
+    },
+    "start_times_mins_from_midnight": [360], # list[int]
+    "station_info": [                        # list[dict]
+        {"station_id": 0, "run_time_sec": 300, "group_id": 0}
+    ],
+    "budget_percent": 100,
+    # ... other scalar schedule fields
+}
+```
+
+**Verification status:** in the contributor's reference library the `setProgramSchedule` encoder
+byte-reproduced the captured h2d `setProgramSchedule` frame, and the full schedule flow is
+**LIVE-VERIFIED on Timer-NW (2026-06-28)** (schedule setting is not implemented in this integration).
+Setting a schedule that actually runs requires **three writes** plus the app's ordering:
+
+1. **store** -- `setProgramSchedule` (f19) -- defines the program and its zone (`stationInfo.stationId`; Timer-NW = `0`).
+2. **enable** -- `setActivePrograms` (f20) -- `activeProgramFlags` uint32 bitmask, program A = bit 0 (`1<<(programId-1)`, a=1 -> **1**); sole field.
+3. **run-mode / "enable watering"** -- `timerMode{mode=autoMode(1), manualModeParams={} EMPTY}` (f14) -- autoMode encoder not implemented in this integration; byte-exact to `btsnoop_enable_program.log` idx94 = `aa775a0f0800720408011200972f`. The **empty `manualModeParams` (f2) is REQUIRED**; sending only `mode` is silently ignored.
+
+The device computes a next start only when it receives store+enable **while in autoMode**, so the app
+does store -> enable -> autoMode -> **re-send store+enable**,
+then reads `deviceStatusInfo` (f9 `nextStartProgramFlags`, f10 `nextStartTimeSecEpochUTC`). No BLE
+schedule READ exists (section Section L). Live result: device flipped `deviceOff/off` -> `deviceIdle/on` and
+computed next watering 2026-06-28T06:00 for program A.
+
+---
+
+### A.7b -- `0x0011`-length h2d `setRainDelay` (f17)
+
+Delay all watering for N minutes -- the local "skip schedules" control. Saved on the device
+(`btsnoop_rain_delay.log` idx94). `OrbitPbApi_SetRainDelay`: f1 `rainDelayTimeMins` (required),
+f2 `delayStartTimeSecEpochUtc`, f3 `delayEndTimeSecEpochUtc`, f4 `delayType`. The app sends f1+f3+f4.
+
+Captured 3-hour delay (rain-delay encoder not implemented in this integration):
+`aa775a0f10008a010b08b40118c88f83d2062001b959` -> `{rainDelayTimeMins=180, delayEndTimeSecEpochUtc, delayType=1}`.
+`rain_delay_mins=0` cancels. The active delay reads back in `deviceStatusInfo` (`rain_delay`:
+mins/end_epoch/type); `device_status` becomes `rainDelayEnabled`.
+**LIVE-VERIFIED on Timer-NW (2026-06-28)** -- set 3h and cancel both confirmed. Rain delay is not
+implemented in this integration; its `deviceStatusInfo` decoder here,
+`BHyveHT34ADevice._parse_status()` in `devices/ht34a.py`, reads run-state + time-remaining only and
+does not decode the rain-delay fields.
+
+### A.7c -- `setScheduledMode` (f120) and cloud-only settings
+
+`setScheduledMode` (f120, `OrbitPbApi_SetScheduledMode{scheduledMode{turnOn/turnOffDaySecEpochUtc, repeatAnnually}}`)
+is the **system on/off date** (seasonal); sent over BLE, empty (`0a00`) when no dates are set.
+**Cloud-only (no BLE writes -- confirmed from `btsnoop_rain_delay.log`):** Weather Adjustments
+(weather station, rain/wind/freeze-delay thresholds) and Smart Watering Restrictions. The app's
+"saving" toast on those screens is a cloud sync; the cloud computes them and pushes resulting
+schedules/rain-delays down to the device.
+
+---
+
+### A.8 -- `0x0015` d2h `wateringStatus`
+
+**Direction:** device -> host  
+**Frame type:** `0x0015`  
+**OrbitPbApi_Message field:** f30 `wateringStatus`  
+**Class:** `OrbitPbApi_WateringStatus`  
+**Parser:** folded into `BHyveHT34ADevice._parse_status()` in `devices/ht34a.py` (no separate function; it reads run-state + time-remaining only)
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `status` | `Status` | required |
+| f2 | `rainSensorHold` | bool | |
+| f3 | `currentProgramId` | `OrbitPbApi_ProgramId` | |
+| f4 | `currentStationId` | uint32 | |
+| f5 | `currentTimeRemainingSec` | uint32 | |
+| f6 | `waterEventQueue` | `OrbitPbApi_WateringEvent` | repeated |
+| f7 | `totalRunTimeSec` | uint32 | |
+| f9 | `databaseId` | uint32 | |
+| f10 | `runtimeIndex` | uint32 | |
+| f11 | `sessionId` | uint32 | |
+| f12 | `waterInstanceId` | uint32 | |
+| f13 | `waterEventIndex` | uint32 | |
+| f14 | `waterInstanceStartSecEpochUtc` | uint32 | |
+
+**Status enum:**
+
+| Value | Name |
+|-------|------|
+| 1 | `wateringComplete` |
+| 2 | `wateringInProgress` |
+| 3 | `pumpDelay` |
+| 4 | `stationComplete` |
+| 5 | `stationDelay` |
+| 6 | `programPreDelay` |
+| 7 | `programPostDelay` |
+
+**OrbitPbApi_ProgramId enum:** see [A.7](#a7--0x005f-h2d-setprogramschedule).
+
+**Nested: OrbitPbApi_WateringEvent**
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `programId` | `OrbitPbApi_ProgramId` | required |
+| f2 | `stationId` | uint32 | required |
+| f3 | `runTimeSec` | uint32 | required |
+| f4 | `databaseId` | uint32 | |
+| f5 | `eventType` | `EventType` | |
+
+**WateringEvent.EventType enum:**
+
+| Value | Name |
+|-------|------|
+| 1 | `wateringInProgress` |
+| 2 | `programPreDelay` |
+| 3 | `programPostDelay` |
+| 4 | `soak` |
+| 5 | `scheduleSyncDelay` |
+
+#### Captured example
+
+```
+aa 77 5a 0f 15 00 0a 06 44 67 55 d8 28 ac 38 97 d7 f0 d0 06 f2 01 02 08 01 2b 72
+```
+
+Decoded: `wateringStatus { status: wateringInProgress, currentStationId: ..., currentTimeRemainingSec: ... }` -- active watering notification.
+
+---
+
+### A.9 -- `0x0016` d2h `batteryStatus`
+
+**Direction:** device -> host  
+**Frame type:** `0x0016`  
+**OrbitPbApi_Message field:** f46 `batteryStatus`  
+**Class:** `OrbitPbApi_BatteryStatus`  
+**Parser:** inline in `BHyveHT34ADevice._observe_plaintext()` in `devices/ht34a.py`
+
+Note: type code `0x0016` is shared with [A.5](#a5--0x0016-h2d-setepochtime); direction distinguishes them.
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `state` | `BatteryState` | |
+| f2 | `batteryLevelPercent` | uint32 | |
+| f3 | `batteryLevelMV` | uint32 | millivolts |
+| f4 | `externallyPowered` | bool | |
+
+**BatteryState enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `charging` |
+
+#### Captured example
+
+```
+aa 77 5a 0f 16 00 0a 06 44 67 55 d8 28 ac 38 cf d6 f0 d0 06 f2 02 03 18 96 16 10 37
+```
+
+Decoded: `batteryStatus { batteryLevelMV: 2838, batteryLevelPercent: ... }` -- Timer_SE battery reading (2838 mV observed in capture).
+
+---
+
+### A.10 -- `0x002F` d2h `deviceInfo`
+
+**Direction:** device -> host  
+**Frame type:** `0x002F`  
+**OrbitPbApi_Message field:** f23 `deviceInfo`  
+**Class:** `OrbitPbApi_DeviceInfo`
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `numStations` | int32 | |
+| f2 | `hwVersion` | string | |
+| f3 | `fwVersion` | string | |
+| f4 | `wifiVersion` | uint32 | |
+| f5 | `powerBoardId` | `PowerBoardId` | |
+| f6 | `testState` | uint32 | |
+| f7 | `pumpEnabled` | bool | |
+| f8 | `stationsEnabledFlags_0_31` | uint32 | bitmask of enabled stations 0-31 |
+| f9 | `stationsEnabledFlags_32_63` | uint32 | bitmask of enabled stations 32-63 |
+| f10 | `deviceType` | `DeviceType` | |
+| f11 | `bootloaderVersion` | uint32 | |
+| f12 | `hasMfiSetupCode` | bool | |
+| f13 | `bleStatus` | `BleStatus` | |
+| f14 | `bleBootloaderVersion` | uint32 | |
+| f15 | `bleAppVersion` | uint32 | |
+| f16 | `bleSdkVersion` | uint32 | |
+| f17 | `rl78Version` | uint32 | |
+| f18 | `mfrTestStatus` | `OrbitPbApi_MfrTest_DutTestStatus` | |
+| f19 | `pumpEnabledFlags` | uint32 | |
+
+**PowerBoardId enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `orbit6Station` |
+| 1 | `orbit12Station` |
+| 2 | `pro8Station` |
+| 3 | `pro16Station` |
+| 4 | `international6Station` |
+| 5 | `international12Station` |
+| 6 | `unknown` |
+
+**DeviceType enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `hosetapTimer` |
+| 1 | `undergroundTimer` |
+| 2 | `rainSensor` |
+| 3 | `moistureSensor` |
+
+**BleStatus enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `bleUninitialized` |
+| 1 | `bleUpdating` |
+| 2 | `bleInitialized` |
+| 3 | `bleError` |
+
+**Nested: OrbitPbApi_MfrTest_DutTestStatus**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `buttonTestState` | `ButtonTestState` |
+| f2 | `rl78CommTestPassed` | bool |
+| f3 | `zcdTestPassed` | bool |
+| f4 | `scdSigDetected` | bool |
+| f5 | `rainSenseSigDetected` | bool |
+| f6 | `battSenseGood` | bool |
+| f7 | `testDioFlags` | uint32 |
+| f64 | `hscTestStatus` | `OrbitPbApi_MfrTest_Hsc` |
+| f65 | `gcTestStatus` | `OrbitPbApi_MfrTest_GC` |
+
+**ButtonTestState enum** (partial, from schema):
+
+| Value | Name |
+|-------|------|
+| 0 | `buttonTestState_none` |
+| 1 | `buttonTestState_clear` |
+| 2 | `buttonTestState_back` |
+| 3 | `buttonTestState_program` |
+| 4 | `buttonTestState_rainDelay` |
+| 5 | `buttonTestState_dialCw` |
+| 6 | `buttonTestState_select` |
+| 7 | `buttonTestState_dialCcw` |
+| 8 | `buttonTestState_reset` |
+| 9 | `buttonTestState_finished` |
+
+#### Captured example
+
+```
+aa 77 5a 0f 2f 00 0a 06 44 67 55 d8 28 ac 38 cf d6 f0 d0 06 ba 01 1c 08 04 12 0a 48 54 33 34 41 2d 30 30 30 31 1a 04 30 ...
+```
+
+Decoded (partial): `deviceInfo { numStations: 4, hwVersion: "HT34A-0001", fwVersion: "0..." }` -- hardware model and firmware version of the captured device (Timer_SE).
+
+---
+
+### A.11 -- `0x003E` and `0x005E` d2h `deviceStatusInfo`
+
+**Direction:** device -> host  
+**Frame types:** `0x003E` (standard status), `0x005E` (watering-summary variant -- carries `f18 wateringStatusSummary`)  
+**OrbitPbApi_Message field:** f16 `deviceStatusInfo`  
+**Class:** `OrbitPbApi_DeviceStatusInfo`  
+**Parser:** `BHyveHT34ADevice._parse_status()` in `devices/ht34a.py` (decodes run-state (f1) + time-remaining (f6/f7) only; the remaining fields below are protocol reference, not all parsed)
+
+Both type codes carry the same protobuf class. `0x003E` is the typical device status update;
+`0x005E` is seen when the device sends a watering status summary (its `OrbitPbApi_DeviceStatusInfo`
+includes a populated `f18 wateringStatusSummary` containing one or more `WateringStatus` sessions).
+
+Note: [`protocol.md`](protocol.md) also references type code `0x003D` for `deviceStatusInfo` -- that is the
+**same message** observed live on Timer-NW (`44:67:55:D7:4B:F9`); the btsnoop capture (Timer-SE)
+shows `0x003E` and `0x005E`. The frame type code for this `f16` message varies by device/firmware.
+
+#### Fields
+
+| Field | Name | Type | Notes |
+|-------|------|------|-------|
+| f1 | `deviceStatus` | `OrbitPbApi_DeviceStatus` | required |
+| f2 | `timerMode` | `OrbitPbApi_TimerMode` | |
+| f3 | `batteryLevelPercent` | uint32 | |
+| f4 | `nextStartTime` | `OrbitPbApi_NextStartTime` | |
+| f5 | `rainDelayTimeRemainingMins` | uint32 | |
+| f6 | `wateringStatus` | `OrbitPbApi_WateringStatus` | |
+| f7 | `faultStatus` | `OrbitPbApi_FaultStatus` | |
+| f8 | `wacModeEnabled` | bool | |
+| f9 | `nextStartProgramFlags` | uint32 | |
+| f10 | `nextStartTimeSecEpochUTC` | uint32 | |
+| f11 | `batteryLevelMV` | uint32 | |
+| f12 | `programDelayType` | `OrbitPbApi_ProgramDelayType` | |
+| f13 | `rainDelay` | `OrbitPbApi_SetRainDelay` | |
+| f14 | `batteryStatus` | `OrbitPbApi_BatteryStatus` | |
+| f15 | `lastLogEntryTime` | `OrbitPbApi_LogEntry` | |
+| f16 | `deviceSettingsHash` | bytes | |
+| f17 | `sensors` | `OrbitPbApi_Sensor` | |
+| f18 | `wateringStatusSummary` | `OrbitPbApi_WateringStatusSummary` | populated in `0x005E` variant |
+
+**OrbitPbApi_DeviceStatus enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `deviceOff` |
+| 1 | `deviceIdle` |
+| 2 | `lowBattery` |
+| 3 | `rainDelayEnabled` |
+| 4 | `wateringInProgress` |
+| 5 | `meshDeviceOffline` |
+
+**OrbitPbApi_ProgramDelayType enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `programDelayType_none` |
+| 1 | `programDelayType_user` |
+| 2 | `programDelayType_rain` |
+| 3 | `programDelayType_wind` |
+| 4 | `programDelayType_freeze` |
+
+**Nested: OrbitPbApi_NextStartTime**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `nextStartTimeIso8601` | string (required) |
+| f2 | `programFlags` | uint32 (required) |
+
+**Nested: OrbitPbApi_FaultStatus**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `pumpFault` | bool |
+| f2 | `stationFaultFlags_0_31` | uint32 |
+| f3 | `stationFaultFlags_32_63` | uint32 |
+| f4 | `voltageBoostCircuitFail` | bool |
+| f5 | `valveOffFlowDetected` | bool |
+| f6 | `valveOnNoFlowDetected` | bool |
+| f7 | `valveLowFlowDetected` | bool |
+| f8 | `valveHighFlowDetected` | bool |
+| f9 | `smartAccessoryFaultFlags` | uint32 |
+| f10 | `batteryFault` | bool |
+| f15 | `pumpFaults` | `OrbitPbApi_PumpFault` (repeated) |
+| f16 | `stationFaults` | `OrbitPbApi_StationFault` (repeated) |
+| f17 | `mainlineFaults` | `OrbitPbApi_MainlineFault` (repeated) |
+
+**Nested: OrbitPbApi_SetRainDelay**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `rainDelayTimeMins` | uint32 (required) |
+| f2 | `delayStartTimeSecEpochUtc` | uint32 |
+| f3 | `delayEndTimeSecEpochUtc` | uint32 |
+| f4 | `delayType` | `OrbitPbApi_ProgramDelayType` |
+| f5 | `sensorStatus` | `SensorStatus` (repeated) |
+
+**SensorStatus enum:**
+
+| Value | Name |
+|-------|------|
+| 0 | `sensorDisabled` |
+| 1 | `sensorOpen` |
+| 2 | `sensorClosed` |
+
+**Nested: OrbitPbApi_LogEntry**
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `logTimeSecEpochUTC` | uint32 |
+| f2 | `logIndex` | uint32 |
+| f10 | `waterEventLogEntry` | `OrbitPbApi_LogEntry_WaterEvent` |
+
+**Nested: OrbitPbApi_WateringStatusSummary** (present in `0x005E` variant)
+
+| Field | Name | Type |
+|-------|------|------|
+| f1 | `sessions` | `OrbitPbApi_WateringStatus` (repeated) |
+
+`OrbitPbApi_TimerMode` fields: see [A.4](#a4--0x000e-h2d-timermode).  
+`OrbitPbApi_WateringStatus` fields: see [A.8](#a8--0x0015-d2h-wateringstatus).  
+`OrbitPbApi_BatteryStatus` fields: see [A.9](#a9--0x0016-d2h-batterystatus).  
+`OrbitPbApi_Sensor` / `OrbitPbApi_SensorInfo` are present in the schema but nested details are not extracted to this doc level (no example values observed).
+
+#### Captured example (`0x003E`)
+
+```
+aa 77 5a 0f 3e 00 0a 06 44 67 55 d8 28 ac 38 ce d6 f0 d0 06 82 01 2b 08 00 12 02 08 00 3a 00 48 00 50 00 6a 0b 08 a0 0b ...
+```
+
+Decoded (partial): `deviceStatusInfo { deviceStatus: deviceOff, timerMode { mode: offMode }, faultStatus {}, batteryStatus { batteryLevelMV: 2838 }, ... }` -- idle device status for Timer_SE.
+
+#### Captured example (`0x005E`)
+
+```
+aa 77 5a 0f 5e 00 0a 06 44 67 55 d8 28 ac 38 f9 d6 f0 d0 06 82 01 4b 08 04 12 0e 08 02 12 0a 10 00 1a 04 08 00 10 1e 20 ...
+```
+
+Decoded (partial): `deviceStatusInfo { deviceStatus: wateringInProgress, timerMode { mode: manualMode, stationInfo [...] }, wateringStatusSummary { sessions [...] } }` -- active watering with session summary.
+
+---
+
+### A.12 -- `0x0067` d2h `setProgramSchedule`
+
+**Direction:** device -> host  
+**Frame type:** `0x0067`  
+**OrbitPbApi_Message field:** f19 `setProgramSchedule`  
+**Class:** `OrbitPbApi_SetProgramSchedule`
+
+The device echoes the program schedule in this direction (same protobuf class as the h2d `0x005F` request).
+
+#### Fields
+
+Same as [A.7 `0x005F` h2d `setProgramSchedule`](#a7--0x005f-h2d-setprogramschedule).
+
+#### Captured example
+
+```
+aa 77 5a 0f 67 00 0a 06 44 67 55 d8 28 ac 38 d3 d6 f0 d0 06 9a 01 54 08 01 22 1d 08 01 12 19 32 30 32 36 2d 30 34 2d 31 ...
+```
+
+Decoded (partial): `setProgramSchedule { programId: a, programTypeInterval { ... }, stationInfo [...] }` -- device echoing back schedule A. This is the only d2h occurrence; the h2d direction uses type `0x005F`.
+
+---
+
+## Section B -- Un-captured BLE messages (schema-only, from APK)
+
+These messages are referenced in the APK's BLE layer (`lib.ble.*` in `apk/hbc-out/decompiled.js`) but have **no example in the capture**.
+**The outer BLE frame type code is unknown for all of these** -- type codes are only recoverable from live wire traffic.
+Field ids and names are from the reconstructed schema (see [`protobuf-schema.md`](protobuf-schema.md)). Direction is inferred from naming conventions (get* = h2d request, response = d2h) or from the APK writer/transformer evidence; direction marked `?` where ambiguous.
+
+Confidence levels reflect the strength of the APK evidence:
+
+- **high**: explicit `socket.writer.X_BANG_` BLE-write call site, or appears in `get_device_settings`/`send_device_settings` BLE connection sequence
+- **medium**: `socket.util.X` builder exists, no direct BLE dispatch call site confirmed, or pairing is implied from a confirmed counterpart
+- **low/keyword**: only a ClojureScript keyword in the global symbol table, no confirmed BLE dispatch call site
+
+| Field ID | Field Name | Direction | Type code | APK evidence | Confidence |
+|----------|------------|-----------|-----------|--------------|------------|
+| f10 | `syncRequest` | h2d | unknown | `sync_request` builder + `sync_request_BANG_` writer | high |
+| f17 | `setRainDelay` | h2d | unknown | `rain_delay_BANG_` writer; BLE-connect send sequence | high |
+| f21 | `skipCurrentStation` | h2d | unknown | `skip_station_BANG_` writer; keyword confirmed | high |
+| f22 | `getDeviceInfo` | h2d | unknown | `get_device_info_BANG_` writer; BLE-connect read sequence; keyword confirmed | high |
+| f26 | `getNextStartTime` | h2d? | unknown | transformer field name `nextStartTime` -- no direct BLE call site found | low |
+| f27 | `nextStartTime` | d2h | unknown | transformer for `.OrbitPbApi_NextStartTime.nextStartTimeIso8601` | medium |
+| f28 | `getSettings` | h2d | unknown | `get_settings` builder + `get_settings_BANG_` writer; keyword confirmed | high |
+| f29 | `setSettings` (`SetSettings`) | d2h resp | `0x13` | **live-verified 2026-06-28**: `getSettings`->`0x13`/f29. Device returned **EMPTY** `SetSettings` over BLE (payload `0a06...ea0100`). Parser: not implemented in this integration. | high |
+| f36 | `getNetworkStatus` | h2d | unknown | `get_network_status_BANG_` writer; BLE-connect read sequence | high |
+| f37 | `networkStatus` | d2h | unknown | implied counterpart to `getNetworkStatus` | medium |
+| f47 | `identifyDevice` | h2d | unknown | keyword in global table; no BLE call site confirmed | low |
+| f48 | `getManualPresetRunTime` | h2d | unknown | `set_manual_preset_runtime_BANG_` + `get_pump_config_BANG_` patterns; BLE-connect send | medium |
+| f49 | `manualPresetRunTime` | d2h | `0x16` | **live-verified 2026-06-28**: `getManualPresetRunTime`->`0x16`/f49 = `08d804` (`presetRunTimeSec=600`). Parser: not implemented in this integration. | high |
+| f55 | `getFlowSensorParams` | h2d | unknown | `flow_sensor_params_BANG_` writer; keyword confirmed | high |
+| f56 | `flowSensorParams` | d2h | unknown | implied counterpart to `getFlowSensorParams` | medium |
+| f57 | `enableFlowSensorData` | h2d | unknown | `enable_flow_sensor_event_BANG_` writer; keyword confirmed | high |
+| f58 | `getFlowSensorData` | h2d | unknown | `get_instantaneous_flow_BANG_` writer; keyword confirmed | high |
+| f59 | `flowSensorData` | d2h | unknown | implied counterpart to `getFlowSensorData` | medium |
+| f69 | `getProgramSchedule` | h2d | unknown | `get_program_schedule` keyword confirmed; `set_program_BANG_` write patterns | high |
+| f76 | `programSchedule` | d2h | unknown | implied counterpart to `getProgramSchedule` | medium |
+| f77 | `getActivePrograms` | h2d | unknown | keyword confirmed; implied writer | medium |
+| f78 | `activePrograms` | d2h | unknown | implied counterpart to `getActivePrograms` | medium |
+| f94 | `setStationCfg` | h2d | unknown | `set_station_configs_BANG_` writer; BLE-connect send; keyword confirmed | high |
+| f97 | `getStationCfg` | h2d | unknown | `get_station_configs_BANG_` writer; BLE-connect read; keyword confirmed | high |
+| f98 | `stationCfg` | d2h | unknown | implied counterpart to `getStationCfg` | medium |
+| f100 | `ack` | d2h | unknown | schema-only -- standard protobuf acknowledgement | low |
+| f101 | `resetDevice` | h2d | unknown | `reset_device_BANG_` writer; confirmed | high |
+| f105 | `pumpCfg` | d2h | unknown | implied counterpart to `get_pump_config_BANG_` | medium |
+| f107 | `getPumpCfg` | h2d | unknown | `get_pump_config_BANG_` writer | high |
+| f110 | `getWateringStatus` | h2d | unknown | `get_watering_status_BANG_` writer; keyword confirmed | high |
+| f111 | `wateringStatusSummary` | d2h | unknown | implied counterpart to `getWateringStatus` | medium |
+| f112 | `skipWaterInstance` | h2d | unknown | `skip_water_instance_BANG_` writer; keyword confirmed | high |
+| f113 | `skipWaterEvent` | h2d | unknown | `skip_water_event_BANG_` writer; keyword confirmed | high |
+| f116 | `setConcurrentProgramGroups` | h2d | unknown | `set_concurrent_programs_BANG_` writer | high |
+| f119 | `scheduledMode` | d2h | unknown | implied counterpart to `getScheduledMode` | medium |
+| f120 | `setScheduledMode` | h2d | unknown | `set_system_scheduled_modes_BANG_` writer; BLE-connect send; keyword confirmed | high |
+| f121 | `getScheduledMode` | h2d | unknown | implied by `set_system_scheduled_modes_BANG_` sequence | medium |
+| f200 | `getSmartAccessories` | h2d | unknown | `get_smart_accessories_BANG_` writer; BLE-connect read; keyword confirmed | high |
+| f201 | `setSmartAccessories` | h2d | unknown | `set_smart_accessories_BANG_` writer; keyword confirmed | high |
+| f214 | `getSmartAccessoryOtaStatus` | h2d | unknown | `get_smart_accessory_ota_status_BANG_` writer | high |
+| f215 | `smartAccessoryOtaStatus` | d2h | unknown | implied counterpart to `getSmartAccessoryOtaStatus` | medium |
+
+### Excluded fields (not BLE-layer)
+
+The following `OrbitPbApi_Message` fields appeared in the APK keyword table but are excluded from this catalog because evidence places them in cloud/hub/provisioning paths, not direct BLE:
+
+| Field IDs | Reason |
+|-----------|--------|
+| f32/f33 `getApList`/`apList` | WiFi AP provisioning -- cloud/hub path |
+| f34 `networkConnect` | WiFi provisioning -- cloud/hub path |
+| f39/f40 `updateBlockRequest`/`updateBlockResponse` | OTA block protocol -- `ota-block-request` is dropped at the cloud socket event handler (line 1135850); not forwarded over direct BLE |
+| f60/f61 `getMfiSaltVerifier`/`mfiSaltVerifier` | HomeKit MFi -- no BLE call site found |
+| f63-f68 `agGetApList`, `radioConfigure`, etc. | `BhyveAgApi_*` = cloud aggregator/hub paths |
+| f72-f74 `getHomeKitParams`/`setHomeKitParams`/`homeKitParams` | HomeKit -- no BLE call site |
+| f80-f87 `cpaLite*`, `bleBridged*` | Cloud bridging / AG paths |
+| f200+ `cellular*`, `lorawan*` | Explicitly cellular/LoRa transport (field IDs above f200 in this category; distinct from f200 `getSmartAccessories`) |
+
+**OTA note:** The `OTAV1Service` class in `bhyve-app.lib.ble.service.ota-v1-service` uses the BLE `write_char_uuid` characteristic, suggesting firmware OTA may use direct BLE. However, the protobuf-level framing relationship to `OrbitPbApi_Message` is unclear, and the field mappings above are marked "dropped at cloud socket handler." OTA over BLE is out of scope for this catalog.
+
+---
+
+## Section C -- Scope and method
+
+**Transport scope:** This catalog covers the direct BLE channel only -- frames on GATT characteristics `0x0014` (h2d) and `0x0016` (d2h). Cloud is used exclusively for initial login and AES-128 `network_key` retrieval (`GET /v1/network_topologies`); all device control and status is local BLE. `OrbitPbApi_Message` has approximately 173 used fields across its oneof, the majority of which are cloud-only and excluded here.
+
+**Capture reconciliation:** 13 distinct message types are present in `bluetooth_logs/btsnoop_hci.log.last` (Timer_SE session, `44:67:55:D8:28:AC`) and cross-verified on Timer-NW hardware (`44:67:55:D7:4B:F9`). These are ground truth -- both type code and protobuf field mapping are confirmed from wire traffic.
+
+**APK reconciliation:** An additional ~41 field references were identified in the APK BLE layer (`lib.ble.*` in `apk/hbc-out/decompiled.js`) via `socket.util.*` builders, `socket.writer.*_BANG_` dispatch, and the `get_device_settings`/`send_device_settings` BLE connect sequences. Outer type codes for these are unknown -- they are confirmed BLE messages but were not present in the capture session.
+
+**Schema source:** All field ids, names, types, and enum values are from the reconstructed schema in [`protobuf-schema.md`](protobuf-schema.md) (originally extracted from the APK's embedded protobuf schema JSON at `apk/hbc-out/decompiled.js` line 977559). That reconstructed schema is the source for the 13-row inventory and the nested field tables used in Section A.

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -1,0 +1,88 @@
+# BLE Protocol Reference
+
+*Reverse-engineering notes; imported from the maintainer's research project.*
+
+> **See also:** [`protocol.md`](protocol.md) is the wire-verified protocol reference for the protobuf "XD" family and supersedes this document where they differ (notably the inner-message length field — see the note below). This document is kept for the extra behavioral notes (bonding, MAC enforcement, replay, ATT opcode quirks) and the connection-sequence walkthrough.
+
+Technical reference for the Orbit B-Hyve XD BLE protocol as observed and reconstructed during the project. For the narrative of how this was figured out, see [`reverse-engineering-journey.md`](reverse-engineering-journey.md).
+
+## GATT Service & Characteristics
+
+The device advertises one custom GATT service:
+
+| Service UUID | Notes |
+|---|---|
+| `0000fe32-0000-1000-8000-00805f9b34fb` | Used for HA's BLE auto-discovery |
+
+The service exposes five characteristics. The three used in normal operation are:
+
+| Handle | UUID | Properties | Purpose |
+|---|---|---|---|
+| 0x0012 | `00006c71-fe32-4f58-8b78-98e42b2c047f` | read, write | AES session initialization (always 20-byte writes) |
+| 0x0014 | `00006c72-fe32-4f58-8b78-98e42b2c047f` | write-without-response, write | Encrypted data channel — outgoing (TX) |
+| 0x0016 | `00006c73-fe32-4f58-8b78-98e42b2c047f` | notify | Encrypted data channel — incoming (RX, via notifications) |
+| 0x0017 | (CCCD for 0x0016) | write | Enable notifications on RX (write `0x0100`) |
+| 0x0018 | `00006c76-fe32-4f58-8b78-98e42b2c047f` | write | Unknown — ATT 0x80 (Application Error) for any write without proper auth context |
+
+## Connection Sequence
+
+A working session looks like this:
+
+1. **Connect** to the device's BLE address (no BLE bonding required — the device does not maintain a paired-peer table).
+2. **Service discovery**.
+3. **MTU negotiation.** The application requests an MTU around 262; the device accepts up to about 672 bytes. In practice 247 is plenty.
+4. **AES session init.** Write a 20-byte buffer to characteristic `0x6c71` (handle 0x0012). The structure of the buffer is described in the Encryption section below. Read `0x6c71` back; the device returns a 20-byte response whose first 4 bytes are a session-specific value used to derive the session IV.
+5. **Enable notifications on `0x6c73`** by writing `0x0100` to its CCCD (handle 0x0017).
+6. **Exchange encrypted frames.** Outgoing on `0x6c72`; incoming on `0x6c73` notifications. Each frame uses the framing described next.
+
+## Frame Format (data channel)
+
+```
++------+--------+--------------------------+----------+----------+
+| 0x11 | length | encrypted_payload (length bytes)    | trailer  |
++------+--------+--------------------------+----------+----------+
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2 bytes LE
+```
+
+- **`0x11`** — fixed magic header byte (decimal 17).
+- **`length`** — single byte. Length of the encrypted payload **only**; does not include the trailer.
+- **encrypted payload** — `length` bytes of AES-encrypted data (see [`encryption.md`](encryption.md) for the cipher construction).
+- **trailer** — 2 bytes, little-endian, content-dependent checksum. Algorithm:
+  ```
+  trailer_uint16 = (sum(plaintext_bytes) + 0x11 + length) mod 65536
+  ```
+  Where `plaintext_bytes` is the unencrypted inner message (the bytes that were encrypted to produce the encrypted payload).
+
+Total frame size on the wire = `2 + length + 2` = `length + 4` bytes.
+
+## Inner Message (plaintext) Format
+
+After decryption, the inner message is itself wrapped:
+
+```
++----+----+----+----+--------+------+------+----------------+--------------+
+| AA | 77 | 5A | 0F | length |  00  |  00  | protobuf bytes | CRC16-CCITT  |
++----+----+----+----+--------+------+------+----------------+--------------+
+```
+
+> **Correction:** later wire analysis (51/51 frames) showed the byte after the `aa 77 5a 0f` magic is a **little-endian uint16 length** (`= len(protobuf) + 2`), not a single length byte followed by two reserved bytes. Read the field as `aa 77 5a 0f <length:LE16> <protobuf> <crc16>`. See [`protocol.md`](protocol.md) for the authoritative layout. The description below reflects the earlier decode.
+
+- **`AA 77 5A 0F`** — 4-byte fixed inner-frame header.
+- **`length`** — payload length including the 2 trailing CRC bytes.
+- **`00 00`** — reserved.
+- **protobuf bytes** — encoded `OrbitPbApi_Message` (or `OrbitPbApi_IpcMsg`); see [`protobuf-schema.md`](protobuf-schema.md).
+- **CRC-16 CCITT** — checksum over the protobuf bytes only, using the standard CCITT polynomial `0x1021` and lookup table. In this repo: `_crc16_ccitt()` in `custom_components/orbit_bhyve/devices/ht34a.py`.
+
+## Notes on Behavior
+
+- **No BLE bonding.** The device does not write to the host's `bt_config.conf` paired-devices table. It does not enforce link-layer pairing or LE Secure Connections.
+- **No MAC enforcement.** The device does not validate the BLE link-layer source MAC of incoming writes. Confirmed by experiment with a spoofed adapter MAC.
+- **ATT Write Command vs Write Request.** The device accepts both for short payloads. For longer payloads (≈ 25+ bytes), the device returns ATT Error 0x80 (Application Error) on Write Request but accepts Write Command. The custom integration uses Write Command for compatibility.
+- **Replay protection.** The session-init handshake establishes a per-session IV/counter. Replaying a captured init message from a previous session does not work — the device tracks something across sessions (likely a counter in flash).
+
+## Verifying Your Connection
+
+The simplest live test, after establishing a session:
+
+- Send a timestamp-sync message setting the device clock to a recognizable value (e.g. `2000-01-01T00:00:00Z`). The B-Hyve LCD should immediately update to show that date/time.
+- This confirms encryption, framing, trailer, and protobuf encoding are all correct, even if no valve actuates.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,133 @@
+# Encryption: Custom AES-ECB-as-CTR Construction
+
+*Reverse-engineering notes; imported from the maintainer's research project.*
+
+This document describes the AES construction used by the Orbit B-Hyve XD on its data-channel BLE characteristic, plus the content-dependent trailer checksum that protects each frame's integrity. It focuses on the *cipher and framing*, which are shared by every device family; see [`hermes-findings.md`](hermes-findings.md) for the same construction as recovered from the vendor app, and [`protocol.md`](protocol.md) for the wire-verified message layout.
+
+In this integration the cipher, handshake and outer-frame trailer live in `custom_components/orbit_bhyve/connection.py` (`BHyveBleConnection._handshake`, `_aes_keystream` / `_aes_xor`, and the trailer computed inline in `encrypt()`).
+
+## Cipher Construction
+
+The B-Hyve uses **AES-128 in a custom CTR-style mode**, implemented manually using AES-ECB to generate keystream blocks. It is not a library's AES-CTR primitive — it is a hand-rolled construction.
+
+### Parameters
+
+| | |
+|---|---|
+| Cipher | AES-128 (ECB primitive used as keystream generator) |
+| Key | The account-specific 16-byte `networkKey` |
+| Block size | 16 bytes (standard AES) |
+| IV length | 12 bytes, per session |
+| Counter | 32-bit, little-endian, increments per 16-byte block |
+
+### Algorithm
+
+```
+# Per-session setup (after the 20-byte 6c71 init exchange):
+IV       = rx_response[:4] || init_tx[4:12]      # 12 bytes
+Counter  = uint32_LE(init_tx[12:16])             # initial counter
+
+# Per-block keystream:
+Block_in   = IV || uint32_LE(Counter)            # 16 bytes
+Keystream  = AES-ECB-Encrypt(networkKey, Block_in)
+Ciphertext = Plaintext XOR Keystream
+Counter    = (Counter + 1) mod 2^32
+
+# Continue for each subsequent 16-byte block of the message.
+```
+
+Decryption is identical (XOR is its own inverse). The cipher is symmetric in both encrypt and decrypt directions, as expected of CTR-style modes.
+
+### Why "ECB used as CTR" rather than just AES-CTR?
+
+The construction is functionally equivalent to AES-CTR with a specific nonce/counter layout (12-byte nonce, 4-byte counter), but the implementation uses the AES-ECB primitive with a manually-assembled `IV || counter` block as input. This is because the application's encryption library (a pure JavaScript AES library bundled inside the React Native app) expects an ECB primitive and applies the counter increment in JavaScript code, rather than calling a higher-level CTR API.
+
+### Session Init Handshake (`0x6c71`)
+
+The 20-byte write to characteristic `0x6c71` establishes the session IV and counter. The bytes are:
+
+```
+init_tx = [ rx_seed_bytes (4) | iv_seed (8) | counter_LE (4) | reserved (4) ]
+```
+
+- The first 4 bytes are not used to derive the session IV directly; they are echoed-and-modified by the device in its response.
+- Bytes 4–11 (8 bytes) are used as the second half of the 12-byte session IV.
+- Bytes 12–15 (4 bytes, little-endian uint32) become the initial counter.
+- Byte 11 (the last byte of the IV-seed range) is **always written as `0x00`** by the application. The device may reject otherwise.
+
+The device's 20-byte response to the read of `0x6c71` contains:
+
+```
+rx_response = [ session_seed (4) | zero_bytes (16) ]
+```
+
+The session IV is then assembled as:
+
+```
+session_IV = rx_response[:4] || init_tx[4:12]
+```
+
+This is 12 bytes total, used as the high-order portion of every keystream block.
+
+## Inner Message Integrity (CRC-16 CCITT)
+
+Inside the encrypted payload, after the 4-byte inner header `AA 77 5A 0F` and a little-endian uint16 length (see [`protocol.md`](protocol.md) — earlier notes described this as a length byte plus reserved bytes), the protobuf data is followed by a **CRC-16 CCITT** checksum:
+
+- Polynomial: `0x1021`
+- Initial value: `0`
+- No reflection, no XOR-out
+- Standard 256-entry lookup table
+
+This is the textbook CCITT CRC-16 used in many BLE and embedded protocols. It validates the protobuf bytes **before** encryption.
+
+## Outer Frame Integrity (the Trailer)
+
+Outside the encrypted payload, every frame carries a 2-byte trailer:
+
+```python
+def compute_trailer(plaintext: bytes, length: int) -> bytes:
+    """Compute the 2-byte content-dependent trailer for a B-Hyve BLE frame.
+
+    Args:
+        plaintext: the unencrypted inner message bytes (header + protobuf + CRC16)
+        length: the value of the frame length byte (= len(plaintext))
+
+    Returns:
+        2 bytes, little-endian uint16
+    """
+    total = sum(plaintext) + 0x11 + length
+    return struct.pack("<H", total & 0xFFFF)
+```
+
+In this codebase the trailer is computed inline in `BHyveBleConnection.encrypt()` (`custom_components/orbit_bhyve/connection.py`) as `(sum(plaintext) + trailer_const + len(plaintext)) & 0xFFFF`, where `trailer_const` is `0x11` for the protobuf/XD family and `0x10` for the older HT25 "d7-47" family.
+
+### Why this trailer matters
+
+The CTR-style cipher is **malleable**: any bit in the ciphertext can be flipped to flip the corresponding plaintext bit. Without an outer integrity check, a captured ciphertext could be mutated into a different valid command without knowing the key. The byte-sum trailer plugs this hole — modifying any byte changes the sum, breaking the trailer.
+
+It is not a cryptographic MAC (it has none of the unforgeability guarantees of HMAC or AES-GCM), but it is sufficient to defeat the trivial bit-flip attack and to detect transmission corruption.
+
+### Trailer values for known commands (firmware 0107, sample plaintexts)
+
+| Command | Trailer (uint16 LE) |
+|---|---|
+| Zone 1 ON, 60s | `0x8004` |
+| Zone 2 ON, 60s | `0xa304` |
+| Zone 3 ON, 60s | `0xa203` |
+| Zone 4 ON, 60s | `0xc403` |
+
+These are illustrative — your exact values will depend on the duration, timestamps, and any additional protobuf fields you include.
+
+## Putting It All Together — Send Path
+
+```
+1. Build protobuf message (e.g. timerMode { mode=manual, manualModeParams { stationInfo { stationId=0, runTimeSec=300 } } })
+2. Compute CRC-16 CCITT over the protobuf bytes; append.
+3. Prepend [AA 77 5A 0F] + [length:LE16] => "inner message" / plaintext.
+4. AES-encrypt the plaintext using the per-session IV/counter from the connection sequence.
+5. Compute the outer trailer = uint16_LE((sum(plaintext) + 0x11 + length) mod 65536).
+6. Assemble the on-wire frame: [0x11] + [length] + [ciphertext] + [trailer].
+7. Write to characteristic 0x6c72 (handle 0x0014).
+```
+
+In this integration the send path is split across `custom_components/orbit_bhyve/devices/ht34a.py` (protobuf build → `_build_message` → CRC-16) and `custom_components/orbit_bhyve/connection.py` (`encrypt()` for AES + trailer, then the GATT write). The equivalent for the older HT25 "d7-47" family is in `custom_components/orbit_bhyve/devices/ht25.py`.

--- a/docs/findings/apk-findings.md
+++ b/docs/findings/apk-findings.md
@@ -1,0 +1,153 @@
+# APK reverse-engineering findings — official B-Hyve app v3.0.53
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+## TL;DR
+
+**The official app writes to a fourth GATT characteristic, `0x6c76`
+(`network_char_uuid`), during its connect-and-prepare flow, BEFORE the AES
+handshake.** At the time this was written, the working theory was that this write
+*provisions* the device with the network key and that a missing provisioning step was
+why valves don't actuate even though the AES handshake succeeds and encrypted command
+writes are accepted.
+
+> **Correction (later finding):** The "provision by writing the network key to
+> `0x6c76`" conclusion in this document was **disproven**. Every device tested returns
+> **"Write not permitted"** on `0x6c76`, so the app cannot be writing the key there over
+> BLE. The network key is **per-account and fetched from the cloud** — it is never
+> written to the device over BLE. Read the discovery of the 4th characteristic and the
+> `provision → init_aes → subscribe` sequence below as accurate *observations of the
+> decompiled call graph*, but treat the "you must write the key to `0x6c76` to actuate"
+> claim as false. The characteristic exists and is referenced by the app, but it is not
+> a client-writable key-provisioning channel.
+
+The discovery of the 4th characteristic itself was the missing piece the BLE captures
+could never show us — the phone uses RPAs and the single-channel sniffer couldn't follow
+its connections, so we never observed this part of the sequence directly.
+
+## How we got here
+
+- APK: `com.orbit.orbitsmarthome` v3.0.53 (versionCode 1448), 70 MB single-ABI variant from APKMirror.
+- App is **React Native + ClojureScript** (re-frame). All BLE protocol logic is in `assets/index.android.bundle` (16.4 MB Hermes bytecode). Java side has zero Orbit business logic — only stock `react-native-ble-manager` (`it.innove.BleManager`) and four boilerplate classes.
+- Decompiled with `hbc-decompiler` (P1sec/hermes-dec, in a Python venv). Output: `bundle_decompiled.js` (98 MB, 2.77M lines of computed-goto JS pseudocode).
+
+## The four GATT characteristics
+
+Verbatim from the decompiled bundle, lines 1016769–1016865:
+
+| Characteristic UUID | Source name | Our code |
+|---|---|---|
+| `00006c71-fe32-4f58-8b78-98e42b2c047f` | `aes_char_uuid` | `AES_CHAR` ✓ |
+| `00006c72-fe32-4f58-8b78-98e42b2c047f` | `write_char_uuid` | `WRITE_CHAR` ✓ |
+| `00006c73-fe32-4f58-8b78-98e42b2c047f` | `read_char_uuid` | `READ_CHAR` ✓ |
+| `00006c76-fe32-4f58-8b78-98e42b2c047f` | **`network_char_uuid`** | **discovered here** |
+
+Service UUID base is `fe32` → full service UUID is `0000fe32-0000-1000-8000-00805f9b34fb` (`SERVICE_UUID` ✓).
+
+Other constants from the same module:
+- `max_message_size` = 255
+- (`default_tx_delay_ms`, `encryption_frame_size`, `our_protocol_overhead`, `ble_protocol_overhead` — values are register-relative; not yet decoded but secondary.)
+
+## The connection sequence
+
+The official app's connect-and-prepare-for-commands flow, mapped from decompiled functions in `lib.ble.service.common`:
+
+```
+provision_device!(peripheral, network_key_buf):
+    BleManager.write(peripheral, service_uuid, network_char_uuid,
+                     [01 00] ++ network_key_buf)
+    # 2-byte LE prefix (default = 1) + 16-byte network key
+
+init_aes(peripheral):
+    BleManager.write(peripheral, service_uuid, aes_char_uuid, init_payload_20B)
+    response = BleManager.read(peripheral, service_uuid, aes_char_uuid)
+    iv, counter = derive_session_iv(init_payload, response)
+
+subscribe_read_char(peripheral):
+    BleManager.startNotification(peripheral, service_uuid, read_char_uuid)
+
+init_network(args):
+    if NOT app_db_marks_provisioned(peripheral):
+        provision_device!(peripheral, base64_decode(stored_b64_key))
+    init_aes(peripheral)
+```
+
+> **Correction (later finding):** the `provision_device!` write shown above targets
+> `0x6c76`, which real devices reject with "Write not permitted." The call exists in the
+> decompiled app, but it does not succeed as a key-provisioning write over BLE. The
+> `init_aes` → `subscribe_read_char` ordering below is still a useful observation.
+
+Source line refs in the decompiled bundle (`bundle_decompiled.js`):
+- `provision_device!` — defined L1017723–1017942, written at L1017814
+- `init_aes` — defined L1017277–1017711, write at L1017620, read at L1017309
+- `subscribe_read_char` — defined L1017265
+- `init_network` — defined L1017954–1018156, calls provision at L1018106, then init_aes at L1018120
+
+## What's written to `network_char_uuid`
+
+Decompiler output for the data payload assembly (L1017766–1017778):
+
+```
+short_LE = (slot2547(args) if truthy else 1)              # 2-byte little-endian short
+key_vec  = buffer_to_vec(network_key_buffer)              # 16 bytes
+data     = clj_to_js(concat([short_LE], key_vec))         # final 18-byte payload
+BleManager.write(peripheral, service_uuid, network_char_uuid, data)
+```
+
+Payload shape: `01 00 || <16-byte network_key>` → 18 bytes total. The `slot2547` value
+defaults to `1` when the args map doesn't carry an alternate (a versioning/key-id hint).
+
+> **Correction (later finding):** this 18-byte write is what the app *constructs*, but
+> the device does not accept it on `0x6c76` ("Write not permitted"). Do not implement a
+> key-write step against this characteristic — it will fail. The network key is obtained
+> from the cloud account, not written to the device.
+
+## Provisioning is per-app-session (as coded in the app)
+
+`init_network` checks `db.read([slot2617, address, slot6158])` — re-frame app-db keyed
+by device address. App-db is in-memory (not persistent across app launches). So, as the
+app is written:
+
+- Phone app: would provision on first connection per app launch, then skip on subsequent connections within the same launch.
+- (This whole branch is moot given the correction above — the write is rejected by the device regardless.)
+
+## What this section originally claimed (superseded)
+
+> **Correction (later finding):** the reasoning in this subsection is built on the
+> disproven "provisioning gates commands" theory. It is retained for the record but is
+> not correct.
+
+The original theory was:
+
+- Direct BLE connection works (we observed connection success in HA logs).
+- AES handshake succeeds (the AES init exchange uses the encryption key correctly).
+- WRITE_CHAR writes are *accepted* (no GATT error).
+- But the valve never actuates → the guess was that the device's command-handling layer
+  ignores commands until "provisioned" via `0x6c76`.
+
+The later finding — that `0x6c76` is not writable and the key comes from the cloud —
+means the actual cause of non-actuation lies elsewhere (inner payload format for the
+device family), not in a missing provisioning write.
+
+The capture-side observation still holds: an earlier phone "Control via Bluetooth" mode
+capture showed no capturable Orbit `CONNECT_IND` because the phone uses Bluetooth
+privacy (RPAs) and the single-channel sniffer couldn't follow its connection.
+
+## Other notes worth keeping
+
+- The crypto used is what the integration already implements: AES-CTR-style keystream with 12-byte IV (`response[:4] || init_payload[4:12]`) and 4-byte LE counter (`init_payload[12:16]`). No change needed there — the bundle's `read_aes_init_response` matches the integration's `derive_session_iv`. In this repo the cipher lives in `custom_components/orbit_bhyve/connection.py` (`_aes_xor` / `_handshake`).
+- `subscribe_read_char` is called *after* `init_aes` in the official app. The integration currently subscribes *before* (in `custom_components/orbit_bhyve/connection.py`). Worth keeping in mind if command delivery still misbehaves.
+- The decompiled bundle preserves no protobuf field names. If we ever need to refine the watering protobuf shapes, we'd need to find them in the same `bundle_decompiled.js` (search around `runZone`, `quickRun`, watering keywords).
+- The `AA 77 5A 0F` message header, CRC-16-CCITT trailer, frame magic `0x11`, and 2-byte trailer all match what the integration implements in `custom_components/orbit_bhyve/devices/ht34a.py` — no change needed.
+
+## Action items
+
+> **Correction (later finding):** action items 1 and 2 below were premised on the
+> disproven `0x6c76` key-write. `NETWORK_CHAR` can stay defined as a known UUID
+> (`custom_components/orbit_bhyve/const.py`), but do **not** add a provisioning key-write
+> step — the device rejects it. Left here for historical accuracy.
+
+1. Add `NETWORK_CHAR = "00006c76-fe32-4f58-8b78-98e42b2c047f"` to `custom_components/orbit_bhyve/const.py`.
+2. ~~Add a `provision_device(client, network_key)` step and call it BEFORE the AES init.~~ **Disproven** — `0x6c76` returns "Write not permitted"; the key is fetched from the cloud, not written over BLE.
+3. Test on HT25-0000 / firmware 0041 hardware.
+4. If behavior changes: post a follow-up comment on the upstream PR with the finding.

--- a/docs/findings/bundle-decompile.md
+++ b/docs/findings/bundle-decompile.md
@@ -1,0 +1,310 @@
+# Bundle decompile + Frida-gadget findings
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+Written 2026-05-03. Updates the picture from the earlier handoff notes after a full
+session of bundle decompilation and runtime instrumentation.
+
+> **Identifier masking.** The worked hex examples below are per-session ephemeral
+> (session IV and counters are derived from the BLE handshake, not from the network
+> key) and are safe to publish. The network key itself is never reproduced. Any
+> embedded device identifiers — the 2-byte mesh prefix at the start of each plaintext
+> and any 4-byte mesh device IDs in the payload — are masked as `xx`.
+
+## TL;DR — RESOLVED
+
+The full cipher scheme is reverse-engineered. All 7 captured BTSnoop frames decrypt
+cleanly and every trailer formula matches.
+
+**Cipher**: AES-128-ECB used as a keystream generator (CTR-style XOR).
+**Key**: `base64Decode(deviceData[":network-key"])` — a per-account 16-byte value.
+The real key is never shown here; the worked examples below use the synthetic
+placeholder `00112233445566778899aabbccddeeff` where a key value is needed.
+**IV (12 bytes)**: `init_rx[0..4] || init_tx[4..12]` — built from the BLE AES-handshake
+exchange.
+**Counters**: TX and RX have **separate counters**. Both seeded from `init_tx[12..20]`:
+- `:enc-ctr` (TX) initial = `uint32_LE(init_tx[12..16])`
+- `:dec-ctr` (RX) initial = `uint32_LE(init_tx[16..20])`
+- Each counter increments by 1 per frame (per direction).
+
+**Block**: `IV (12B) || counter_LE_4B (4B)` → AES-ECB-encrypt → XOR with plaintext.
+**Trailer**: `sum(plaintext) + 0x10 + len` (16-bit, little-endian).
+
+For the captured session (these values are session-derived and ephemeral):
+```
+IV = 6345939f dd1a4ab3 3b4aad64
+enc-ctr0 = 0xf9bbfffa     (TX side)
+dec-ctr0 = 0xa0e8129a     (RX side)
+```
+
+Decrypted plaintexts confirm a custom binary protocol (NOT protobuf as the earlier
+handoff guessed). All start with the same 2-byte mesh prefix (a device identifier,
+masked as `xx xx` here). See "Decrypted plaintexts" section below.
+
+## Frida-gadget toolchain — fully operational
+
+The `frida_setup/01..05` scripts get you to a launching patched APK. Beyond what's
+documented there:
+
+| Step | What we did differently from the original scripts |
+|---|---|
+| Path | Scripts hardcoded an absolute `/path/to/...` prefix — fixed to derive from `$0`'s parent. |
+| Bundle is a **Play split base** (`requiredSplitTypes="base__abi,base__density"`). objection's `--ignore-nativelibs` is needed; **and** the gadget can't live in `base.apk` because the system only loads native libs from the ABI split. |
+| Solution: pull all 5 splits via `adb pull`, patch `base.apk` smali (objection adds `loadLibrary("frida-gadget")` to MainActivity `<clinit>`), inject `libfrida-gadget.so` into `split_config.arm64_v8a.apk`, re-sign every split with the same objection debug keystore, `adb install-multiple`. |
+| Repack details that bite: `lib/arm64-v8a/libfrida-gadget.so` must be **stored uncompressed**, `resources.arsc` must be stored, all libs page-aligned (`zipalign -p 4`). |
+| `apktool b` chokes on a private-resource reference in `res/layout/number_picker_material.xml`. Strip the `android:textAppearance="@android:style/TextAppearance.SlidingTabActive"` attr before rebuilding. |
+| **PairIP (Google's anti-tamper licensecheck)** ships in this APK. After resigning, `LicenseContentProvider.onCreate()` redirects to Play Store. Stub it to `return true` (`smali_classes2/com/pairip/licensecheck/LicenseContentProvider.smali`) before rebuilding base. No other PairIP entry points in the manifest, so this single stub is enough. |
+| Gadget needs a JSON config in the arch split at `lib/arm64-v8a/libfrida-gadget.config.so` — content: `{"interaction":{"type":"listen","address":"127.0.0.1","port":27042,"on_load":"wait"}}`. |
+| Connect from host with `adb forward tcp:27042 tcp:27042` then Python: `frida.get_device_manager().add_remote_device('localhost:27042').attach('Gadget')`. |
+
+The re-signing keystore is objection's default debug keystore (its password is
+objection's built-in default — not reproduced here).
+
+## Bundle structure (decompiled)
+
+`assets/index.android.bundle` — 16 MB Hermes bytecode, magic `c61fbc03`, version 96.
+
+Decompiled with `hbc-decompiler` (from PyPI `hermes-dec`) → 102 MB JS at
+`hermes_work/decomp.js`. Disassembly at `hermes_work/disasm.hasm` (196 MB).
+
+### AES library
+
+`module$aes_js` is the standard npm `aes-js` library.
+- `Function #27951` = `ModeOfOperationECB` constructor
+- `Function #27956` = `ModeOfOperationCTR` constructor
+- The library defines all of ECB / CBC / CFB / OFB / CTR even though the user code only
+  calls ECB.
+
+### User code's cipher construction (the BLE messaging path)
+
+In ClojureScript, function `init_aes` (decomp.js around line 1017950):
+
+```js
+// destructure device data
+r6 = __destructure_map(a0)              // a0 = device record from cloud
+const networkKeyString = get(r6, :network-key)   // base64 string
+const keyBuffer = base64ToBuffer(networkKeyString)  // 16 bytes
+// build BLE service path  [:lib :ble :service :data ... :aes]
+r7 = service_path(r6, [..., :aes])
+
+// construct cipher
+r3 = aesjs.ModeOfOperation.ecb           // function ECB(key)
+const cipher = new r3(keyBuffer)         // r12 in decomp is undefined; ECB takes 1 arg
+
+// store cipher into app db at the ble path
+db.core.write(ctx, r7, cipher)
+```
+
+Closure slots resolved by tracing keyword definitions:
+- `_closure1_slot3313` = `:network-key`
+- `_closure1_slot3777` = `:aes`
+- `_closure1_slot5988` = `:iv`
+
+### Encryption call site (BLE write path)
+
+`perform_crypto(ctx, ctr, plaintext_seq, acc)` at decomp.js line ~1018347, ClojureScript
+named `:lib/:ble/:service/:common/perform_crypto`.
+
+For each 16-byte chunk of plaintext:
+```js
+buf = Buffer.alloc(encryption_frame_size)        // 16 bytes
+ivBytes = (:iv ctx)                              // 12-byte IV from cipher state
+ivBytes.copy(buf, 0, 0, 13)                      // copies bytes 0..12 (note: 13 bytes, but
+                                                 // overwritten by next op at offset 12)
+buf.writeUInt32LE(ctr, 12)                       // counter as little-endian uint32 at [12..16]
+
+cipher = (:aes ctx)
+keystream = cipher.encrypt(buf)                  // AES-ECB(key, buf)
+
+ctr_next = inc_ctr(ctr)
+remaining_pt = drop(16, plaintext_seq)
+this_pt     = take(16, plaintext_seq)
+xored = map(bit_xor, keystream, this_pt)         // XOR keystream with plaintext
+accumulator = concat(acc, xored)
+```
+
+So the full block construction is:
+- `block = ctx[:iv][0..12] || u32_LE(counter)`  (16 bytes)
+- `keystream = AES_ECB_encrypt(key, block)`
+- `ciphertext = plaintext XOR keystream`
+
+Counter starts at *something* and increments per block via `inc_ctr`. (Resolved below —
+see "What unlocked it".)
+
+### The two crypto modules (don't confuse them)
+
+There's also a SECOND, separate crypto module at decomp.js line 609571 — `make_cbc` /
+`encrypt_string_BANG_` / `decrypt_string_BANG_` — uses **AES-CBC** with a key passed
+through `trim_pad_encyption_key` (sic). This is an internal *string* encryption used by
+the app's local DB, not the BLE messaging path. Don't confuse the two.
+
+## What unlocked it
+
+The breakthrough was finding the cipher-state construction by tracing where `:iv` is
+PUT (not just READ). It's set in the `init_aes` `.then()` callback at decomp.js
+~line 1017340-1017430:
+
+```js
+// init_aes (a0=ctx, a1=init_tx_bytes); _closure2_slot0 = a1
+rn_ble_manager.read(peripheralId, service_uuid, aes_char_uuid).then(function(init_rx_bytes) {
+  // validate handshake
+  if (every?(zero?, take(4, init_rx_bytes))) error;          // init_rx[0..4] must be non-zero
+  if (not_every?(zero?, drop(4, init_rx_bytes))) error;      // init_rx[4..end] must be all zero
+
+  // build cipher state buffer = init_rx[0..4] + init_tx[4..end]
+  const buf = Buffer.from(concat(take(4, init_rx_bytes), drop(4, _closure2_slot0)));
+
+  // store three values into the cipher state map
+  cipherState[:iv]      = buf.slice(0, 12);                  // 12-byte IV
+  cipherState[:enc-ctr] = buf.readUInt32LE(12);              // TX counter seed
+  cipherState[:dec-ctr] = buf.readUInt32LE(16);              // RX counter seed
+});
+```
+
+Resolved closure-slot keywords:
+- `_closure1_slot3313` = `:network-key`
+- `_closure1_slot3777` = `:aes`
+- `_closure1_slot4479` = `:enc-ctr`   ← TX counter
+- `_closure1_slot1656` = `:dec-ctr`   ← RX counter
+- `_closure1_slot5988` = `:iv`
+
+## Decrypted plaintexts (verification)
+
+The leading 2-byte mesh prefix and any 4-byte mesh device IDs are masked as `xx`.
+
+```
+1308 TX  cnt=0xf9bbfffa  pt=xx xx 81 05 40 xx xx xx xx 10 ff
+1311 RX  cnt=0xa0e8129a  pt=xx xx c1 05 40 xx xx xx xx 10 ff 00
+1312 TX  cnt=0xf9bbfffb  pt=xx xx 02 02 40 00
+1314 RX  cnt=0xa0e8129b  pt=xx xx 42 02 40 01 ff ff ff ff 00 00
+1316 RX  cnt=0xa0e8129c  pt=xx xx a0 02 40 01 ff ff ff ff 00 00
+1317 TX  cnt=0xf9bbfffc  pt=xx xx 03 03 40 00 00 00 00 00 00 00
+1319 RX  cnt=0xa0e8129d  pt=xx xx 43 03 40 xx xx xx xx 38 0b 00
+```
+
+All trailers match `sum(pt) + 0x10 + len` exactly (verified against the unmasked
+plaintexts). ✓
+
+Custom binary protocol observations:
+- All plaintexts start with the same **2-byte mesh prefix** (a device identifier,
+  masked as `xx xx`; NOT protobuf — the earlier handoff was wrong about this)
+- Byte 2: looks like a type/direction flag (TX uses 0x81, 0x02, 0x03; RX uses 0xc1, 0x42, 0xa0, 0x43 — high bit set on RX seems intentional)
+- Byte 3: sequence number — pairs match between TX/RX (1308↔1311 both have 0x05; 1312↔1314 both have 0x02; 1317↔1319 both have 0x03)
+- Byte 4: constant `0x40`
+- Bytes 5+: payload (a 4-byte mesh device id — masked `xx xx xx xx` — appears repeatedly in the early frames for the device being controlled)
+
+## Key files this session
+
+Paths are relative to the research toolchain; local filesystem prefixes have been dropped.
+
+| Path | Notes |
+|---|---|
+| `apk/base.apk`, `apk/split_config.*.apk` | original 5 splits pulled from the device |
+| `apk/base.objection.apk`, `apk/split_config.arm64_v8a.apk` | the **patched + signed** versions actually installed on the phone. base has the smali loadLibrary + PairIP-stub edits, arm64 split has the gadget + config |
+| `hermes_work/index.android.bundle` | 16 MB original Hermes bundle |
+| `hermes_work/decomp.js` | 102 MB decompiled JS |
+| `hermes_work/disasm.hasm` | 196 MB disassembly |
+| `heap_full.bin`, `heap_full.index` | 964 MB heap dump from the running gadget process |
+
+## Inner mesh plaintext protocol — what we've found
+
+The plaintext is built by a **mesh wire-format encoder**, not protobuf. Trace from the
+decompile:
+
+1. The TX driver looks up `(:stream input)` from a map (`_closure1_slot4960` = `:stream`)
+   and feeds it to `perform_crypto`.
+2. `:stream` is set via `(event->stream tx_subsys event)` (decomp.js ~line 1019944).
+3. `event__GT_stream` (~line 1019877) calls
+   `lib.serialize.mesh.core.transcode(svc, event)`.
+4. `transcode` dispatches on the BLE service implementation. The relevant impl
+   (decomp.js line 1042719) does:
+   ```
+   buf = util.buffer.seq->buffer(
+           serialize.common.->le_byte_stream(
+             serialize.mesh.core.encode(mesh_body_spec, event, "")))
+   ```
+5. `mesh_body_spec` (decomp.js ~line 1035967) is **procedurally constructed at runtime**
+   as a deeply-nested PersistentArrayMap of field specs (`r195[27] = ...` etc.). It's
+   not a static constant and isn't easily reconstructable from grep alone.
+
+The **2-byte prefix does not appear anywhere as a static constant in the JS source** —
+not as a byte-array literal, not as a packed 16-bit hex word, and not as either of its
+decimal encodings. It is *computed* by the `encode` step from the spec + event. This
+strongly implies:
+
+- the prefix is a **fixed mesh-protocol preamble** the encoder emits unconditionally
+  (perhaps a length/version byte plus a routing tag), or
+- it is a **packed bitfield / device mesh identifier** (subsystem id, mesh layer flags)
+  that always renders to the same two bytes for direct-BLE messages to a given device.
+
+Either way, treat the prefix as opaque-but-stable for now. (Subsequent work identified
+it as a per-device mesh identifier — hence the masking in this doc.)
+
+### Empirical structure (from the 7 captured plaintexts)
+
+```
+byte 0..1  xx xx        2-byte device mesh prefix (masked; constant across a session)
+byte 2     <type/flag>  request 0x02/0x03/0x81; response 0x42/0x43/0xc1; notification 0xa0
+                        — bit 0x40 is set on RX→TX responses; bit 0x80 appears on
+                        session-init-class messages
+byte 3     <seq>        sequence id; pairs match between request/response
+byte 4     0x40         constant (probably a routing/subsystem id)
+byte 5..   <payload>    variable. First TX command after init carries a 4-byte mesh
+                        device id (masked xx xx xx xx). Later commands omit the id once
+                        the session is bound.
+```
+
+Without labeled samples (e.g. "tap Start zone N for D seconds" → known plaintext) we
+can't confidently map type/payload → action. The 7 frames we have are all from one
+short "Control via Bluetooth → start zone 1 → stop" session and don't contain enough
+diversity to disambiguate.
+
+## Next steps (work that remains)
+
+1. **Capture more labeled traffic.**
+   Reinstall the original (Play Store) B-Hyve on the phone — the patched APK has
+   resource corruption from repeated apktool rebuilds and was crashing on the React
+   Switch widget. The original app is unmodified and works. Steps:
+   - On phone: Settings → Apps → B-Hyve → Uninstall (removes the broken patched build)
+   - Install B-Hyve from the Play Store
+   - Settings → Developer options → enable **Bluetooth HCI snoop log**
+   - Reproduce a SCRIPTED set of actions, e.g.:
+     - `[t=0]`  open app → tap "Control via Bluetooth"
+     - `[t=10]` start zone 1 for 60 s
+     - `[t=15]` stop
+     - `[t=20]` start zone 2 for 60 s
+     - `[t=25]` stop
+     - `[t=30]` start zone 3 for 60 s
+     - `[t=35]` stop
+     - `[t=40]` exit
+   - `adb bugreport` (or trigger via Settings → Send feedback) to pull a fresh
+     `btsnoop_hci.log`
+   - Decrypt with `decode_btsnoop_frames.py` (will need to update the constants to use
+     the NEW session's `init_tx` / `init_rx` bytes — easy to extract from the new
+     BTSnoop)
+   - Diff plaintexts side-by-side: bytes that change with zone number / duration are
+     clearly identifiable
+
+2. **Implement `turn_on` / `turn_off`** for this device family using the inner binary
+   protocol once the action↔payload mapping is known. In this repo the shared cipher
+   already lives in `custom_components/orbit_bhyve/connection.py`
+   (`encrypt` / `decrypt` / `_aes_xor` / `_handshake`) and is correct — outer frame
+   magic `0x10`/`0x11`, IV from the handshake mix, dual counters, trailer
+   `sum + 0x10 + len`. What needs writing is the inner mesh (`xx xx …`) payload builder
+   for this family, which belongs in `custom_components/orbit_bhyve/devices/ht25.py`.
+   (The protobuf-style `_pb_field_*` builders now live in
+   `custom_components/orbit_bhyve/devices/ht34a.py` — that is the separate XD device
+   family, not the mesh path described here.)
+
+3. **Test end-to-end** with the research CLI (`bhyve.py on 1 60 --device 2`) and a
+   Home Assistant entity toggle.
+
+## Frida live-decrypt: tried, not viable
+
+We attempted live-decrypt via Frida-gadget (see `live_decrypt.py`). It works in
+principle (TX hook captures setValue calls fine) but consistently SIGSEGVs the patched
+RN/Hermes process at fault address `0x367faa9026ffc` shortly after the inlined Java
+bridge installs. The crash is in Frida 17.9.5's Java bridge interacting with this
+specific Hermes build — same fault occurred with and without `getValue()` hooks active.
+Pursuing this further would need a different Frida-gadget version or native-only hooks
+(no Java bridge), neither cheap. The BTSnoop path above sidesteps all of this.

--- a/docs/findings/d7-47-protocol.md
+++ b/docs/findings/d7-47-protocol.md
@@ -1,0 +1,315 @@
+# d7-47 inner protocol (HT25 hose-tap family)
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+Protocol reference for the older HT25 single-zone hose-tap timers. These devices
+speak a **custom binary framing** over a proprietary GATT service — **no
+protobuf, no CRC16**. The outer BLE frame is identified by magic byte `0x10` and
+protected only by a simple additive checksum. Reversed from 257 decoded frames
+across eight capture sessions plus one labelled "zone on for 10 minutes"
+session that pinned the start-command shape exactly.
+
+The name "d7-47" is historical. As the [mesh-address prefix](#the-prefix-is-a-mesh-address-not-a-magic)
+section explains, `d7 47` is not a protocol constant — it was one device's mesh
+address that early code mistook for a fixed header.
+
+---
+
+## Two framing layers
+
+There are two nested frames. Keep them straight — the magic byte `0x10` and the
+mesh-address prefix live at different layers.
+
+### Outer BLE frame (on the wire, command characteristic)
+
+```
+0x10   [len:1]   [ciphertext: len bytes]   [trailer: uint16_LE]
+```
+
+- `0x10` — outer frame magic. Constant for this family.
+- `len` — ciphertext length in bytes.
+- `ciphertext` — the inner frame (below), encrypted.
+- `trailer` — `(sum(plaintext_bytes) + 0x10 + len) & 0xFFFF`, little-endian. A
+  plain additive checksum, **not** a CRC16. All decoded captures verify against
+  this formula.
+
+The cipher itself (AES-128-ECB used as a CTR-style keystream, IV mixed from the
+handshake, independent TX/RX counters) is out of scope here — see the cipher
+notes. In this repo the outer wrap/unwrap and checksum live in
+`custom_components/orbit_bhyve/connection.py` (`encrypt` / `decrypt`), whose
+`frame_magic` and `trailer_const` default to `0x10`.
+
+### Inner plaintext frame
+
+After decryption the payload is:
+
+```
+[mesh-addr:2]   [type:1]   [seq:1]   0x40   [payload:N]
+```
+
+- `mesh-addr` — the device's own 2-byte mesh address, little-endian. **See the
+  next section — this is the field that used to be hard-coded.**
+- `type` — 1 byte. Bit `0x40` is **set on responses** (reply/echo). Bit `0x80`
+  appears on init-class messages. The remaining bits behave like a
+  session-relative message counter that advances monotonically within a single
+  BLE connection — it is **not** the message *kind*. Do not switch on it.
+- `seq` — 1 byte. **This is effectively the command code.** The same value pairs
+  a request to its response (TX `seq=0d` → RX `seq=0d`). Different values mean
+  different operations.
+- `0x40` — routing/subsystem byte. Constant; no other value has ever been
+  observed.
+- `payload` — variable, depends on `seq`.
+
+---
+
+## The prefix is a mesh address, not a magic
+
+**Correction to earlier notes.** The leading `d7 47` bytes are **not** a fixed
+protocol magic. They are one specific device's `mesh_device_id` written
+little-endian:
+
+```
+mesh id 18391 = 0x47D7  →  bytes  d7 47
+```
+
+Early code hard-coded that one device's value as a "D747 magic" constant. That
+worked for the one device it was captured from and **silently failed for every
+other device** — a timer whose real mesh address is (for example) `0x1234`
+receives frames addressed to `0x47D7`, does not recognise them as its own, and
+drops them without error. It acks the handshake but ignores the watering
+command.
+
+The correct frame uses **each device's own 2-byte mesh address** as the prefix.
+The mesh address comes from the cloud device record (`mesh_device_id`). Treat
+`d7 47` / `18391` throughout this document as **one illustrative example only**;
+substitute your device's address (shown generically as `<mesh-addr>`) in every
+frame.
+
+### In this repo
+
+Implemented per-device in `custom_components/orbit_bhyve/devices/ht25.py`:
+
+- `BHyveHT25Device.mesh_address` returns `mesh_device_id.to_bytes(2, "little")`,
+  and raises if the cloud record has no mesh id (rather than falling back to a
+  wrong constant).
+- `BHyveHT25Device._build(type_byte, seq, payload)` assembles
+  `mesh_address + bytes([type, seq, 0x40]) + payload` — the inner frame above.
+- `_build_start` / `_build_stop` build the two watering commands on top of
+  `_build`.
+
+The device also carries a **hub** mesh address, used only inside the "magic
+check" init payloads (below). It resolves per network key; two topologies were
+observed with distinct hub mesh ids (shown here generically as
+`<hub-mesh-addr>`).
+
+---
+
+## Command / seq catalog
+
+`seq` is the command code. `type` carries the `0x40` response bit and the
+session counter, so the same command shows different `type` bytes across a
+session; match requests to responses by `seq`.
+
+| seq  | name          | dir | payload (hex)                     | meaning                                                    |
+|------|---------------|-----|-----------------------------------|------------------------------------------------------------|
+| `05` | BIND          | TX  | `<sid:2> f6 69 10 ff`             | Bind session to the timer                                  |
+| `05` | BIND          | RX  | `<sid:2> f6 69 10 ff <status>`    | Bind ack; echoes the session id, trailing byte varies by fw |
+| `02` | STATUS        | TX  | `00`                              | Status request                                             |
+| `02` | STATUS        | RX  | `01 ffffffff 0000` (idle)         | See [status / is_watering](#status--is_watering-decode)    |
+| `03` | INFO          | TX  | `00 00 00 00 00 00 00`            | Device-info request                                        |
+| `03` | INFO          | RX  | `<sid:2> f6 69 <mv_LE:2> 00`      | Device info — **payload bytes 4-5 = battery_mV (LE)**      |
+| `01` | SUBSYSTEM     | TX  | `00 00 00`                        | Subsystem init                                             |
+| `01` | SUBSYSTEM     | RX  | `00 <fw> 00 01 00 00 00`          | byte 1 = **firmware version as a decimal byte**            |
+| `00` | MAGIC_CHECK   | TX  | `01 <mesh-addr> 00 00 00 00`      | Self mesh-address ping                                     |
+| `00` | MAGIC_CHECK   | TX  | `00 <hub-mesh-addr> 00 00 00 00`  | Hub mesh-address ping                                      |
+| `00` | MAGIC_CHECK   | RX  | (echoes both of the above)        |                                                            |
+| `09` | HEARTBEAT     | TX  | `00`                              | Heartbeat                                                  |
+| `09` | HEARTBEAT     | RX  | `00 00 00 00 7f <b5> 7c`          | byte 5 tracks firmware (see notes); last byte `7c` constant |
+| `0d` | WATER_CTRL    | TX  | `04 <dur_LE:2> 00 00 00 00`       | **Start watering — confirmed by labelled capture**        |
+| `0d` | WATER_CTRL    | TX  | `02 00 00 00`                     | Stop / cancel                                              |
+| `0d` | WATER_CTRL    | RX  | echo with `0x40` reply bit set    | Ack; start-ack echoes the accepted `04 <dur_LE> …`        |
+| `0b` | (keep-alive)  | T/R | `00 00 00 00 00 00 00`            | Connection ack / keep-alive                               |
+| `0e` | (timer)       | T/R | `e8 03 02 00 [7f fb 7c]`          | Periodic timer echo (`0x03e8` = 1000)                     |
+| `0c` | (state push)  | RX  | `02 03 00 00 00 00 00`            | Older watering-state update observation                    |
+
+### Watering command detail
+
+- **Start:** payload `04 <dur_LE_u16> 00 00 00 00`. The leading `04` is a
+  constant flag, **not** a zone selector — the HT25 is single-zone, so there is
+  nothing to select. The same `04 58 02 00 00 00 00` payload appeared identically
+  across five sessions on different days, the strongest "stable command shape"
+  signal in the data.
+- **Stop:** payload `02 00 00 00`.
+- This repo sends START with inner `type = 0xB6` (ack `0xF6`) and STOP with
+  `type = 0xB7` (ack `0xF7`); the `0x40` reply bit is what distinguishes an ack
+  from the outgoing frame's echo. See `_build_start` / `_build_stop` /
+  `_observe_plaintext` in `devices/ht25.py`.
+
+### Duration encoding
+
+Little-endian uint16 seconds:
+
+```
+58 02  →  0x0258  =  600 seconds  =  10 minutes  (the app's default manual run)
+3c 00  →  0x003c  =   60 seconds
+1e 00  →  0x001e  =   30 seconds
+```
+
+The same `<dur_LE:2>` field appears in both the START payload and the active
+STATUS response, so a started run reports back the duration it accepted.
+
+---
+
+## Init-response sequence (8 steps)
+
+The device is driven through a fixed 8-step handshake before it will accept a
+watering command. Each step is a TX frame; the device replies with a matching
+frame carrying the `0x40` reply bit. In this repo the sequence is
+`BHyveHT25Device._post_handshake` in `devices/ht25.py`, written via
+`connection._write_locked` (never `send()` from inside the hook — the connection
+lock is already held).
+
+The reply payloads, after the `<mesh-addr> [type] [seq] 40` header. `<sid>` is a
+per-session id echoed back; it is random-ish and increments across the two bind
+steps.
+
+| Step        | seq  | reply payload (fw0085 example)   | notes                                                                 |
+|-------------|------|----------------------------------|----------------------------------------------------------------------|
+| bind        | `05` | `<sid> f6 69 10 ff 00`           | echoes session id; trailing byte differs by firmware (`00` vs `ff`)  |
+| status      | `02` | `01 ffffffff 0000`               | idle baseline — identical across all devices, no per-device data      |
+| info        | `03` | `<sid> f6 69 <mv_LE> 00`         | **battery_mV in payload bytes 4-5**; bytes 0-1 vary per session       |
+| subsystem   | `01` | `00 55 00 01 00 00 00`           | **byte 1 = firmware version** (`0x55`=85 → fw0085)                    |
+| magic1      | `00` | echoes `01 <mesh-addr> 00000000` | self-address ping                                                    |
+| magic2      | `00` | echoes `00 <hub-mesh-addr> 0…`   | hub-address ping; hub mesh id varies by network topology             |
+| heartbeat   | `09` | `0000 00 7f fb 7c`               | byte 5 (`fb`) tracks firmware; last byte `7c` constant                |
+| rebind      | `05` | `<sid+n> f6 69 10 ff 00`         | re-issues bind with an incremented sid (increment differs by fw)      |
+
+After the rebind ack the device emits **spontaneous pushes** unprompted (count
+varies per connection). On fw0041 devices these pushes are byte-for-byte
+identical to the subsystem ack (`00 29 00 01 00 00 00`) — a "current
+device-state snapshot" broadcast rather than new information.
+
+Firmware differences observed between an fw0085 device and two fw0041 devices:
+the bind trailing byte (`00` vs `ff`), the sid increment on rebind, the
+subsystem firmware byte (`0x55` vs `0x29`), and heartbeat byte 5 (`0xfb` vs
+`0x95`). All are firmware-stable, none are battery.
+
+---
+
+## Status / is_watering decode
+
+The STATUS command (`seq=0x02`) returns a fixed-shape payload. The first byte is
+a state flag; the rest is meaningful only while active.
+
+| State    | payload (after routing `0x40`)      |
+|----------|-------------------------------------|
+| Idle     | `01 ff ff ff ff 00 00`              |
+| Watering | `04 c0 95 40 58 02 00`              |
+| Watering | `04 80 95 40 58 02 00` (counting down) |
+
+Working byte layout of the payload:
+
+- **byte 0** — state flag: `0x01` idle, `0x04` active.
+- **bytes 1-3** — remaining-time counter (24-bit LE; possibly 32-bit including
+  byte 4). Idle fills these with `ff ff ff ff` (no active run).
+- **byte 4** — `0x40` while active (alignment / part of the counter; unresolved).
+- **bytes 5-6** — requested duration uint16_LE. `58 02` = 600 s, matching the
+  labelled 10-minute run and the START payload's duration field.
+- **byte 7** — `0x00`.
+
+Idle is unambiguous (`01 ffffffff 0000`); active is `04 <countdown> … <dur> 00`.
+There is **no standard GATT Battery Service (0x180F)** and no separate watering
+service — status must be parsed from this proprietary response.
+
+In this repo `is_watering` is driven optimistically from command stamping plus
+the START-ack: `_observe_plaintext` in `devices/ht25.py` watches for the
+`seq=0x0D` reply (`0x40` bit set), reads the echoed `04 <dur_LE> …`, and arms an
+off-timer for that duration. That makes the auto-off reliable even when the
+BLE write-response times out.
+
+---
+
+## Battery decode
+
+The battery voltage rides in the **INFO** response (`seq=0x03`), which is already
+part of the init handshake — no separate battery command is needed. (An earlier
+investigation wrongly concluded battery was absent from the init responses,
+because it read the two voltage bytes as a "session counter" instead of a
+little-endian uint16.)
+
+INFO reply payload (7 bytes):
+
+```
+<bytes 0-1: session counter>  <bytes 2-3: f6 69>  <bytes 4-5: battery_mV LE u16>  <byte 6: 00>
+```
+
+- bytes 0-1 vary session-to-session (counter / random).
+- bytes 2-3 are always `f6 69`.
+- bytes 4-5 are `battery_mV` as **little-endian uint16** — e.g. `58 02` … no,
+  for battery: `38 0b` → `0x0b38` = **2872 mV**.
+- byte 6 is always `0x00`.
+
+### Evidence
+
+- One fw0041 device read **2601 mV** over BLE vs **2602 mV** from the cloud
+  snapshot (off by 1 mV).
+- A second fw0041 device read **2606 mV** vs **2606 mV** (exact).
+- An fw0085 device captured across nine sessions over about a week produced a
+  **monotonically decreasing** trace — `2872 → 2872 → 2867 → 2861 → 2845 → 2840
+  → 2840 → 2840 → 2835 mV` — consistent with battery discharge. Random session
+  counters would not behave this way; this is the decisive proof that bytes 4-5
+  are voltage.
+
+### In this repo
+
+`custom_components/orbit_bhyve/devices/base.py`:
+
+- `connection.set_plaintext_observer` feeds every decrypted notification to
+  `BHyveBleDeviceBase._observe_plaintext`.
+- `_observe_plaintext` filters for the info reply (`pt[3] == 0x03`,
+  `pt[4] == 0x40`, and the `0x40` reply bit set on `pt[2]`), reads
+  `mv = int.from_bytes(pt[9:11], "little")` (payload bytes 4-5), and range-checks
+  `1500 ≤ mv ≤ 4000` before accepting it.
+- `_mv_to_pct(mv)` converts to a percentage with a linear approximation of the
+  cloud's discharge curve: **0 % at 2400 mV, 100 % at 3000 mV**, clamped to
+  0-100. Tuned against three live devices (e.g. 2602 mV ≈ 33 %, 2771 mV ≈ 65 %).
+
+Confirmed on both firmwares (fw0085 and fw0041).
+
+---
+
+## Firmware version is a decimal byte
+
+The SUBSYSTEM ack (`seq=0x01`) carries the firmware version in **payload byte 1,
+as a plain decimal byte** (not hex-coded, not ASCII):
+
+```
+0x55 = 85  →  fw0085
+0x29 = 41  →  fw0041
+```
+
+Confirmed stable across repeat probes of the same device and consistent across
+three devices. Two other bytes track firmware and are explicitly **not** battery
+or any per-device varying property:
+
+- **Subsystem byte 1** — firmware version (above).
+- **Heartbeat byte 5** — `0xfb` (=251) on fw0085, `0x95` (=149) on fw0041. Exact
+  meaning unknown, but constant within a firmware.
+
+Everything that genuinely varies session-to-session (bind/rebind sid bytes, INFO
+bytes 0-1) is a session-derived counter, not a device property. The only
+per-device fields that are both stable across probes and meaningful are the
+firmware byte and the battery voltage.
+
+---
+
+## Open questions
+
+- The active-STATUS counter (bytes 1-4) is not fully decoded — whether it is a
+  24-bit or 32-bit remaining-time value, and the role of byte 4 (`0x40` while
+  active), needs more captures at different durations.
+- Whether any of the 8 init steps are optional (a minimal "connect → start →
+  stop" capture would show which acks the device actually requires).
+- The write-only characteristic in the custom service is unused; its purpose
+  (settings / OTA / query trigger) is unknown and it should not be written
+  without deliberate testing.

--- a/docs/findings/mesh-analysis.md
+++ b/docs/findings/mesh-analysis.md
@@ -1,0 +1,166 @@
+# BLE Sniffer Findings — Broadcast/Advertising Analysis
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+> **Superseded hypothesis:** This document's headline conclusion — that commands
+> are delivered **only** via a broadcast mesh, so a direct per-device BLE
+> connection "can't work" — was **later disproven**. Direct, per-device BLE
+> control does work: the timer accepts encrypted command frames on its GATT data
+> channel. That protocol is implemented as the **d7-47 protocol family** in
+> `custom_components/orbit_bhyve/devices/ht25.py`. Read the broadcast-only claims
+> below as a dead end that was investigated and ruled out. The **advertising-
+> analysis methodology** (extended-adv detection, manufacturer-data parsing under
+> company ID `0x047f`, and the "this is not SIG Mesh" reasoning) is still valid
+> and worth keeping.
+
+## Original TL;DR (later disproven)
+
+The working theory at the time was that the B-Hyve hub-to-timer protocol is **not
+a regular BLE connection** with ATT/GATT writes, but a **mesh broadcast protocol**
+where the hub puts encrypted commands into **BLE advertisement data** and the
+timers receive them via passive scanning — no `CONNECT_IND`, no GATT, no L2CAP.
+
+This was contrasted with the upstream integration, which BLE-connects and uses the
+GATT data channel. (As it turned out, the GATT path is the correct one; see the
+superseded-hypothesis banner above.)
+
+## Evidence
+
+After 5 captures totaling ~12 minutes and ~250,000 packets across various
+conditions (with/without `--follow`, with/without hub power-cycle, with/without
+watering trigger), we observed:
+
+- **Zero `CONNECT_IND` for any Orbit-pattern device** — in our captures, neither timers nor hubs ever connected to each other.
+- **Zero ATT writes / notifications / data-channel traffic** of any kind.
+- **All Orbit-pattern devices broadcast frequently** in the 30-50 Hz range, with manufacturer-specific data fields containing variable-length encrypted-looking payloads.
+- **At least 3 distinct payload sizes observed:**
+  - 2 bytes (e.g. `0500`, `0600`) — likely heartbeat / status flags.
+  - 13 bytes (`5c2e6337dee3a06a05377e8132`) — observed once on the Zone A timer at t=43s, possibly a state update tied to a watering action.
+  - 20 bytes (`4acc1a97176357fbbffde44c8368aba9402fcc61`) — observed once on a Zone B timer MAC variant.
+  - 46 bytes (`f547b7a7…0eed1a7a0cfb775176ea330abec4`) — observed once on a Hub 2 MAC variant; long enough to be a full encrypted command + envelope.
+
+> **Note (correction):** The absence of `CONNECT_IND` / GATT traffic in these
+> captures is now understood as a **capture-rig limitation**, not proof that no
+> connection happens. The single-channel PCA10059 misses much of the extended-adv
+> secondary-channel and connection setup. Direct BLE connections to the timer do
+> occur and do carry the commands.
+
+## Account topology (from the account topology config)
+
+This deployment spans **two separate meshes**, each with its own hub and one
+shared `ble_network_key`:
+
+| Mesh | Hub | Network Key | Devices |
+|---|---|---|---|
+| Mesh 1 | Hub 1 (`AA:BB:CC:00:00:10`) | `<network-key>` | Zone B timer, Zone C timer |
+| Mesh 2 | Hub 2 (`AA:BB:CC:00:00:11`) | `<network-key>` | Zone A timer, Zone D timer |
+
+Both hubs are Orbit-branded Wi-Fi gateways, registered in the same Orbit cloud
+account.
+
+**Tooling bug noted:** the analyzer was defaulting to the first mesh's key, which
+is wrong for any device on the second mesh. The right mesh key has to be selected
+based on which timer's traffic is being decoded.
+
+## Why the upstream integration connects but valves didn't move (original theory)
+
+At the time, the integration was seen to succeed at:
+
+1. BLE-connecting to the timer (timers DO accept connections).
+2. Completing the AES init handshake on `0x6c71` (the per-session IV negotiation works because the network key IS correct).
+3. Writing encrypted frames to `0x6c72`.
+
+...yet the valve didn't actuate. The (incorrect) conclusion drawn was that the
+timer's real command channel must be the broadcast scanner rather than the GATT
+writes, and that the connection-based command form (legacy `IpcMsg.field_14`) was
+a leftover from an older firmware that supported both paths — with HT25-0000 /
+firmware 0041 acting only on the broadcast path for routine commands.
+
+> **Correction:** The valve failure was a **frame-format problem, not a wrong
+> channel**. The GATT write path is correct; the earlier frames used the wrong
+> magic byte, envelope, and mesh_device_id shape. Once the d7-47 frame format was
+> matched to what the firmware expects, direct GATT commands actuate the valve.
+
+## Decryption attempts so far
+
+Tried with both mesh keys, AES-ECB and AES-CTR with various IV constructions
+(zero, MAC forward/reverse, MAC + counter): **none yielded plaintext containing
+the `AA 77 5A 0F` MSG_HEADER**. For the broadcast payloads specifically, this is
+unsurprising — a broadcast protocol would likely use:
+
+- AES-CCM (the standard for BLE Mesh and most mesh protocols).
+- A nonce that incorporates a **broadcast sequence number** (which we don't yet know how to extract).
+- Possibly the source MAC AND a per-message counter.
+- Possibly authenticated encryption with a MIC trailing the ciphertext.
+
+Without multiple samples of known-content commands (e.g., 10× "water on for 60s"
+so we can spot the constant fields), the nonce construction can't be reversed.
+
+## Take #6 — phone "Control via Bluetooth" also didn't surface a connection
+
+`captures/phone_direct_*.pcap`, 5 min, 151,814 packets.
+
+Triggered the official B-Hyve app's "Control via Bluetooth" button on the Zone A
+timer. The app showed **find → connect → sync** — succeeded. Then triggered
+watering on, then off.
+
+**Capture findings:**
+
+- 597 ADV/SCAN_RSP packets from the Zone A timer (`AA:BB:CC:00:00:01`).
+- 6 SCAN_REQs targeting the Zone A timer (some scanner — probably the phone or hub — actively scanning).
+- 188 total CONNECT_INDs across **147 unique advertiser addresses**.
+- **ZERO of those CONNECT_INDs target any Orbit-pattern address** (no advertiser under Orbit's vendor OUI `44:67:55`, even allowing for bit-error variants).
+- 720 ADV_EXT_IND packets (extended advertising, BLE 5.x) — but zero usable aux pointers in our captures.
+
+At the time this read as a strong signal that no capturable BLE connection to the
+timer was happening. Three explanations were on the table:
+
+1. **Random/RPA addresses on both peers** — Orbit uses Resolvable Private Addresses for the connection peer, derived from an Identity Resolving Key we haven't extracted. Without the IRK we can't tell which CONNECT_IND is "to a B-Hyve device."
+2. **Connection setup happens on extended-advertising secondary channels** that single-channel sniffers (PCA10059) can't reliably follow. Multi-channel sniffers (Ubertooth, HackRF) might.
+3. **"Control via Bluetooth" actually goes phone→hub→broadcast.** The name suggests direct, but the flow might still route through the local hub's BLE peripheral mode.
+
+> **Correction:** Explanations (1) and (2) were the real story — the connection
+> and its GATT commands were happening but were **not captured** by the
+> single-channel rig (RPA peers + extended-adv secondary channels). The
+> broadcast-only reading in (3) was wrong.
+
+## Tooling assessment — it is NOT BLE SIG Mesh, and the payloads are BLE5 extended adv
+
+Two conclusions that still stand and redirect the effort:
+
+**1. This is a proprietary broadcast, not standard Bluetooth SIG Mesh.** Across
+all captures the encrypted advertisement payloads ride in **manufacturer-specific
+data** under company ID `0x047f` ("Pro-Mark, Inc."). We saw **no** SIG-Mesh AD
+types (Mesh Message `0x2A`, Mesh Beacon `0x2B`) and **no** mesh service UUIDs
+(Provisioning `0x1827`, Proxy `0x1828`). So there is **no spec-based shortcut** —
+the SIG Mesh crypto (AES-CCM with a documented `type‖pad‖seq‖src‖ivIndex` nonce,
+crackable with the nRF Mesh app once the NetKey is known) does **not** apply. Any
+broadcast decryption would mean reversing the *proprietary* nonce. (Confirmation
+scan to keep on file: a passive scan should never surface `0x2A`/`0x2B`/
+`0x1827`/`0x1828` for a device under Orbit's vendor OUI `44:67:55`.)
+
+**2. The 46-byte hub broadcast must be BLE5 extended advertising.** Legacy
+advertising AdvData is capped at **31 octets**; a 46-byte manufacturer-data
+element cannot fit a legacy PDU. This matches the `720 ADV_EXT_IND` packets seen
+in Take #6. The single-channel **PCA10059 caught a 46-byte payload only once** —
+consistent with unreliable capture of the AUX (secondary-channel) extended-adv
+packets. Any effort that needs **many** samples of that hub broadcast is bottle-
+necked by the capture rig, not just the trigger log.
+
+**Recommended capture upgrade:** a **Sniffle** BLE5 sniffer (TI CC1352/CC2652,
+e.g. a reflashable Sonoff dongle), which reliably follows extended advertising.
+Capture filtered to a hub MAC (`AA:BB:CC:00:00:10` / `AA:BB:CC:00:00:11`) with
+`sniff_receiver.py -e`, then diff the extracted `0x047f` payloads to localize the
+changing nonce/counter bytes across repeated identical actions. A BLE5 *host
+adapter* + BlueZ extended scan is a cheaper thing to try first, but BlueZ
+extended-adv scanning is known-flaky (bleak issue #1347), so treat it as a quick
+experiment.
+
+## Bugs noted along the way
+
+1. The analyzer defaulted to the first mesh's `network_key`, which only matches one of the two meshes. It should pick the right mesh based on which timer's traffic is being decoded.
+2. The original framework assumed a connection-based ATT-write protocol only. For broadcast decoding, a separate code path is needed that:
+   - Walks ADV_IND packets per source MAC.
+   - Extracts the manufacturer-specific data field (Type 0xff).
+   - Strips the manufacturer ID (`0x047f`, "Pro-Mark, Inc.").
+   - Treats the remaining bytes as the encrypted payload to decrypt.

--- a/docs/findings/nrf-sniffer-setup.md
+++ b/docs/findings/nrf-sniffer-setup.md
@@ -1,0 +1,64 @@
+# nRF52840 BLE Sniffer — Capture-Rig Setup
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+This is the modern workflow for setting up an nRF52840 dongle (PCA10059) as a
+Bluetooth LE sniffer for Wireshark, using the Rust-based `nrfutil`.
+
+## Background: skip the manual ZIP download
+
+Older guides tell you to manually download **nRF Sniffer for Bluetooth LE** from
+Nordic's license-gated download page:
+
+> https://www.nordicsemi.com/Products/Development-tools/nRF-Sniffer-for-Bluetooth-LE
+
+That URL returns 404 in 2026 — Nordic restructured their site and **deprecated
+the manual ZIP download** in favor of fetching the firmware via `nrfutil`. The
+steps below auto-fetch everything, so there is no license-click dance and no
+broken URLs to chase.
+
+## The workflow
+
+```bash
+# 1. Download the modern Rust-based nrfutil (no auth, no license click)
+curl -L -o ~/bin/nrfutil \
+    https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
+chmod +x ~/bin/nrfutil
+
+# 2. Install the ble-sniffer module (auto-downloads the sniffer firmware too)
+nrfutil install ble-sniffer
+
+# 3. Install the device-flash module
+nrfutil install device
+
+# 4. Bootstrap the Wireshark extcap shim
+nrfutil ble-sniffer bootstrap \
+    --extcap-dir ~/.config/wireshark/extcap
+
+# 5. Flash the dongle (in DFU mode: hold SW1 while plugging in)
+nrfutil device program \
+    --firmware ~/.nrfutil/share/nrfutil-ble-sniffer/firmware/sniffer_nrf52840dongle_nrf52840_4.1.1.zip \
+    --serial-number <SERIAL_FROM_DEVICE_LIST> \
+    --traits nordicDfu
+```
+
+Get `<SERIAL_FROM_DEVICE_LIST>` from `nrfutil device list`.
+
+## Where the firmware lives
+
+After `nrfutil install ble-sniffer`, the dongle firmware is at:
+
+```
+~/.nrfutil/share/nrfutil-ble-sniffer/firmware/sniffer_nrf52840dongle_nrf52840_4.1.1.zip
+```
+
+Other supported board firmwares (DK variants) are bundled there too — for the
+PCA10059 dongle, use only the `_nrf52840dongle_` one.
+
+## Why the manual download still appears in some guides
+
+Older blog posts and older upstream project docs describe the manual ZIP flow
+because that was the only option for years. Nordic added the
+`nrfutil install ble-sniffer` automation in the Rust-based nrfutil rewrite (v7+,
+released ~2023). Stick with the modern path: no version drift, no license-click
+dance, no broken URLs.

--- a/docs/findings/phone-ground-truth.md
+++ b/docs/findings/phone-ground-truth.md
@@ -1,0 +1,114 @@
+# Ground-Truth Bytes From the Official B-Hyve App — Zone A timer (HT25-0000 / fw 0085)
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+Captured from an Android phone's `btsnoop_hci.log` while doing the following:
+
+- Phone running the official B-Hyve app.
+- The hub (`AA:BB:CC:00:00:11`) physically unplugged (proving the phone goes direct, not via the hub).
+- Tapped "Control via Bluetooth" on the Zone A timer (`AA:BB:CC:00:00:01`).
+- Started zone 1 watering → stopped → exited.
+
+This is the **gold standard** of bytes that the timer DOES accept and act on.
+
+## Connection-level facts
+
+- **No SMP/pairing/encryption events.** Plain unencrypted L2CAP throughout.
+- The phone's NETWORK_CHAR (`0x6c76`, handle 0x10) write got an ATT **error response** (opcode 0x01) — the same rejection we get. The phone proceeded anyway.
+- The phone's WRITE_CHAR (`0x6c72`, handle 0x0b) writes used **opcode 0x12 = WRITE_REQUEST** (with response). The device acknowledged each (opcode 0x13).
+  - Important: when WE try `response=True` on the same characteristic, the BlueZ ESPHome proxy reports ATT error 0x06 "Request not supported" from the device. The phone gets clean acks. Reason unknown — same handle, same characteristic, different result.
+- Notifications come back on READ_CHAR (`0x6c73`, handle 0x0d) opcode 0x1B.
+
+## Raw bytes — first session (frames 1290–1319)
+
+| Frame | t (s) | Op | Handle | Char | Bytes |
+|-------|-------|----|--------|------|-------|
+| 1290 | 3171.38 | 0x01 (ERROR) | 0x10 | NETWORK_CHAR | (rejected) |
+| 1299 | 3171.70 | 0x12 (WRITE_REQ) | 0x09 | AES_CHAR | `d56ca2cddd1a4ab33b4aad64faffbbf99a12e8a0` (init_tx, 20B) |
+| 1300 | 3171.77 | 0x13 (WRITE_RSP) | 0x09 | AES_CHAR | (ack) |
+| 1301 | 3171.78 | 0x0a (READ_REQ) | 0x09 | AES_CHAR | (req) |
+| 1303 | 3171.87 | 0x0b (READ_RSP) | 0x09 | AES_CHAR | `6345939f00000000000000000000000000000000` (init_rx, 20B) |
+| 1308 | 3172.73 | 0x12 | 0x0b | WRITE_CHAR | `100b87219f1fdb1053fdfcf5b43605` (15B) |
+| 1311 | 3172.92 | 0x1b (NOTIFY) | 0x0d | READ_CHAR | `100c9c51bb37c3a7757be8fd02ca7705` (16B) |
+| 1312 | 3173.79 | 0x12 | 0x0b | WRITE_CHAR | `1006b6fdc18adb937801` (10B) |
+| 1314 | 3173.87 | 0x1b | 0x0d | READ_CHAR | `100c058cbf2c897979b7582de612bb05` (16B) |
+| 1316 | 3175.92 | 0x1b | 0x0d | READ_CHAR | `100c1b06737c70ae60e8179b35701906` (16B) |
+| 1317 | 3176.40 | 0x12 | 0x0b | WRITE_CHAR | `100c7cde4784a126244380a996938001` (16B) |
+| 1319 | 3176.47 | 0x1b | 0x0d | READ_CHAR | `100c11eb3603e5909f514b1da238b603` (16B) |
+
+## What we learn from the bytes
+
+**Frame format used by the phone:**
+```
+[0x10][length_byte][ciphertext_N_bytes][2_byte_trailer]
+```
+- Magic byte is **`0x10`** — NOT `0x11` as the upstream's HT34/0107 code assumes. Our code used `0x11`.
+- `length_byte` = number of ciphertext bytes (NOT including trailer or header). Frame 1308 has len=`0x0b`=11, ciphertext is exactly 11 bytes (`87 21 9f 1f db 10 53 fd fc f5 b4`), trailer is the last 2 bytes (`36 05`).
+- All notifications use the same format. Length is always `0x0c`=12 in this session.
+
+**Cipher: NOT what the decompile naively suggests.**
+
+I tried decrypting `87 21 9f 1f db 10 53 fd fc f5 b4` with the timer's network key (`<network-key>`) using:
+
+- AES-CTR, IV = `init_rx[:12]` + counter `00000000` (this is what the decompile shows)
+- Same with counter starting at 1
+- Same with iv = `init_tx[:12]`, `init_rx[:4]+init_tx[4:12]`, etc. (~12 IV variants)
+- AES-CBC with various IVs
+- AES-ECB direct
+- IV = MD5(tx+rx)[:12], MD5(tx)[:12], MD5(rx)[:12]
+- IV = AES_ECB(key, rx[:16])[:12], AES_ECB(key, tx[:16])[:12]
+
+**None decrypt to a plaintext whose byte-sum + flag + len equals the observed trailer.** That trailer formula was the upstream's; if it's also wrong on this firmware, our chances of identifying the cipher by trailer-cross-check are low.
+
+The decompile is unambiguous that the cipher is `aes-js`'s `ModeOfOperation.ecb` used in a CTR pattern (manual block construction), with the IV stored at db key `:iv` (12 bytes) and counters at `:enc-ctr` and `:dec-ctr` (uint32 LE each, derived from `read_aes_init_response[:12]`, `[12:16]`, `[16:20]`). Yet the math doesn't work.
+
+Possibilities I haven't ruled out:
+
+- The KEY used by the cipher is a **derived value**, not the raw network key from the cloud API. The decompile's `r5` register at the cipher constructor (`new ecb(r5, r12)`) traces back to a chain involving `base64_to_buffer` of `:network-key-b64`, but maybe a hash or KDF is applied somewhere in between that I didn't catch.
+- The IV used in encryption blocks may NOT be `:iv` directly — `state.iv.copy(block, 0, 0, 13)` copies "up to 13 bytes" but we only stored 12. The 13th byte might come from somewhere we missed (initial value of the allocated buffer? a different state slot?). However, `Buffer.alloc(N)` zeros memory, so byte 12 of the block before the counter is written would be 0 — same as our model.
+- The "trailer" might not be a checksum. It could be a sequence number, or part of an authenticated-encryption tag.
+- The cipher object might be created with a `Counter` object (not plain ECB), making `cipher.encrypt(block)` advance internal state per call. That would change every encryption result.
+
+## Comparison to our integration's frames
+
+Our HA component sent, for "zone 1 ON 600s" with our then-current best guess:
+```
+0x11  0x19  <25-byte ciphertext>  <2-byte trailer>
+```
+where the plaintext was `aa 77 5a 0f 0f 00 30 xx xx xx 72 0b 08 02 12 07 1a 05 08 01 10 d8 04 e7 8e` (the `xx` bytes are the device's mesh_device_id), AES-CTR-encrypted with the same key, IV from `read_gatt_char(AES_CHAR)[:12]`, counter 0.
+
+Differences vs what the phone actually sends:
+
+- We used magic `0x11`; the phone uses `0x10`.
+- Our plaintext length is 25; the phone's first command was 11. So the protobuf shape we send is ~2x larger than what the device expects on this firmware.
+- We embed an upstream-defined inner envelope (MSG_HEADER `aa 77 5a 0f` + length + reserved + protobuf + CRC-16-CCITT). The phone's plaintexts (whatever they are) decrypt to 11 / 6 / 12 bytes — too short to contain that envelope plus a meaningful protobuf message.
+
+That suggests the inner-envelope concept is an upstream HT34-specific layer that doesn't exist on HT25/0085. The plaintext on the wire might be JUST the protobuf (or just the protobuf with a tiny prefix).
+
+## What we need to do to crack this
+
+1. **Resolve the cipher's actual key.** This means resolving `r5` in the decompiled bundle to its actual byte value at that moment. Hard because of the register-based decompiled output, but doable with patient line-by-line tracing through `init_aes`. Alternatively, instrument the `aes-js` calls at runtime by injecting JS into the running app (frida on a real device).
+
+2. **Confirm the trailer formula.** We have 7 known frames (3 TX, 4 RX). The trailer is consistent within a session but doesn't match `sum(pt) + flag + len` for any decryption we tried. Likely candidates left to try once we have correct decryption:
+   - sum(plaintext bytes) only (no flag/len)
+   - CRC-16-CCITT of plaintext
+   - CRC-16-CCITT of the full unencrypted prefix
+   - HMAC truncated to 2 bytes
+
+3. **Decode the resulting plaintext as protobuf** — should be an `OrbitPbApi_Message` with fields like `meshDeviceId`, `messageId`, `getDeviceStatusInfo` (the first message after connect is usually a status request).
+
+## Practical next steps
+
+- **Easiest:** use a cloud-based HA integration (e.g. `sebr/hass-bhyve`) which routes through Orbit's cloud → hub → BLE the same way the official app does. Works today on hub-paired devices.
+- **Medium:** repeat this snoop-log capture but **with packet timestamps preserved** so we can correlate exactly which "Control via Bluetooth" UI action produced which write. Currently we know the byte order but not the semantic intent of each write.
+- **Hard:** extract the actual cipher key at runtime via frida on a rooted Android device, OR finish reverse-engineering the cipher key derivation in the Hermes bundle by hand.
+
+## Files
+
+| Path | Contents |
+|---|---|
+| `btsnoop_hci.log` | Raw BTSnoop log extracted from the Android phone's bug report (`bugreport-*.zip`) |
+| `orbit_schema.json` | Pretty-printed protobuf schema extracted from the Hermes bundle |
+| `apk_decompiled/bundle_decompiled.js` | Decompiled JS (~98 MB) |
+
+The cipher/frame reference implementation now lives in `custom_components/orbit_bhyve/connection.py`.

--- a/docs/findings/wrong-hypotheses.md
+++ b/docs/findings/wrong-hypotheses.md
@@ -1,0 +1,101 @@
+# Dead Ends and Falsified Hypotheses
+
+*Reverse-engineering notes; imported from the maintainer's research project and scrubbed of device-specific identifiers.*
+
+Most write-ups of a reverse-engineering effort only show the path that worked, which makes the result look inevitable and teaches almost nothing. The reality is that progress came from a series of confident, well-argued hypotheses that turned out to be wrong. Each one cost days, and each one was falsified by a single decisive test. Documenting those dead ends is the most useful thing this project can leave behind: it shows *why* a wrong idea looked right, and it stops the next person from spending the same days re-deriving the same mistake.
+
+Three hypotheses stand out. Each was internally consistent with the evidence available at the time. Each was wrong. Here is what we believed, why it seemed right, how it fell, and what the actual answer turned out to be.
+
+---
+
+## Hypothesis 1 — "Provisioning writes the network key to GATT char `0x6c76`"
+
+### What we believed
+
+The integration completed the AES handshake and its encrypted command writes were accepted with no GATT error, yet valves refused to actuate. Decompilation of the official app's bytecode bundle revealed a **fourth** GATT characteristic we had never used, `0x6c76` (`network_char_uuid`), alongside the three we already spoke (`aes`, `write`, `read` on the `0xfe32` service). The app appeared to write an 18-byte payload — a 2-byte little-endian prefix (`01 00`) followed by the 16-byte network key — to `0x6c76` *before* the AES init. The conclusion seemed unavoidable: this "provisioning" write is the device's signal that the central is authorized to issue commands, and because our code never performed it, the command-handling layer silently ignored everything we sent.
+
+### Why it seemed right
+
+- It explained the exact symptom precisely: connect succeeds, handshake succeeds, writes are accepted, but nothing actuates. A "you are not provisioned, so I will accept and ignore your commands" state fit perfectly.
+- The characteristic was real and named `network_char_uuid` in the app's own code — not something we invented.
+- The provisioning step lived in the app's connect-and-prepare flow, gated by an in-memory "already provisioned?" check, exactly where a one-time-per-session authorization write would go.
+- We had never *observed* the phone doing this over the air (it uses resolvable private addresses and our single-channel sniffer couldn't follow its connections), so an unobserved-but-plausible step was easy to believe.
+
+### How it was falsified
+
+We implemented the write: `[01 00 || <network-key>]` to `0x6c76`, before the AES handshake. Every device rejected it with **GATT error 3, "Write not permitted"** — including the one reference device that actuates correctly with our existing code. The characteristic is firmware-locked. Whatever the app does to that characteristic (if anything, at runtime), it is not a plain client write we can replicate, and it is emphatically not the missing step for the broken devices — because the *working* device also refuses the write yet works fine without it.
+
+### The actual answer
+
+The network key is **per-account, fetched from the vendor cloud, and never written over BLE** by a third-party central. There is no provisioning-write handshake to reproduce. The provisioning code was reverted; the `0x6c76` constant was kept in the source for documentation only. The real cause of the broken devices lay elsewhere entirely (see Hypothesis 3).
+
+### Lesson
+
+A characteristic existing in the app's symbol table does not mean a client is *allowed* to write it, and "we never captured it, but it's plausible" is a hypothesis, not evidence. The single cheapest test — just attempt the write and read the GATT status — falsified in one shot what a plausibility argument had propped up for days. When a theory predicts a specific observable ("this write unlocks commands"), run the one-line experiment that can kill it *before* building on top of it.
+
+---
+
+## Hypothesis 2 — "Control is broadcast-mesh only; direct point-to-point BLE is impossible"
+
+### What we believed
+
+After several passive sniffer captures, we concluded the hub-to-timer protocol was **not** a GATT connection at all but a **broadcast mesh**: the hub places encrypted commands into BLE advertisement data and timers receive them by passive scanning. On that theory, the whole idea of connecting to a timer and driving it over the GATT data channel was a dead end — the connection existed only for setup-class operations (pairing, firmware, key acceptance), and routine watering commands were delivered exclusively over the broadcast path. The recommended conclusion was that direct BLE control was fundamentally incompatible with this hardware and that the only viable Home Assistant path was a cloud-based integration.
+
+### Why it seemed right
+
+- Across ~12 minutes and ~250,000 packets we saw **zero `CONNECT_IND`** to any timer- or hub-pattern address, and **zero ATT writes/notifications** — only frequent advertisements (30–50 Hz) carrying variable-length encrypted-looking payloads under company ID `0x047f`.
+- Multiple distinct payload sizes (2, 13, 20, and 46 bytes) looked like a real message family — heartbeat, status, and a long-enough-to-be-a-command hub broadcast.
+- Even with the official app in its "Control via Bluetooth" mode, we captured **no** `CONNECT_IND` to any timer-pattern address — 188 connection requests across 147 advertisers, none matching the vendor OUI.
+- The GATT writes we *did* make were accepted but produced no actuation, which the broadcast theory explained neatly: we were writing to a channel that wasn't the real command channel.
+
+### How it was falsified
+
+The broadcast picture was an artifact of the capture rig, not the protocol. The devices use resolvable private addresses for their connections, and the long 46-byte hub payloads were BLE5 extended advertising — legacy AdvData caps at 31 octets, so a 46-byte element *cannot* be a legacy PDU. A single-channel PCA10059 sniffer cannot reliably follow either RPAs or the secondary-channel extended-advertising packets, so it saw advertisements and missed every connection. The absence of `CONNECT_IND` in our logs meant "our sniffer couldn't follow the connection," not "no connection happened." Direct per-device GATT control does work — **the entire integration is built on it**, connecting to each timer and driving its valve over the data channel.
+
+### The actual answer
+
+Direct, point-to-point BLE control of each timer is exactly how the device is driven: connect, run the AES handshake, and write encrypted command frames on the data channel. The broadcast advertisements are real but are status/beacon traffic, not the control path a central must use. The "broadcast-mesh only" conclusion inverted cause and effect: an under-powered sniffer produced an absence of evidence that we read as evidence of absence.
+
+### Lesson
+
+Absence of evidence is not evidence of absence — *especially* when your instrument is known to be blind to the thing you're looking for. Before concluding "X never happens," establish that your tooling *could have seen X if it did happen*. A single-channel sniffer against RPAs and BLE5 extended advertising was structurally incapable of observing the connections, so its silence proved nothing. Had this hypothesis won, the project would have been abandoned in favor of a cloud integration — the most expensive dead end of all: the one that stops you from trying the thing that actually works.
+
+---
+
+## Hypothesis 3 — "`d7 47` is a fixed protocol magic constant"
+
+### What we believed
+
+Frames on the working reference device began with the bytes `d7 47`, and the integration hardcoded them as a protocol magic constant (`D747_MAGIC = bytes([0xD7, 0x47])`), prepended to every command frame for every device. On the reference unit this worked end-to-end, so `d7 47` looked like a fixed envelope marker shared by the whole device family — the same kind of constant as the message header or the frame-type byte.
+
+### Why it seemed right
+
+- It was empirically load-bearing on the one device we developed against: frames starting `d7 47` actuated the valve, and the acknowledgements came back with the matching prefix.
+- Two bytes at the very start of every frame is exactly what a protocol magic *looks* like, and we already had other genuine constants (message header, frame-type, trailer formula) in the same frames, so one more fit the mental model.
+- All development and regression testing happened against that single reference device, so the hardcoded value was never contradicted — every frame it built was correct *for that device*.
+
+### How it was falsified
+
+Other devices of the same hardware family exhibited a sharp, distinctive failure: the AES handshake completed, all init writes succeeded with no GATT error, and **the device returned zero notifications at any stage**. The working reference device returned an acknowledgement per init step; the others returned none. A phone-app BTSnoop capture against one of the broken devices settled it: same magic byte, same trailer formula (`sum(pt) + 0x10 + len`), same AES cipher, same 8-step init — **only the 2-byte prefix differed**. The captured frames for that device started with *its* prefix, not `d7 47`.
+
+`d7 47` was not a constant at all. It was the reference device's own `mesh_device_id`, `18391` (`0x47D7`), written little-endian → `d7 47`. By hardcoding it, the integration addressed *every* device's frames to the reference unit's mesh address. The reference unit answered because the frames were addressed to it; every other device silently dropped frames addressed to someone else — which is exactly why they produced zero notifications while erroring nowhere.
+
+### The actual answer
+
+Each device's frame is prefixed with **its own** 2-byte mesh address — its `mesh_device_id` in little-endian — not a shared constant. In this repo the fix lives in `custom_components/orbit_bhyve/devices/ht25.py`: the frame builders are instance methods that use a per-device `mesh_address` property (`self.mesh_device_id.to_bytes(2, "little")`) instead of the hardcoded `d7 47`. A companion address, the paired hub's mesh address (`hub_mesh_address`), is used for the second init frame and is resolved from the cloud record (with an empirical per-network-key fallback). The change is backward-compatible: for the original reference device, the dynamically built prefix is byte-identical to the old hardcoded `d7 47`, so it keeps working as a regression target while the previously broken devices now actuate.
+
+### Lesson
+
+Beware constants derived from a sample size of one. A value that is genuinely device-specific is indistinguishable from a global constant when you only ever test against one device — the hardcode is *correct* for that device, so nothing pushes back. The tell was there in plain sight (`d7 47` reversed is `0x47D7` = `18391`, a value that also appeared as that device's `mesh_device_id`), but it took a second device to force the question. When something works on exactly one unit, treat every literal in the working frame as a suspect until a *different* unit confirms it's actually shared.
+
+---
+
+## Common thread
+
+All three failures share a shape: a hypothesis that perfectly explained the evidence *available at the time*, defeated by one decisive test that the evidence had made easy to skip.
+
+- H1 was killed by attempting the write and reading one GATT status code.
+- H2 was killed by recognizing the instrument was blind to the thing it "didn't see."
+- H3 was killed by testing against a second device.
+
+The recurring discipline: identify the single cheapest experiment that could falsify the theory, and run it *before* building on the theory — not after the scaffolding is already load-bearing.

--- a/docs/hermes-findings.md
+++ b/docs/hermes-findings.md
@@ -1,0 +1,130 @@
+*Contributed by @anahnymous in [issue #19](https://github.com/ljmerza/orbit-bhyve-ble/issues/19); code references adapted to this repository's layout.*
+
+# B-hyve Hermes Decompilation Findings
+
+The B-hyve Android app's BLE protocol logic lives in a Hermes-bytecode JavaScript
+bundle (`index.android.bundle`), not in native code. This document records what that
+bundle reveals about the BLE crypto, key architecture, and session handshake. Symbol
+names below are the app's own (ClojureScript compiled to JS), so they are findable in
+any decompile of the same bundle. Companion references: [`protocol.md`](protocol.md)
+(wire format) and [`ble-messages.md`](ble-messages.md) (message catalog).
+
+## App structure
+
+- The app is React Native. The BLE protocol layer is ClojureScript (compiled
+  CLJS -> JS -> Hermes; identifiers appear as `cljs$core$...`), in the namespace
+  `lib.ble.service.common`.
+- BLE transport is `react-native-ble-manager` (Java `it.innove`). It only moves
+  bytes; all framing and crypto live in the ClojureScript.
+
+## GATT characteristics
+
+Custom characteristics use the base UUID `0000XXXX-fe32-4f58-8b78-98e42b2c047f`:
+
+| App name | Short UUID | Role |
+|----------|-----------|------|
+| `service_uuid` | `fe32` (base) | service |
+| `aes_char_uuid` | `6c71` | AES init / handshake (key setup + nonce) |
+| `write_char_uuid` | `6c72` | command frames (host -> device) |
+| `read_char_uuid` | `6c73` | notification frames (device -> host) |
+| `network_char_uuid` | `6c76` | WiFi / network provisioning |
+
+The bundle also defines `encryption_frame_size` (frame chunk size),
+`max_message_size = 255`, and `default_tx_delay_ms`.
+
+## Handshake and session nonce
+
+`init_aes` generates `randomBytes(20)` (one byte set from a field) and writes it to
+the AES characteristic. `read_aes_init_response` reads back a 20-byte device reply.
+The per-session cipher state is composed from both blobs:
+
+```
+composed     = device_resp[0:4] ++ client_write[4:20]
+nonce12      = composed[0:12]
+counter_h2d  = readUInt32LE(composed, 12)
+counter_d2h  = readUInt32LE(composed, 16)
+```
+
+Validation performed before composing:
+- `device_resp[0:4]` must not be all-zero (the device supplies fresh entropy here).
+- `device_resp[4:20]` must be all-zero.
+
+So the nonce mixes 4 bytes of device randomness with 8 bytes of client randomness,
+and both direction counters are purely client-generated (from the `randomBytes(20)`
+in `init_aes`). This is an AES-CTR IV setup: a 12-byte nonce followed by a 4-byte
+little-endian block counter, with separate counters per direction. The handshake
+establishes only the per-session nonce and counters; the AES key is not exchanged.
+
+## Cipher
+
+- The cipher is `aes-js` `ModeOfOperation`. AES-CTR is realized manually over the
+  nonce and counter above. There are no `createCipheriv` / `aes-128-ctr` algorithm
+  strings, which is consistent with `aes-js` (it takes no algorithm string).
+- The encrypt/decrypt path reads the AES key as a base64 field from the device
+  record (`util.buffer.base64->buffer`), set on the `provision_device!` path. The key
+  is provisioned, not embedded as a constant in the bundle.
+- PBKDF2-SHA256 is present in the crypto stack (`pbkdf2`, `cachedPbkdf2`) via a
+  crypto polyfill, but it is **not** used for the frame key: frames decrypt directly
+  with the raw base64-decoded key. PBKDF2 is an unused polyfill or serves a different
+  feature.
+
+## Key architecture
+
+- The AES key is a per-mesh `network_key`. `lib.ble.core.random_network_key` is:
+
+  ```js
+  function () { return randomBytes(16).toString('base64'); }
+  ```
+
+  a random 16-byte (AES-128) key, base64-encoded, generated at provisioning. It is
+  not derived from the device serial, MAC, the handshake token, or any observable
+  value; it is pure `crypto.randomBytes`.
+- The key is shared by every timer in a `network_topology` (mesh) and is set once at
+  provisioning. It is never sent over BLE.
+- Because it is random, it cannot be reconstructed from a capture or from device
+  identifiers. It can be obtained by:
+  - retrieving it from the Orbit cloud account (see below),
+  - reading it from a provisioned install's private storage (requires root), or
+  - re-provisioning the timer, which generates a new key the provisioner then knows
+    (this rewrites the timer's key and breaks the existing pairing).
+
+## Retrieving the key from the Orbit cloud
+
+At provisioning the app uploads the mesh record -- including the network key -- to
+the Orbit cloud, and the server stores it. The provisioning code path is
+`save_mesh_and_connect_BANG_` -> `save_mesh_to_server_BANG_` -> `save_mesh`, which
+PUTs or POSTs the full mesh map (with the key) to the web service. The key survives
+to the HTTP body because only the `:devices` sub-list is rewritten before the call.
+
+Retrieve the key with two requests:
+
+```
+POST /v1/session
+  orbit-app-id: Bhyve Dashboard
+  body: {"session": {"email": "<account email>", "password": "<account password>"}}
+  -> orbit_api_key: <jwt>
+
+GET /v1/network_topologies
+  orbit-app-id: Bhyve Dashboard
+  orbit-api-key: <jwt>
+  -> [{ ... "network_key": "<base64 AES-128 key>" ... }, ...]
+```
+
+Notes:
+- The server stores the key under `network_key`. The CLJS keyword is
+  `:ble-network-key`; the server normalises it on ingest.
+- `/v1/network_topologies` is the correct endpoint. `/v1/meshes` returns an empty
+  list, despite what the provisioning symbol names suggest.
+- The response lists one entry per mesh, each with its associated devices. Pick the
+  topology containing the target timer and base64-decode its `network_key` to the 16
+  raw bytes used as the AES-128 key.
+
+## Frame trailer
+
+The outer BLE frame's 2-byte trailer is a 16-bit additive checksum over
+`[0x11, len] + plaintext` (type and length header bytes included), little-endian:
+`(0x11 + len + sum(plaintext)) & 0xFFFF`. It is not a CRC (a CRC-16 brute force over
+the on-wire ciphertext bytes matches no common variant). The device drops any host
+frame whose trailer does not match. The separate trailer inside the decrypted
+`aa 77 5a 0f` application message is CRC-16/XMODEM; only the outer frame trailer is
+the additive checksum. See [`protocol.md`](protocol.md) for the full wire format.

--- a/docs/network-key-extraction.md
+++ b/docs/network-key-extraction.md
@@ -1,0 +1,90 @@
+# Extracting Your Network Key
+
+*Reverse-engineering notes; imported from the maintainer's research project.*
+
+The Orbit B-Hyve XD encrypts its BLE data channel using an AES-128 key that is **specific to your Orbit account**, not specific to the physical device. Anyone in possession of the key can control all devices on your account, so treat it like a password.
+
+You do **not** normally extract the key by hand — this integration does it for you during setup. The manual paths below are documented for reference and troubleshooting.
+
+## Option 1 — Let the integration fetch it (recommended)
+
+Add the integration and enter your Orbit account email and password (**Settings → Devices & Services → Add Integration → "Orbit B-Hyve BLE"**). The config flow authenticates against the Orbit cloud, lists the devices on your account, and fetches each mesh's `network_key` automatically — you never handle the key yourself.
+
+The cloud logic lives in `custom_components/orbit_bhyve/cloud.py` (`OrbitCloudClient.discover` → `login` → `list_devices` → `get_mesh`). Your credentials are used only for the one cloud authentication request at setup; after that, all control is local BLE.
+
+## Option 2 — Cloud API direct call
+
+To retrieve the key yourself, replicate what the integration does — two requests against the Orbit cloud REST API (base `https://api.orbitbhyve.com/v1`):
+
+```
+POST /v1/session
+  orbit-app-id: Bhyve Dashboard
+  body: {"session": {"email": "you@example.com", "password": "your-password"}}
+  -> orbit_api_key: <jwt>
+
+GET /v1/network_topologies        # this integration also tries /meshes and /networks
+  orbit-app-id: Bhyve Dashboard
+  orbit-api-key: <jwt>
+  -> [{ ... "network_key": "<base64 AES-128 key>" ... }, ...]
+```
+
+Pick the topology/mesh containing your timer and base64-decode its `network_key` to the 16 raw bytes. See [`hermes-findings.md`](hermes-findings.md) for how this endpoint was discovered.
+
+## Option 3 — From the Mobile App's Storage (advanced)
+
+If you have a rooted Android device with the official B-Hyve app installed and paired, you can extract the key directly from the app's local storage without going through the cloud at all. This is useful for debugging cases where the cloud API path fails (rare, usually due to two-factor authentication or account changes).
+
+The key lives in two places inside the app's data directory:
+
+1. **HTTP cache.** The app caches the cloud response that delivered the key. Look in `/data/data/com.orbit.orbitsmarthome/cache/http-cache/` for files containing JSON like:
+   ```json
+   {"id":"...","user_id":"...","network_key":"<BASE64_NETWORK_KEY>","bridge_devices":[],"devices":[...]}
+   ```
+2. **MMKV persistent storage.** Tencent's MMKV format is used by the app for offline state. The relevant store is `mmkv-db-instance-users.<user_id>`. The MMKV format is a key-value flat file; the keys can be enumerated using any of the open-source MMKV reader libraries.
+
+You can pull the cache file over ADB and grep it for `network_key`:
+
+```bash
+adb devices                                     # confirm the device is connected
+adb shell run-as com.orbit.orbitsmarthome cat cache/http-cache/*   # rooted / debuggable build
+```
+
+This requires:
+- An ADB-connected Android device with the B-Hyve app installed and signed in to your account.
+- Either a rooted device, or `adb shell` access via a debug-enabled build (rare for production apps).
+
+## Format of the Key
+
+The key is **16 bytes (128 bits)**. The cloud API returns it as base64; the integration and CLI accept it as 32 hex characters. To convert base64 to hex:
+
+```python
+import base64
+b64 = "YOUR_BASE64_KEY"
+print(base64.b64decode(b64).hex())
+```
+
+Or in shell:
+
+```bash
+echo -n 'YOUR_BASE64_KEY' | base64 -d | xxd -p
+```
+
+## Security Considerations
+
+- **Treat the key as a password.** Anyone with the key can issue valve commands to all devices on your account, and can decrypt any captured BLE traffic from those devices.
+- The key is **regenerated** if you delete and recreate your Orbit account, but is **not** rotated automatically.
+- Storing the key in the Home Assistant integration's config entry persists it in HA's config directory (encrypted at rest only if your filesystem is encrypted). If your HA installation is exposed to untrusted users, take normal precautions.
+- This project never transmits your key anywhere. The integration uses it only to decrypt notifications from and encrypt commands to your local BLE device.
+
+## Troubleshooting
+
+**Setup says "authentication failed".**
+- The Orbit cloud API uses OAuth-style flows that occasionally change. Try logging into the official app once to refresh your account state, then retry setup.
+- If you have two-factor authentication enabled on your Orbit account, the cloud-API path will likely fail. Use Option 3 (mobile-app extraction) instead.
+
+**Setup authenticates but reports "no devices found".**
+- The cloud account must have at least one B-Hyve device registered.
+- The first time you set up a B-Hyve, complete the registration in the official app first.
+
+**The Home Assistant integration says "invalid_key".**
+- The key must be exactly 32 hexadecimal characters (16 bytes). Strip any spaces, colons, or `0x` prefix before pasting.

--- a/docs/protobuf-schema.md
+++ b/docs/protobuf-schema.md
@@ -1,0 +1,52 @@
+# Reconstructed Protobuf Schema
+
+*Reverse-engineering notes; imported from the maintainer's research project.*
+
+The Orbit B-Hyve XD messages on the BLE data channel are protobuf. This document records how that schema was **reconstructed by observation** — it is not a copy of any vendor source code. This integration does **not** ship a `.proto` file or depend on the `protobuf` runtime; it encodes/decodes the wire format by hand with small helpers in `custom_components/orbit_bhyve/devices/ht34a.py` (`_pb_varint`, `_pb_field_varint`, `_pb_field_bytes`, `_rd_varint`, `_pb_fields`). The full reconstructed field/enum tables live in [`ble-messages.md`](ble-messages.md).
+
+## How It Was Reconstructed
+
+The schema was assembled from the following observations:
+
+1. **Wire-format inspection.** Decrypted plaintexts (see [`encryption.md`](encryption.md)) were fed to `protoc --decode_raw` to dump field numbers and wire types. This produces a structural skeleton (e.g. `1: 0, 2: 600, 14: { ... }`) without field names.
+2. **Behavioral inference.** Field numbers were correlated with observed device behavior — sending a message with field 1 set to N caused station N to actuate, sending field 2 set to S caused the run time to be S seconds, etc.
+3. **Cross-referencing observable strings.** Where the official mobile application exposes message-class names through public Android APIs (e.g. via `android.util.Log` traces or `getClass().getSimpleName()` calls visible in BLE-write contexts), those names were used to label the corresponding reconstructed messages. Names like `OrbitPbApi_Message`, `TimerMode`, `ManualModeParams`, and `StationInfo` were obtained this way.
+4. **Empirical validation.** The reconstructed schema was used to *encode* messages and send them to the device. If the device responded as expected, the field interpretation was validated. If not, the schema was adjusted until behavior matched.
+
+The schema was therefore built from a combination of:
+
+- Wire-level traffic that any owner of the device can capture with standard Android developer tools (HCI snoop log).
+- Public-API-observable class names from the mobile application running on the project authors' own hardware.
+- Targeted experiments with the device the project authors lawfully own.
+
+No proprietary firmware or vendor source code was redistributed.
+
+## Coverage
+
+The reconstructed schema covers what is needed to control a B-Hyve XD locally:
+
+- `OrbitPbApi_Message` — the top-level message exchanged on the BLE data channel.
+- `TimerMode` and `ManualModeParams` — for valve activation.
+- `StationInfo` — to specify which valve and for how long.
+- `DeviceControl` — for stop-watering and skip-current-station commands.
+- `BleInitMsg` — used in the IPC top-level wrapper that surrounds device messages.
+
+Many top-level fields exist in the protocol that this project did **not** reverse — anything related to scheduling, weather, sensors, programs, etc. — because they were not needed to satisfy the project's goal of HA-integrated manual zone control. If you extend this work, the schema will likely need extending too.
+
+## Limitations of This Schema
+
+- **Field names are approximations.** Where a name is not observable from public APIs, the schema uses descriptive English names (e.g. `runTimeSec` rather than the unknown internal token).
+- **Field types may be looser than the vendor's.** The vendor likely uses `required` on many fields where this schema uses optional fields, because over-permissive types do not affect interoperability and are safer when names/constraints are uncertain.
+- **No oneOf or oneof reconstruction.** Where the vendor likely uses `oneof` to group mutually-exclusive options, this schema uses optional fields. The device tolerates this.
+- **Enum values were determined empirically** — `mode = 2` for manual mode was found by experiment, not extracted from any vendor source.
+
+## Working With the Schema
+
+This integration builds the protobuf wire-format **manually** and avoids the `protobuf` runtime dependency entirely: the `_pb_varint` / `_pb_field_varint` / `_pb_field_bytes` encoders and the `_rd_varint` / `_pb_fields` decoders in `custom_components/orbit_bhyve/devices/ht34a.py` emit and parse fields directly. That approach is simpler to vendor into a Home Assistant custom component and does not break across `protoc` versions.
+
+If you would rather work from a generated `.proto` (as the original research project did), write one from the field/enum tables in [`ble-messages.md`](ble-messages.md) and generate bindings with:
+
+```bash
+pip install protobuf
+protoc --python_out=. orbit_ble.proto   # produces orbit_ble_pb2.py
+```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,253 @@
+*Contributed by @anahnymous in [issue #19](https://github.com/ljmerza/orbit-bhyve-ble/issues/19); code references adapted to this repository's layout.*
+
+# B-hyve BLE Protocol Reference
+
+This document specifies the Bluetooth Low Energy protocol used to control an Orbit
+B-hyve water-valve timer locally, without the Orbit cloud hub. It is the canonical
+protocol reference. In this integration the implementation lives in
+`custom_components/orbit_bhyve/`: the cipher, handshake, and frame I/O in
+`connection.py` (`BHyveBleConnection`), and the protobuf message building and
+parsing in `devices/ht34a.py` (`BHyveHT34ADevice`). The full message catalog with
+per-field tables and example hex is in [`ble-messages.md`](ble-messages.md); cipher
+and key internals are in [`hermes-findings.md`](hermes-findings.md).
+
+> **Scope:** This document covers the protobuf **"XD" family** (BLE frame magic
+> `0x11`: HT34A / HT32A / HT25G2). The older HT25 **"d7-47" family** (frame magic
+> `0x10`) is documented separately in
+> [`findings/d7-47-protocol.md`](findings/d7-47-protocol.md). This integration
+> implements a subset of the catalog (run-zone, stop, status request, battery
+> request, and status/battery decode); the other commands below are documented for
+> completeness.
+
+## Protocol stack
+
+A single logical command travels down four layers on the way out and back up the
+same four on the way in:
+
+```
++-- BLE GATT --------------------------------------------------------+
+|  Write / notify on fixed characteristics (auth, tx, rx).           |
++-- BLE frame -------------------------------------------------------+
+|  0x11 <len:1> <ciphertext> <additive-checksum:2>                   |
+|  A large app message is split across several frames.               |
++-- Crypto ----------------------------------------------------------+
+|  AES-128-CTR. Each frame payload is XORed with the keystream.      |
+|  Nonce and counters come from the session handshake.               |
++-- App message -----------------------------------------------------+
+|  aa 77 5a 0f <len:LE16> <protobuf> <crc16_xmodem:LE16>             |
+|  This is the unit the device dispatches on. May span >1 frame.     |
++-- Protobuf --------------------------------------------------------+
+   An OrbitPbApi_Message. The command = which field is set.
+```
+
+## GATT layout
+
+Custom characteristics use the base UUID `0000XXXX-fe32-4f58-8b78-98e42b2c047f`:
+
+| UUID (`XXXX`) | Role | Properties | Notes |
+|---------------|------|------------|-------|
+| `6c71` | Auth / key setup | write + read | 20-byte write, 20-byte read (see Handshake) |
+| `6c72` | Data TX (host -> device) | write-without-response | encrypted `0x11` frames |
+| `6c73` | Data RX (device -> host) | notify | encrypted `0x11` frames |
+| `6c76` | Write-only | write | unused by local control (OTA firmware path) |
+
+Handle numbers vary per device, so address by UUID rather than handle. Notifications
+on the RX characteristic must be enabled by writing `01 00` to its CCCD before the
+device will send status frames. A larger-than-default ATT MTU is negotiated so that
+frames up to ~100 bytes arrive as a single notification.
+
+## Session handshake and key
+
+### Key
+
+Encryption uses a 16-byte AES-128 `network_key`. One key is generated per mesh
+(`network_topology`) at provisioning and shared by every timer in that mesh. It is
+**not** derived from the handshake and is not exchanged over BLE. Obtain it from the
+Orbit cloud API:
+
+```
+GET https://api.orbitbhyve.com/v1/network_topologies    ->    field "network_key" (base64)
+```
+
+The response lists one entry per mesh; pick the `network_topology` whose devices
+include the target timer and decode its base64 `network_key` to the 16 raw bytes used
+as the AES-128 key.
+
+### Handshake
+
+At session start, exchange 20-byte blobs on the auth characteristic (`6c71`):
+
+1. Host writes 20 random bytes (`client_write`).
+2. Host reads 20 bytes back (`device_resp`); only the first 4 bytes are significant.
+
+The per-session cipher state is composed from both blobs:
+
+```
+composed     = device_resp[0:4] + client_write[4:20]     # 20 bytes
+nonce12      = composed[0:12]
+counter_h2d  = LE32(composed[12:16])
+counter_d2h  = LE32(composed[16:20])
+```
+
+After the handshake, enable notifications (CCCD `01 00`); encrypted frames then flow
+in both directions.
+
+## Encryption
+
+AES-128 in counter (CTR) mode with a manual little-endian counter block:
+
+```
+keystream_block = AES-ECB(key, nonce12 || LE32(counter))
+out             = data XOR keystream
+counter         = (counter + 1) mod 0xFFFFFFFF
+```
+
+The counter advances once per 16-byte block. Host-to-device and device-to-host
+traffic use independent counters (`counter_h2d`, `counter_d2h`), each seeded from the
+handshake. Because CTR mode XORs a keystream, encrypt and decrypt are the same
+operation. Each `0x11` frame payload is encrypted independently.
+
+## BLE frame format
+
+Every write to the TX characteristic and every RX notification is one frame:
+
+```
+0x11  <len>  <ciphertext (len bytes)>  <checksum (2 bytes)>
+```
+
+- Byte 0 is `0x11`, a constant frame-type marker.
+- Byte 1 is the payload length in bytes. Total frame size is `len + 4`.
+- The 2-byte trailer is a little-endian 16-bit **additive checksum** over
+  `[0x11, len] + plaintext` (the type and length header bytes are included):
+
+  ```
+  checksum = (0x11 + len + sum(plaintext_bytes)) & 0xFFFF     # little-endian
+  ```
+
+  It is not a CRC. It is computed over the **plaintext** payload, but the frame
+  carries the **ciphertext** payload followed by this trailer. The device silently
+  drops any host frame whose checksum does not match. Computed inline in
+  `BHyveBleConnection.encrypt()` (`connection.py`); there is no standalone checksum
+  function.
+
+A single application message may span several frames; concatenate the decrypted
+payloads and parse the running buffer.
+
+## Application message
+
+Decrypted frame payloads reassemble into an application message:
+
+```
+aa 77 5a 0f  <length:LE16>  <protobuf payload>  <crc16_xmodem:LE16>
+```
+
+- `aa 77 5a 0f` is a constant magic preamble.
+- `length` equals `len(protobuf) + 2` (the protobuf plus its 2-byte CRC), stored
+  little-endian. This is a **length, not a message type**. The device routes purely
+  on the protobuf field that is set; the length field is not used for dispatch.
+  `_build_message()` (with `MSG_HEADER`) in `devices/ht34a.py` computes this length
+  from the payload.
+- The inner 2-byte trailer is **CRC-16/XMODEM** (poly `0x1021`, init `0`, no
+  reflection) over the protobuf, stored little-endian. This is distinct from the
+  outer frame's additive checksum. Implemented by `_crc16_ccitt()` in
+  `devices/ht34a.py` (the "CCITT" name notwithstanding, poly `0x1021` + init `0` is
+  CRC-16/XMODEM).
+
+The payload is an `OrbitPbApi_Message` protobuf with exactly one field set; that
+field selects the command. Field numbers and enum values come from the reconstructed
+schema in [`protobuf-schema.md`](protobuf-schema.md). A malformed or unknown protobuf
+field gets no reply and desyncs the AES-CTR counter for the remainder of the
+connection; reconnect or power-cycle to recover.
+
+### Command and status messages
+
+Identify a message by its `OrbitPbApi_Message` field number:
+
+| Field | Dir | Meaning | Encoder / decoder (this integration) |
+|-------|-----|---------|-------------------|
+| f18 `setDateTime` | h2d | set clock (ISO-8601 local + offset) | (not implemented in this integration) |
+| f75 `setEpochTime` | h2d | set epoch + tz offset (triggers first status burst) | (not implemented in this integration) |
+| f15 `getDeviceStatusInfo` (empty) | h2d | request status | `_GET_STATUS_PB` constant (`devices/ht34a.py`) |
+| f45 `getBatteryStatus` (empty) | h2d | request battery status | `_GET_BATTERY_PB` constant (`devices/ht34a.py`) |
+| f19 `setProgramSchedule` | h2d | store a watering program (zone via `stationInfo`) | (not implemented in this integration) |
+| f20 `setActivePrograms` | h2d | enable programs (uint32 bitmask, program A = bit 0) | (not implemented in this integration) |
+| f14 `timerMode {mode=autoMode, manualModeParams={}}` | h2d | enable watering / run schedules (empty f2 required) | (not implemented in this integration) |
+| f14 `timerMode {mode=manualMode, manualModeParams{stationInfo}}` | h2d | manual run-zone | `_build_start_pb()` (`devices/ht34a.py`) |
+| f14 `timerMode {mode=offMode, manualModeParams={}}` | h2d | stop watering (empty f2 required) | `_STOP_PB` constant (`devices/ht34a.py`) |
+| f17 `setRainDelay {rainDelayTimeMins, delayEndTimeSecEpochUtc, delayType}` | h2d | rain delay (skip schedules); `mins=0` cancels | (not implemented in this integration) |
+| f120 `setScheduledMode` | h2d | seasonal system on/off dates (empty = none) | -- |
+| f16 `deviceStatusInfo` | d2h | device status (state, schedule, rain delay) | `BHyveHT34ADevice._parse_status()` (`devices/ht34a.py`) |
+
+The `timerMode` `manualModeParams` submessage (f2) must be present and empty for
+`autoMode` and `offMode`; sending only the `mode` field is ignored. Zone / station
+ids are 0-indexed (`station_id 0` is zone 1). See [`ble-messages.md`](ble-messages.md)
+for the full field tables, example hex, the read-only GET requests, and the
+device-to-host messages (`wateringStatus`, `batteryStatus`, `deviceInfo`, and the
+`setProgramSchedule` echo).
+
+### deviceStatusInfo decode
+
+`deviceStatusInfo` (`OrbitPbApi_Message` field f16) is the device-to-host status
+message. Its length varies with content (a status with no rain-delay or schedule
+block is shorter), so detect it by decoding the protobuf, never by the frame length
+field. The full `OrbitPbApi_DeviceStatusInfo` submessage is documented below as
+protocol reference; this integration's decoder, `BHyveHT34ADevice._parse_status()`
+(`devices/ht34a.py`), reads only the run state (f1) and the time-remaining inside the
+`wateringStatus` block (f6) — it does not extract every field in the table:
+
+| Field | Name | Notes |
+|-------|------|-------|
+| f1 | `deviceStatus` (enum) | `deviceOff`, `deviceIdle`, `lowBattery`, `rainDelayEnabled`, `wateringInProgress` (4), `meshDeviceOffline` |
+| f2 | `timerMode.mode` | off / on / program |
+| f6 | `wateringStatus` | running station and `time_remaining_sec` |
+| f7 | `faultStatus` | empty message means no faults |
+| f9 | `nextStartProgramFlags` | program bitmask for the next scheduled start |
+| f10 | `nextStartTimeSecEpochUTC` | epoch time of the next scheduled start |
+| f13 | `rainDelay` | `{mins, end_epoch, type}` |
+| f14 | `batteryStatus.batteryLevelMV` | battery level in millivolts |
+
+The outer `OrbitPbApi_Message` also carries f1 `id` (device MAC) and f7
+`timestampSecEpochUTC`.
+
+## Setting a schedule
+
+A schedule runs only when three things are in place:
+
+1. **Store** the program: `setProgramSchedule` (f19).
+2. **Enable** it: `setActivePrograms` (f20), a uint32 bitmask where program A is bit 0
+   (`1 << (programId - 1)`; program A = `1`).
+3. **Run mode**: put the timer in `autoMode` via `timerMode {mode=autoMode,
+   manualModeParams={}}` (f14). Without autoMode, `deviceStatusInfo.timerMode` stays
+   `off` and the schedule does not run.
+
+Saving is fire-and-forget, matching the app: send `setProgramSchedule` then
+`setActivePrograms` without blocking on a reply. The device computes a next start
+time only when it receives the store and enable while already in autoMode, so the
+sequence is: store, enable, autoMode, then re-send store and enable. The device then
+pushes an updated `deviceStatusInfo` from which the next start is read (f9/f10). The
+optional unsolicited `0x0067`-length schedule frame is a cache-refresh push, not a
+required acknowledgement.
+
+There is no schedule read over BLE; `getProgramSchedule` returns nothing and the app
+reads schedules from the cloud.
+
+## Rain delay
+
+`setRainDelay` (f17) sets or cancels a rain delay that suppresses scheduled starts.
+`rainDelayTimeMins = 0` cancels an active delay. Current delay state is reflected in
+`deviceStatusInfo` f13.
+
+## Implementation notes
+
+- The Android app is React Native. The native layer is the generic
+  `react-native-ble-manager` bridge and contains no protocol logic; all framing,
+  encryption, and message building live in the app's Hermes-bytecode JavaScript
+  bundle.
+- The BLE service layer is ClojureScript. Encryption uses `aes-js` in CTR mode. The
+  key is a random per-mesh `network_key` generated at provisioning.
+- The zone-run mode enum is `manual = 0`, `soak = 1`, `rain = 5`.
+- An OTA firmware path chunks blocks over the same BLE channel
+  (`ota-block-request`, `ota-block-chunk`); it is unused by local control.
+- Cloud-only features (weather adjustments, smart-watering restrictions, seasonal
+  adjust) produce no BLE writes; the cloud computes them and pushes results down in
+  `deviceStatusInfo`.

--- a/docs/reverse-engineering-journey.md
+++ b/docs/reverse-engineering-journey.md
@@ -1,0 +1,273 @@
+# The Reverse-Engineering Journey
+
+*Reverse-engineering notes; imported from the maintainer's research project.*
+
+This document chronicles how the protocol used by the Orbit B-Hyve XD Bluetooth hose timer was reverse-engineered from scratch, what worked, what didn't, and the techniques that proved useful. It is intended as a technical record and a learning resource for anyone working on similar BLE-protocol problems.
+
+> **Scope statement.** The work described here was performed against a device the authors lawfully purchased and own. No proprietary firmware was redistributed. No vendor application source code is reproduced in this repository. Where techniques applicable to compiled React Native applications are described, they are presented as *general approaches* to BLE protocol analysis, not as a step-by-step recipe applied to any specific application binary.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Device Information](#device-information)
+3. [Phase Chronicle](#phase-chronicle)
+4. [The Trailer Checksum Breakthrough](#the-trailer-checksum-breakthrough)
+5. [Lessons for BLE Reverse Engineering](#lessons-for-ble-reverse-engineering)
+
+---
+
+## Overview
+
+The B-Hyve XD is a Bluetooth-only hose timer (no Wi-Fi, no LoRa, no proprietary radio). It pairs with the official Orbit B-Hyve mobile application over BLE GATT and is controlled directly by that app — no cloud round-trip is required to open or close a valve. Because the device has no Wi-Fi and the app must be physically near the device to send a command, integrating it into Home Assistant as a network-controllable sprinkler requires either:
+
+1. Standing up a dedicated Bluetooth bridge that runs the official Android app (fragile, cloud-dependent), or
+2. Speaking the BLE protocol directly from a Linux host with a working Bluetooth stack.
+
+The second approach is what this project pursued. It required decoding:
+
+- The BLE GATT service structure and which characteristics carry which traffic
+- The connection initialization handshake (a 20-byte exchange establishing a per-session AES context)
+- The custom AES encryption mode used for the data channel (an unusual ECB-as-CTR construction)
+- The protobuf schema used by the application messages
+- The frame format wrapping each encrypted message
+- A 16-bit content-dependent **trailer checksum** validated by the device firmware (the longest hold-out)
+
+By the end of the project, all four valve channels were controllable from Home Assistant via the included custom integration, with full per-zone duration support.
+
+---
+
+## Device Information
+
+| Property | Value |
+|----------|-------|
+| Model | B-Hyve XD Bluetooth Hose Faucet Timer |
+| Part Number | 24634 |
+| FCC ID | ML6-HT34BT |
+| Valves | 4 ports |
+| Communication | Bluetooth Low Energy (BLE) |
+| Firmware tested | 0107 |
+| Hardware | HT34A-0001 |
+| Manufacturer | Orbit Irrigation Products Inc. |
+
+The device advertises a 16-bit BLE service UUID `0xFE32` (full UUID `0000fe32-0000-1000-8000-00805f9b34fb`) and uses three primary GATT characteristics for data exchange.
+
+---
+
+## Phase Chronicle
+
+### Phase 1 — Reconnaissance
+
+**Objective:** Understand what is on the wire and how the application talks to the device.
+
+**What was done:**
+
+- The device was paired with an Android tablet running the official mobile application. BLE traffic was captured using the OS-level **Bluetooth HCI snoop log** facility — a standard Android developer feature that records every HCI frame to `btsnoop_hci.log`. Enabling this is the textbook first step for any BLE protocol-analysis task and requires no instrumentation of the application itself.
+- The captured `btsnoop` file was opened in Wireshark, which natively decodes ATT, GATT, and SMP layers. This made the GATT service discovery trivially observable: the device exposes a custom service with five characteristics, three of which carry traffic during normal valve operation.
+- The BLE transport was characterized: MTU is negotiated to a higher value early in the connection, LE Data Length Extension is used, and the application transmits data using ATT Write Commands and Write Requests on different characteristics.
+- The device's GATT handle map was reconstructed from the Wireshark dissection. See [`ble-protocol.md`](ble-protocol.md) for the resulting map.
+
+**Result:** A clear picture of the wire format at the BLE layer, and the realization that the data on the data-channel characteristic was opaque encrypted bytes (high entropy, no recognizable structure).
+
+### Phase 2 — Network Key Extraction
+
+**Objective:** Obtain the symmetric key used to encrypt BLE data-channel messages.
+
+**What was done:**
+
+- The mobile application's data directory was inspected via ADB on a rooted Android device. Two locations were found to contain the per-account `networkKey`:
+  1. The application's HTTP cache directory (a JSON response from the Orbit cloud API that the app caches locally).
+  2. The MMKV (Tencent's persistent key-value store) used by the application for offline state.
+- An automated extractor was written to pull this key over ADB without manual file-tree exploration.
+- A second extractor retrieves the same key directly from the Orbit cloud REST API, given valid account credentials. This avoids needing a rooted device entirely and is the path this integration's config flow uses (see [`network-key-extraction.md`](network-key-extraction.md)).
+
+> **Note on key handling:** The network key is account-specific, not device-specific. It is the secret derived for your Orbit account and transmitted to your devices when they are provisioned. Anyone in possession of the key can control all devices on your account; treat it like a password.
+
+**Result:** A 16-byte network key, ready for use as a candidate AES key.
+
+### Phase 3 — BLE Traffic Capture & Encryption Analysis
+
+**Objective:** Crack the encryption used on the data-channel characteristic.
+
+**What was done:**
+
+- Multiple captured BLE write payloads were collected from `btsnoop` for a known plaintext (a "stop all watering" command, sent repeatedly with no other input between attempts).
+- An attempt was made to decrypt the ciphertext directly with the network key under several common AES modes (CBC, CTR, GCM, OFB, CFB) using a brute-force harness that tried plausible IV/nonce derivations from the surrounding bytes. Roughly 500+ combinations were tried; **none produced plaintext that resembled a known protobuf structure.**
+- A more invasive approach was needed. Frida (a dynamic instrumentation toolkit) was attached to the running mobile application and used to hook the relevant BluetoothGatt write methods. This made it possible to log the **plaintext** the application was about to encrypt before it disappeared into the cipher routine.
+
+**The key crypto observation:** The application is built on React Native with Hermes (Facebook's JavaScript engine for React Native). Java-level Cipher hooks produced no hits during BLE writes, and native libcrypto hooks produced no hits either. This narrowed the AES implementation to **JavaScript** — almost certainly the `aes-js` pure-JS library, which is commonly used inside React Native apps.
+
+**Determining the AES construction:**
+
+With pre-encryption plaintext available via Frida hooks and post-encryption ciphertext available from the BLE captures, the encryption algorithm was discovered by inspection. The cipher does not match any standard mode. Specifically:
+
+```
+Key       = networkKey (16 bytes)
+IV        = rx_header[:4] || init_tx[4:12]      (12 bytes, per-session)
+Counter   = init_tx[12:16] interpreted as little-endian uint32
+Block_in  = IV(12 bytes) || counter_LE(4 bytes)  (16 bytes total)
+Keystream = AES-ECB-Encrypt(Key, Block_in)
+Ciphertext_block = Plaintext_block XOR Keystream
+Counter   = (Counter + 1) mod 2^32   per 16-byte block
+```
+
+This is a CTR-mode-style construction implemented manually using AES-ECB as the keystream generator, rather than using a library's CTR mode primitive directly. Once the `Block_in` layout was identified, all captured ciphertexts decrypted cleanly to valid protobuf-shaped plaintexts.
+
+> **Aside on technique.** Compiled React Native applications package their JavaScript as Hermes bytecode, not as readable JS. Various decompilation tools exist that can convert Hermes bytecode back into approximate JavaScript. This is a *general technique* applicable to any React Native app, and is one approach that **may** be used in scenarios where dynamic instrumentation is insufficient. The crypto construction described above is fully derivable from the *observable behavior* of the cipher (matching plaintext/ciphertext pairs and the structure of the session-init handshake) and does not require static analysis of the application's bytecode.
+
+### Phase 4 — Protobuf Schema Recovery
+
+**Objective:** Decode the structure of the plaintext messages.
+
+**What was done:**
+
+- Decrypted plaintexts were fed to `protoc --decode_raw` to dump field numbers and wire types. Structures repeated consistently between captures.
+- A schema was reconstructed by observation: which field number controls the timer mode, which controls the station ID, which controls the duration in seconds, etc. The schema was confirmed by encoding our own messages from the schema and observing the device respond.
+- The reconstructed schema is documented in [`protobuf-schema.md`](protobuf-schema.md). It is described as a *reconstructed interface description* — it is sufficient to interoperate with the device, not a copy of any vendor source.
+
+### Phase 5 — First Working Valve Command
+
+**Objective:** Open Zone 1.
+
+**What was done:**
+
+- A Python script using `bleak` was written to (a) connect to the device, (b) perform the AES session-init handshake, (c) build a protobuf message requesting Zone 1 ON for 60 seconds, (d) encrypt it, (e) wrap it in the observed frame format `[0x11][length][ciphertext][2-byte trailer]`, and (f) write it to the device's data-channel characteristic.
+- After several iterations to get framing details right, **Zone 1 actuated**. A physical click from the solenoid was audible, water flowed.
+
+**Status at end of Phase 5:** Zone 1 fully working, all four zones encryption/decryption working, but **only Zone 1 actually triggers the device** when sent.
+
+### Phase 6 — The Zone 2-4 Mystery
+
+This is where the project nearly stalled for two sessions. The code that worked perfectly for Zone 1 was identical except for the `stationId` field in the protobuf — which should change from 0 to 1, 2, or 3 to address the other zones. But **only Zone 1 worked**. Zones 2-4 produced no device response, no error, no LCD blink — silent rejection.
+
+Things that were ruled out (each verified by experiment, often after hours of work):
+
+1. **Protobuf encoding errors.** The application's own Zone 3 ON command was captured via `btsnoop`, decrypted, and compared byte-for-byte with the project's Zone 3 plaintext. They were **100% identical**.
+2. **BLE transport differences.** `btmon` traces of the working Zone 1 and the failing Zone 2 commands were captured. Both went out as single unfragmented ACL packets, both used the same ATT opcode, both were confirmed delivered by HCI Number-of-Completed-Packets events.
+3. **ATT Write Command vs Write Request opcode.** The application uses Write Request (0x12) which expects a response. The project's code used Write Command (0x52, fire-and-forget). Switching to Write Request was attempted; the device returned ATT Error 0x80 ("Application Error") for any payload longer than 20 bytes, regardless of MTU/data-length negotiation. This is a known firmware quirk and proved to be a red herring.
+4. **MAC address spoofing.** The Linux host's BLE adapter MAC was spoofed to match the tablet's, on the hypothesis that the device might be tied to the paired peer's address. The device responded identically — **MAC was not the gate**. This was a clean negative result: the device uses application-level validation, not BLE-link-layer identity.
+5. **MTU and LE data length negotiation.** Both were re-negotiated to match the application's values. No effect.
+6. **Sync prelude messages.** The project's code sent timestamp-sync, getDeviceStatusInfo, and getWateringStatus messages before the zone command, mimicking the application's full pre-command sequence. No effect on Zones 2-4.
+7. **`stationId` indexing.** Tried 0-indexed and 1-indexed. The application uses 0-indexed; this was confirmed correct.
+8. **Alternative protobuf fields.** Various other top-level fields were tried (`deviceControl runAllStationsManually`, `autoMode` instead of `manualMode`, etc.). None worked for Zones 2-4.
+
+**The critical observation that broke the case:** Timestamp-sync messages **did** work — meaning the device was reading our messages, decrypting them, and acting on them. The B-Hyve LCD display visibly updated to match the timestamp we set. So the encryption was right, the connection was right, the framing was right. *Something* was specifically rejecting valve commands when `stationId != 0`.
+
+### Phase 7 — The Bit-Flip Diagnostic
+
+**Concept:** AES-CTR (and CTR-style) encryption is fundamentally an XOR with a deterministic keystream. Any bit flipped in the ciphertext flips the same bit in the plaintext after decryption. This means it is possible to *modify* an encrypted message **without knowing the key** as long as you know the plaintext byte at the position you want to change.
+
+**The experiment:** Use Frida to intercept the application's *valid* Zone 1 ON command, XOR specific bytes of the ciphertext to transform it into a Zone 2 ON command, and let the application's authenticated, ATT-Write-Request connection deliver it. If the bit-flipped command works, then there is no integrity-protected portion outside the ciphertext we modified — the device is just being silly about something else. If it fails, then there *is* something else being validated.
+
+**XOR values needed for the Zone-1-to-Zone-2 transformation:**
+- `byte[17] XOR 0x01` — flips `stationId` from 0 to 1
+- `byte[21] XOR 0xB4` — fixes CRC16 byte 1 (the inner protobuf checksum changes when stationId changes)
+- `byte[22] XOR 0x76` — fixes CRC16 byte 2
+
+These were precomputed by encoding both Zone 1 and Zone 2 plaintexts ourselves and XORing them.
+
+**Result:** The bit-flipped Zone 2 command was delivered through the application's own authenticated BLE connection. **Zone 2 did not activate.** The application reported "Your timer didn't respond within 30 seconds."
+
+This was the breakthrough. There **must** be content-dependent integrity protection somewhere outside the AES-encrypted region. The only thing outside the encrypted region was the **2-byte trailer**.
+
+### Phase 8 — The Trailer Algorithm
+
+The frame format is `[0x11][length][ciphertext][trailer_lo][trailer_hi]`. The trailer had previously been treated as either a fixed protocol marker or a transport-layer detail — the project's code hardcoded `b"\x80\x04"` for all valve commands and it had worked for Zone 1.
+
+**The hypothesis:** The trailer is a content-dependent checksum, and `0x0480` is the correct value for Zone 1 *by coincidence*.
+
+**Verification approach:** Captures of the application's own Zone 2, Zone 3, and Zone 4 commands were extracted from `btsnoop`. Their trailers were:
+
+| Command | Captured Trailer |
+|---------|------------------|
+| Zone 1 ON | `0x8004` (LE bytes `80 04`) |
+| Zone 2 ON | `0xa304` |
+| Zone 3 ON | `0xa203` |
+| Zone 4 ON | `0xc403` |
+
+Different for every zone. Hypothesis confirmed: the project's hardcoded `0x8004` was right for Zone 1 only, and Zones 2-4 had been silently rejected because their trailers were wrong.
+
+**Deriving the formula:** With plaintext, ciphertext, and correct trailers known for seven different commands (4 zones plus three sync messages), the trailer formula was determined empirically by trying simple combinations of byte sums and structural elements:
+
+```python
+def compute_trailer(plaintext: bytes) -> bytes:
+    """The 2-byte content-dependent trailer for a B-Hyve BLE frame.
+
+    Args:
+        plaintext: the unencrypted inner message (protobuf + inner CRC16)
+
+    Returns:
+        2 bytes, little-endian uint16
+    """
+    total = sum(plaintext) + 0x11 + len(plaintext)
+    return struct.pack("<H", total & 0xFFFF)
+```
+
+In words: sum every byte of the plaintext, add the magic byte `0x11`, add the length byte, take the low 16 bits, store little-endian. This formula matched **all 7** of the captured commands exactly. The project's hardcoded `0x8004` was, by sheer numerical coincidence, the correct sum-mod-65536 for Zone 1's specific plaintext.
+
+### Phase 9 — All Zones Working
+
+With the trailer fix in place:
+
+- **Zone 2 ON:** confirmed, valve actuated, LCD changed.
+- **Zone 3 ON:** confirmed, valve actuated.
+- **Zone 4 ON:** confirmed, the last unsolved zone, screen lit up with all icons and segments as the relay engaged.
+
+### Phase 10 — Home Assistant Integration
+
+The trailer computation was added to the custom HA integration (in this repo it is computed inline in `BHyveBleConnection.encrypt()`, `custom_components/orbit_bhyve/connection.py`). All four zones became controllable from Home Assistant immediately. The integration uses HA's built-in Bluetooth manager for device access (the same pattern used by upstream HA Bluetooth integrations like SensorPush), which means it does not require a dedicated Bluetooth proxy and works on any HA installation with Bluetooth enabled.
+
+---
+
+## The Trailer Checksum Breakthrough
+
+The trailer turns out to be a textbook example of a defense that looks like decoration. Most BLE protocol layers expect that the cipher provides integrity (CTR mode by itself does not — it is malleable). When a vendor uses CTR-style encryption *without* an authenticated mode (no GCM, no Encrypt-then-MAC), they often add an ad-hoc checksum outside the encryption envelope to detect tampering. Because the checksum is plaintext and looks like a fixed marker for any single captured command, it can easily be overlooked as a constant — until you try a second command and see the trailer change.
+
+**Why "sum of bytes" rather than CRC?** A simple byte sum is not a strong checksum (it cannot reliably detect bit transpositions or many forms of structured tampering), but it is cheap on a small embedded MCU and is sufficient to defeat naive bit-flip attacks: if you flip a bit, you must also adjust the trailer to match, and if you don't know the plaintext you can't compute the new sum. Since the bit-flip attack relies on knowing the *change* between two plaintexts, and the trailer depends on the absolute sum, the trailer effectively acts as a poor-man's MAC.
+
+**Why Zone 1 worked by coincidence:** The trailer is `(sum + 0x11 + len) mod 65536`. For Zone 1's specific plaintext, that happens to equal `0x0480` (little-endian `0x8004`). There is no deeper meaning — it is just where the modular arithmetic landed.
+
+---
+
+## Lessons for BLE Reverse Engineering
+
+These are the lessons from this project, applicable to similar work on other BLE-only consumer devices.
+
+### 1. When some commands work but others don't, check the frame checksum first
+
+Two full sessions were spent investigating BLE transport, ATT opcodes, MTU negotiation, MAC spoofing, device provisioning, and dozens of protobuf variations. The answer was a 2-byte checksum in the unencrypted trailer that happened to be correct for one command by coincidence. **Lesson:** when a single command works and structurally identical commands don't, suspect content-dependent integrity protection outside the cipher envelope.
+
+### 2. The bit-flip attack on CTR-style cipher is a powerful diagnostic, not a real attack
+
+When the cipher is CTR-style, you can freely modify the ciphertext to produce any plaintext you want at any byte position you know. Using this to test *whether the protocol depends on the cipher's integrity* is a clean experiment: if a bit-flipped command is rejected even when delivered through the application's authenticated connection, you know there is integrity protection somewhere outside the cipher.
+
+### 3. Use `btmon` and Wireshark to verify BLE transport before investigating higher layers
+
+Confirming that working and non-working commands were delivered identically at the BLE layer (same opcode, same fragmentation, same Number-of-Completed-Packets) ruled out an entire class of problems immediately and saved enormous time.
+
+### 4. Keep your encryption analysis decoupled from your interaction
+
+Once the cipher was understood, decrypting captures became a one-liner. This was used dozens of times during the Zone-2-4 investigation to compare the application's plaintext against the project's plaintext. **If your encryption is solid, your debugging gets faster every iteration.**
+
+### 5. Set up visual feedback for rapid iteration
+
+A USB webcam pointed at the device's LCD allowed instant confirmation of whether commands took effect. This is a small thing but it cuts the iteration loop from "walk to the device, look, walk back" to "watch a window on your monitor."
+
+### 6. Do not assume trailers are decorative
+
+Bytes after an encrypted payload often carry checksums that the firmware validates. They may look like padding, sequence numbers, or framing markers. Test the hypothesis early — capture multiple distinct commands and compare the trailer values.
+
+### 7. MAC spoofing and BLE address-type changes are rarely the answer
+
+For application-level rejections (which most BLE device rejections are), the problem is almost never the BLE MAC address. Devices that care about identity typically use application-level keys or provisioning, not link-layer address matching.
+
+### 8. Document every failed attempt
+
+Keeping a detailed log of what was tried and why it failed prevents re-testing the same hypotheses and helps identify the correct direction by process of elimination. The list of "things ruled out" in Phase 6 above came directly from such a log.
+
+---
+
+## Acknowledgements
+
+This protocol description is the result of original research against the device, conducted entirely by observation of its own wire-level behavior and analysis of the publicly distributed companion mobile application. No proprietary firmware or vendor source code is reproduced. Where techniques applicable to React Native applications are discussed, they are presented as general approaches to BLE protocol analysis.


### PR DESCRIPTION
Adds a `docs/` folder documenting the local BLE protocol and the reverse-engineering behind it.

## What's included

**Protocol reference** — protobuf "XD" family (HT34A / HT32A / HT25G2, frame magic `0x11`):
- `protocol.md` — authoritative wire spec (GATT, handshake, AES-CTR, `0x11` frame + checksum, `aa 77 5a 0f` app message, command/status catalog)
- `ble-messages.md` — full per-message field/enum tables with example hex
- `hermes-findings.md` — cipher, key architecture, and handshake recovered from the vendor app
- `encryption.md`, `ble-protocol.md`, `protobuf-schema.md` — supporting references

**HT25 "d7-47" family** (frame magic `0x10`): `findings/d7-47-protocol.md`

**How it was reverse-engineered**: `reverse-engineering-journey.md`, `network-key-extraction.md`, and scrubbed research notes under `findings/` — Hermes decompile + cipher, APK findings, phone/btsnoop capture, nRF52840 sniffer setup, BLE5 mesh analysis, and a "dead ends & falsified hypotheses" case study.

`docs/README.md` is the index.

## Provenance & attribution

- `protocol.md`, `ble-messages.md`, and `hermes-findings.md` were contributed by **@anahnymous** in #19 — thank you! Code references have been adapted to this repo's `custom_components/orbit_bhyve/` layout, and commands not yet implemented in the integration are marked as such.
- Everything else is imported from the maintainer's own research and **scrubbed of all device-specific identifiers** (network keys, MAC addresses, home device names).

Incorporates the documentation offered in #19.

## Notes

- Docs-only — no code changes.
- Where earlier notes reached conclusions later shown wrong (writing the key to `0x6c76`, broadcast-only mesh, `d7 47` as a fixed magic, the older inner-frame length interpretation), the docs carry correction/superseded notes rather than presenting them as fact.
