### PR TITLE
feat: unify the protobuf-family devices + real device-read state, reliability & capabilities

### DIFF
--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -7,6 +7,7 @@ only at setup time and on user-triggered refresh; runtime is BLE-only.
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any
 
 import voluptuous as vol
@@ -22,11 +23,13 @@ from .const import (
     CONF_DEFAULT_DURATION,
     CONF_DEVICES,
     CONF_EMAIL,
+    CONF_FLOW_COUNTS_PER_GALLON,
     CONF_IDLE_DISCONNECT,
     CONF_PASSWORD,
     CONF_POLL_IDLE,
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
+    DEFAULT_FLOW_COUNTS_PER_GALLON,
     DEFAULT_IDLE_DISCONNECT,
     DEFAULT_POLL_IDLE,
     DEFAULT_POLL_WATERING,
@@ -63,6 +66,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     idle_disconnect = opts.get(CONF_IDLE_DISCONNECT, DEFAULT_IDLE_DISCONNECT)
     poll_idle = opts.get(CONF_POLL_IDLE, DEFAULT_POLL_IDLE)
     poll_watering = opts.get(CONF_POLL_WATERING, DEFAULT_POLL_WATERING)
+    flow_counts_per_gallon = opts.get(
+        CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
+    )
 
     runtime = EntryRuntime()
     for record in devices:
@@ -72,7 +78,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if (record.get("type") or "").lower() == "bridge":
             continue
         try:
-            device = build_device(hass, record, idle_disconnect_sec=idle_disconnect)
+            device = build_device(
+                hass, record,
+                idle_disconnect_sec=idle_disconnect,
+                flow_counts_per_gallon=flow_counts_per_gallon,
+            )
         except UnsupportedModel as err:
             _LOGGER.warning("%s: %s — skipping", record.get("name"), err)
             continue
@@ -88,6 +98,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     _register_services(hass)
+
+    # Kick a prompt (non-blocking) first poll so an in-progress run / live state
+    # is read within one cycle instead of waiting a full idle interval. Matters
+    # after an HA restart mid-run: without this the valve shows idle until the
+    # next idle-cadence tick. async_request_refresh only *schedules* the poll, so
+    # this doesn't block setup on a slow/deep-sleeping device.
+    for coord in runtime.coordinators.values():
+        await coord.async_request_refresh()
     return True
 
 
@@ -104,8 +122,39 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload entry when options change."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    """Apply changed options IN PLACE — no reload.
+
+    A reload would rebuild every device with a fresh idle DeviceState (wiping an
+    in-progress run's live state) and immediately disconnect+reconnect BLE. Orbit
+    valves allow only ONE BLE session, so reconnecting that fast — before the
+    device/proxy releases the old session — leaves comms broken until something
+    (a full HA restart) clears the stale session. So for our tuning options (flow
+    calibration, poll intervals, idle disconnect) we mutate the live coordinators
+    instead. Device-list/credential changes take a different path
+    (refresh_devices / reauth) that reloads explicitly."""
+    runtime: EntryRuntime | None = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if runtime is None:
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
+    opts = entry.options
+    idle_disconnect = opts.get(CONF_IDLE_DISCONNECT, DEFAULT_IDLE_DISCONNECT)
+    poll_idle = opts.get(CONF_POLL_IDLE, DEFAULT_POLL_IDLE)
+    poll_watering = opts.get(CONF_POLL_WATERING, DEFAULT_POLL_WATERING)
+    flow_counts_per_gallon = opts.get(
+        CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
+    )
+    for coord in runtime.coordinators.values():
+        coord.poll_idle = poll_idle
+        coord.poll_watering = poll_watering
+        coord.device.flow_counts_per_gallon = flow_counts_per_gallon
+        if coord.device.connection is not None:
+            coord.device.connection._idle_sec = idle_disconnect
+        # Re-apply the interval for the current state so a changed cadence takes
+        # effect now (the coordinator re-derives it each poll anyway).
+        coord.update_interval = timedelta(
+            seconds=poll_watering if coord.device.state.is_watering else poll_idle
+        )
+    _LOGGER.debug("%s: options applied in place (no reload)", entry.entry_id)
 
 
 def _register_services(hass: HomeAssistant) -> None:

--- a/custom_components/orbit_bhyve/binary_sensor.py
+++ b/custom_components/orbit_bhyve/binary_sensor.py
@@ -55,6 +55,11 @@ class _BHyveBinarySensorBase(CoordinatorEntity[BHyveDeviceCoordinator], BinarySe
 
 
 class BHyveConnectedBinarySensor(_BHyveBinarySensorBase):
+    """Connectivity: True when the last status poll REACHED the device. Under the
+    ephemeral connect-on-demand model the BLE link is torn down between polls, so
+    this reflects poll-reachability (coherent with the Consecutive timeouts sensor)
+    rather than a live socket."""
+
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/orbit_bhyve/button.py
+++ b/custom_components/orbit_bhyve/button.py
@@ -1,14 +1,15 @@
 """Button platform — per-device sync button.
 
 One ButtonEntity per non-hub device. Pressing it forces a fresh BLE
-connect + 8-step init; the info-ack notification that arrives during
-init carries battery_mV (parsed by devices.base.BHyveBleDeviceBase
-._observe_plaintext), and the coordinator refresh after the press
-pushes the new value into HA.
+connect + 8-step init, then requests a coordinator refresh — which for
+protobuf devices issues a solicited #15 status read (real run-state,
+battery, rain-delay, seconds-remaining), the reliable way to pull live
+state on demand (e.g. to see a program run the poll hasn't caught yet).
+Mesh devices fall back to the connect-time push (battery).
 
-Equivalent to calling the orbit_bhyve.probe_status service, but
-attached to the device card so a non-technical user can refresh battery
-without going through Developer Tools.
+Equivalent to a manual, on-demand version of the periodic status poll,
+attached to the device card so a non-technical user can refresh without
+going through Developer Tools.
 """
 from __future__ import annotations
 
@@ -41,6 +42,11 @@ async def async_setup_entry(
         if coord.device.connection is None:
             continue
         entities.append(BHyveSyncButton(coord))
+        # On-demand flow spot-check for models with a flow sensor (Gen2, not XD):
+        # sample flow NOW (automation hook, or a leak check while idle) rather
+        # than waiting for the watering poll's passive update.
+        if getattr(coord.device, "has_flow", False):
+            entities.append(BHyveCheckFlowButton(coord))
     async_add_entities(entities)
 
 
@@ -65,10 +71,40 @@ class BHyveSyncButton(CoordinatorEntity[BHyveDeviceCoordinator], ButtonEntity):
 
     async def async_press(self) -> None:
         device = self.coordinator.device
-        conn = device.connection
-        if conn is None:
+        if device.connection is None:
             return
         _LOGGER.info("%s: sync requested via button", device.mac)
-        await conn.disconnect()
-        await conn.ensure_connected()
         await self.coordinator.async_request_refresh()
+
+
+class BHyveCheckFlowButton(CoordinatorEntity[BHyveDeviceCoordinator], ButtonEntity):
+    """On-demand flow spot-check (Gen2). Samples the flow sensor now and updates
+    the Flow rate gauge — for automations ('is water actually moving?') and for a
+    leak check while idle (nonzero flow with the valve closed = a stuck valve)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Check flow"
+    _attr_icon = "mdi:water-check"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_check_flow"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    async def async_press(self) -> None:
+        device = self.coordinator.device
+        if device.connection is None:
+            return
+        _LOGGER.info("%s: flow check requested via button", device.mac)
+        await device.read_flow()
+        # Push the freshly-sampled flow_gpm to entities without a full #15 poll.
+        self.coordinator.async_set_updated_data(device.state)

--- a/custom_components/orbit_bhyve/config_flow.py
+++ b/custom_components/orbit_bhyve/config_flow.py
@@ -29,12 +29,14 @@ from .const import (
     CONF_DEFAULT_DURATION,
     CONF_DEVICES,
     CONF_EMAIL,
+    CONF_FLOW_COUNTS_PER_GALLON,
     CONF_IDLE_DISCONNECT,
     CONF_INCLUDE,
     CONF_PASSWORD,
     CONF_POLL_IDLE,
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
+    DEFAULT_FLOW_COUNTS_PER_GALLON,
     DEFAULT_IDLE_DISCONNECT,
     DEFAULT_POLL_IDLE,
     DEFAULT_POLL_WATERING,
@@ -103,6 +105,7 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_IDLE_DISCONNECT: DEFAULT_IDLE_DISCONNECT,
                     CONF_POLL_IDLE: DEFAULT_POLL_IDLE,
                     CONF_POLL_WATERING: DEFAULT_POLL_WATERING,
+                    CONF_FLOW_COUNTS_PER_GALLON: DEFAULT_FLOW_COUNTS_PER_GALLON,
                 },
             )
 
@@ -189,5 +192,9 @@ class BHyveOptionsFlow(config_entries.OptionsFlow):
             vol.Required(CONF_POLL_WATERING,
                          default=opts.get(CONF_POLL_WATERING, DEFAULT_POLL_WATERING)):
                 vol.All(vol.Coerce(int), vol.Range(min=5, max=600)),
+            vol.Required(CONF_FLOW_COUNTS_PER_GALLON,
+                         default=opts.get(CONF_FLOW_COUNTS_PER_GALLON,
+                                          DEFAULT_FLOW_COUNTS_PER_GALLON)):
+                vol.All(vol.Coerce(int), vol.Range(min=1, max=100000)),
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/orbit_bhyve/connection.py
+++ b/custom_components/orbit_bhyve/connection.py
@@ -70,6 +70,7 @@ class BHyveBleConnection:
         *,
         frame_magic: int = 0x10,
         trailer_const: int = 0x10,
+        reply_header: bytes | None = None,
         idle_disconnect_sec: int = 60,
         gatt_settle_ms: int = 300,
     ):
@@ -78,6 +79,12 @@ class BHyveBleConnection:
         self._key = bytes.fromhex(network_key)
         self._frame_magic = frame_magic & 0xFF
         self._trailer_const = trailer_const & 0xFF
+        # First-frame plaintext header used to detect a CTR desync. Protobuf
+        # classes reply with the inner-message header b"\xaa\x77\x5a\x0f"; the
+        # d7-47 mesh classes use a different frame shape ([mesh:2][type][seq]
+        # [routing]...) that legitimately never starts with it, so they pass
+        # None here to skip the header-based desync self-heal entirely.
+        self._reply_header = reply_header
         self._idle_sec = idle_disconnect_sec
         self._gatt_settle_ms = gatt_settle_ms
 
@@ -218,7 +225,11 @@ class BHyveBleConnection:
                 "%s: notif pt=%s (ct=%s)",
                 self.mac, pt.hex(), frame.hex(),
             )
-            if len(pt) >= 4 and pt[:4] != b"\xaa\x77\x5a\x0f":
+            if (
+                self._reply_header is not None
+                and len(pt) >= 4
+                and pt[:4] != self._reply_header
+            ):
                 # Only the FIRST frame of a reply must start with the inner-message
                 # header. A long reply that CTR-streams as consecutive 16-byte blocks
                 # (each its own outer frame) has continuation frames that legitimately
@@ -299,6 +310,14 @@ class BHyveBleConnection:
         return bytes(b ^ k for b, k in zip(plaintext, keystream[:len(plaintext)])), next_ctr
 
     def encrypt(self, plaintext: bytes) -> bytes:
+        if self._iv is None:
+            # A disconnect scheduled via hass.add_job (e.g. a desync self-heal)
+            # can interleave with an in-flight handshake/init sequence across its
+            # awaits and null the session mid-write. Fail cleanly with a typed
+            # error the open-retry can catch, not a TypeError from _aes_keystream.
+            raise BleHandshakeError(
+                f"{self.mac}: cannot encrypt — session cleared (disconnected mid-handshake)"
+            )
         ct, self._tx_ctr = self._aes_xor(self._tx_ctr, plaintext)
         trailer = (sum(plaintext) + self._trailer_const + len(plaintext)) & 0xFFFF
         return bytes([self._frame_magic, len(ct)]) + ct + struct.pack("<H", trailer)

--- a/custom_components/orbit_bhyve/connection.py
+++ b/custom_components/orbit_bhyve/connection.py
@@ -10,10 +10,12 @@ Cipher (verified against 257 captured frames + actuated commands):
   TX counter = uint32_LE(init_tx[12:16]); RX counter = init_tx[16:20].
   Frame = [magic][len][ciphertext (len bytes)][trailer u16_LE].
   Trailer = sum(plaintext) + trailer_const + len.
-WRITE_REQ (response=True) is required — WRITE_CMD is silently dropped. The
-device acks via NOTIFICATION, not an ATT Write Response; the ESPHome BLE proxy
-doesn't relay the (absent) write response, so writes are sent with a capped
-wait (WRITE_ACK_TIMEOUT_SEC) and the notification drain is the real ack.
+Commands use WRITE_REQ (response=True) for its ATT delivery ack; char 6c72 also
+advertises write-without-response, and both modes have been observed to actuate
+the HT34A (fw0107), so WRITE_REQ is a safe default across device classes. The
+device's higher-level ack is a NOTIFICATION, not an ATT Write Response — the
+ESPHome BLE proxy never relays the (absent) write response, so writes wait only
+a capped WRITE_ACK_TIMEOUT_SEC and the notification drain is the real ack.
 """
 from __future__ import annotations
 
@@ -24,6 +26,7 @@ import struct
 from collections.abc import Awaitable, Callable
 
 from bleak import BleakClient
+from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -31,19 +34,26 @@ from .const import AES_CHAR, READ_CHAR, WRITE_CHAR
 
 _LOGGER = logging.getLogger(__name__)
 
-# Cap on waiting for an ATT Write Response that the device never sends (it acks
-# via notification instead). Over a direct link the response arrives in <200ms;
-# over the ESPHome proxy it never comes, so we proceed after this. The device's
-# notification ack arrives in ~50-150ms, so this is a generous floor that still
-# keeps cold-start init (8 writes) under ~7s.
-WRITE_ACK_TIMEOUT_SEC = 0.8
-
-# The connect succeeds even on a weak proxy link, but the post-connect handshake
-# (subscribe + AES read/write) can stall on a marginal signal. Bound it so it
-# fails cleanly instead of wedging the connection, and retry the whole open a
-# few times — a clean retry often catches a good GATT window.
+# A connect can succeed on a weak/proxy link while the post-connect handshake
+# (subscribe + AES write/read) stalls with no natural timeout — wedging the
+# pooled connection for ~30s and leaking it. Bound the handshake and retry the
+# whole open, disconnecting between tries; healthy links pass on attempt 1.
 HANDSHAKE_TIMEOUT_SEC = 10.0
 OPEN_MAX_ATTEMPTS = 3
+
+# The device acks a command via NOTIFICATION, not an ATT Write Response. Over a
+# direct link the (unused) write response still arrives in <200ms, but over an
+# ESPHome BLE proxy it is never relayed — so a response=True write would block
+# ~30s. Cap the wait; the notification drain in send() is the real ack.
+WRITE_ACK_TIMEOUT_SEC = 0.8
+
+# Event-driven drain: the reply usually lands in 50-150ms and a status burst
+# arrives as a few frames, but an ack-then-status reply can gap ~150ms between
+# the small ack and the richer #16 status (observed 147ms in a live capture).
+# So after the first frame, keep the drain window open only until no new frame
+# has arrived for this long — returning ~4x faster than sleeping the full
+# drain_ms, without truncating a multi-frame reply. drain_ms remains the hard cap.
+NOTIF_QUIET_SEC = 0.35
 
 PostHandshakeHook = Callable[["BHyveBleConnection"], Awaitable[None]]
 PlaintextObserver = Callable[[bytes], None]
@@ -61,6 +71,7 @@ class BHyveBleConnection:
         frame_magic: int = 0x10,
         trailer_const: int = 0x10,
         idle_disconnect_sec: int = 60,
+        gatt_settle_ms: int = 300,
     ):
         self.hass = hass
         self.mac = mac
@@ -68,6 +79,7 @@ class BHyveBleConnection:
         self._frame_magic = frame_magic & 0xFF
         self._trailer_const = trailer_const & 0xFF
         self._idle_sec = idle_disconnect_sec
+        self._gatt_settle_ms = gatt_settle_ms
 
         self._client: BleakClient | None = None
         self._iv: bytes | None = None
@@ -75,6 +87,7 @@ class BHyveBleConnection:
         self._rx_ctr: int = 0
         self._lock = asyncio.Lock()
         self._notif_buf: list[bytes] = []
+        self._notif_event = asyncio.Event()  # set on every notification; drives _drain
         self._last_rx_frame: bytes | None = None  # last raw RX frame, for de-dup
         self._handshaken = False
         self._post_handshake_hook: PostHandshakeHook | None = None
@@ -98,30 +111,21 @@ class BHyveBleConnection:
         self._plaintext_observer = observer
 
     async def ensure_connected(self) -> None:
-        """Connect + handshake if not already pooled, retrying the whole open a
-        few times. On a marginal proxy link the connect succeeds but the
-        handshake GATT exchange can stall; a clean retry usually gets through,
-        and the bounded handshake means we fail cleanly rather than wedging.
-        Call inside a lock if you need exclusive access; idempotent otherwise."""
+        """Connect + handshake if not already pooled. _open() retries the whole
+        connect+handshake OPEN_MAX_ATTEMPTS times internally: on a marginal proxy
+        link the connect succeeds but the handshake GATT exchange can stall, and
+        a clean retry usually gets through while the bounded handshake means we
+        fail cleanly rather than wedging. Call inside a lock if you need
+        exclusive access; idempotent otherwise."""
         if self.is_connected and self._handshaken:
             return
-        last_err: Exception | None = None
-        for attempt in range(1, OPEN_MAX_ATTEMPTS + 1):
-            try:
-                await self._open()
-                return
-            except (BleHandshakeError, asyncio.TimeoutError) as err:
-                last_err = err
-                _LOGGER.debug(
-                    "%s: open attempt %d/%d failed: %s",
-                    self.mac, attempt, OPEN_MAX_ATTEMPTS, err,
-                )
-                await self.disconnect()
-                if attempt < OPEN_MAX_ATTEMPTS:
-                    await asyncio.sleep(0.5)
-        raise BleHandshakeError(
-            f"{self.mac}: handshake failed after {OPEN_MAX_ATTEMPTS} attempts: {last_err}"
-        )
+        # _open() already retries OPEN_MAX_ATTEMPTS times internally; don't wrap
+        # it in a second retry loop or the attempts multiply (3x3=9 handshakes,
+        # ~90-150s on a stalling device). One call = one bounded retry budget.
+        try:
+            await self._open()
+        except (BleHandshakeError, asyncio.TimeoutError) as err:
+            raise BleHandshakeError(f"{self.mac}: handshake failed: {err}") from err
 
     async def _open(self) -> None:
         from homeassistant.components.bluetooth import async_ble_device_from_address
@@ -130,45 +134,41 @@ class BHyveBleConnection:
         if ble_device is None:
             raise BleNotConnectable(f"{self.mac}: not in range of any connectable BLE adapter")
 
-        _LOGGER.debug("%s: connecting", self.mac)
-        self._client = await establish_connection(BleakClient, ble_device, self.mac, max_attempts=3)
-        _LOGGER.debug("%s: connected", self.mac)
+        last_err: Exception | None = None
+        for attempt in range(1, OPEN_MAX_ATTEMPTS + 1):
+            try:
+                _LOGGER.debug("%s: connecting (attempt %d/%d)", self.mac, attempt, OPEN_MAX_ATTEMPTS)
+                self._client = await establish_connection(
+                    BleakClient, ble_device, self.mac, max_attempts=3
+                )
+                _LOGGER.debug("%s: connected", self.mac)
+                if self._gatt_settle_ms > 0:
+                    await asyncio.sleep(self._gatt_settle_ms / 1000.0)
+                # Bound the handshake: on a marginal link the connect succeeds
+                # but the GATT exchange below can hang indefinitely.
+                await asyncio.wait_for(self._handshake(), timeout=HANDSHAKE_TIMEOUT_SEC)
+            except (asyncio.TimeoutError, BleakError, OSError, BleHandshakeError) as err:
+                last_err = err
+                _LOGGER.debug(
+                    "%s: open attempt %d/%d failed: %s", self.mac, attempt, OPEN_MAX_ATTEMPTS, err
+                )
+                await self.disconnect()  # clean slate so the retry gets a fresh GATT window
+                if attempt < OPEN_MAX_ATTEMPTS:
+                    await asyncio.sleep(0.5)  # space out retries on a marginal link
+                continue
+            # Handshake succeeded — run the per-device-class init, then we're open.
+            if self._post_handshake_hook is not None:
+                await self._post_handshake_hook(self)
+            return
 
-        # Note: tried writing the provisioning frame [0x01 0x00 || key] to
-        # NETWORK_CHAR (0x6c76) here — char is firmware-locked on every
-        # device tested ("Write not permitted"). Confirmed not the actual
-        # mechanism for fw0041 the v1 commit fad91eae assumed.
-
-        # The post-connect handshake (subscribe + AES read/write) is the part
-        # that stalls on a marginal link, so bound it — ensure_connected()
-        # retries the whole open on timeout.
-        try:
-            await asyncio.wait_for(self._handshake(), timeout=HANDSHAKE_TIMEOUT_SEC)
-        except asyncio.TimeoutError as err:
-            raise BleHandshakeError(
-                f"{self.mac}: handshake timed out after {HANDSHAKE_TIMEOUT_SEC}s"
-            ) from err
-
-        # One-shot GATT enumeration — looking for standard Battery Service
-        # (0x180F / 0x2A19) or anything else the device exposes that we
-        # haven't been using. Logged at INFO for reverse-engineering work.
-        try:
-            for service in self._client.services:
-                _LOGGER.info("%s: gatt svc %s", self.mac, service.uuid)
-                for char in service.characteristics:
-                    _LOGGER.info(
-                        "%s:   char %s props=%s",
-                        self.mac, char.uuid, list(char.properties),
-                    )
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("%s: gatt enum failed: %s", self.mac, err)
-
-        if self._post_handshake_hook is not None:
-            await self._post_handshake_hook(self)
+        raise BleHandshakeError(
+            f"{self.mac}: open failed after {OPEN_MAX_ATTEMPTS} attempts: {last_err}"
+        )
 
     async def _handshake(self) -> None:
         """Subscribe + AES handshake. Bounded by a timeout in _open() because
-        these GATT reads/writes are what stall on a weak link."""
+        these GATT reads/writes are what stall on a weak link. The
+        post-handshake hook and open-retry are driven by _open()."""
         # Subscribe BEFORE writing — device may stay silent otherwise.
         self._notif_buf.clear()
         self._last_rx_frame = None  # fresh CTR stream — don't dedup across sessions
@@ -209,6 +209,7 @@ class BHyveBleConnection:
             return
         self._last_rx_frame = frame
         self._notif_buf.append(frame)
+        self._notif_event.set()  # wake any in-flight drain (see _drain)
         if not self._handshaken or self._iv is None:
             return
         try:
@@ -217,8 +218,30 @@ class BHyveBleConnection:
                 "%s: notif pt=%s (ct=%s)",
                 self.mac, pt.hex(), frame.hex(),
             )
+            if len(pt) >= 4 and pt[:4] != b"\xaa\x77\x5a\x0f":
+                # Only the FIRST frame of a reply must start with the inner-message
+                # header. A long reply that CTR-streams as consecutive 16-byte blocks
+                # (each its own outer frame) has continuation frames that legitimately
+                # do NOT — none of the capabilities wired today produce those, but
+                # Program reads (#19, Phase 4) will. _notif_buf is cleared before each
+                # write, so len<=1 means this is the reply's first frame: a bad header
+                # there is a real CTR desync → self-heal. A bad header on a later frame
+                # is a continuation (or a mid-stream desync we recover on the next
+                # reply), so don't tear the session down under it. (Full multi-frame
+                # reassembly in the observer is deferred to the Programs phase.)
+                if len(self._notif_buf) <= 1:
+                    _LOGGER.warning(
+                        "%s: CTR desync detected (bad header %s) — scheduling disconnect to self-heal",
+                        self.mac, pt[:4].hex(),
+                    )
+                    self.hass.add_job(self.disconnect)
+                return
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("%s: notif decrypt failed: %s raw=%s", self.mac, err, frame.hex())
+            _LOGGER.warning(
+                "%s: CTR desync detected (decrypt failed: %s) — scheduling disconnect to self-heal",
+                self.mac, err,
+            )
+            self.hass.add_job(self.disconnect)
             return
         if self._plaintext_observer is not None:
             try:
@@ -290,14 +313,13 @@ class BHyveBleConnection:
         return pt
 
     async def _write_locked(self, plaintext: bytes) -> None:
-        """Encrypt + WRITE_REQ. Caller MUST already hold self._lock and have
+        """Encrypt + write. Caller MUST already hold self._lock and have
         an established connection. Used by send()/send_raw() and by the
         post-handshake hook (which runs inside _open() inside the lock)."""
         frame = self.encrypt(plaintext)
         assert self._client is not None
-        # WRITE_CHAR (6c72) requires a Write Request (response=True) — the device
-        # silently drops Write Commands. But it answers via NOTIFICATION and, on
-        # some transports (notably the ESPHome Bluetooth proxy), the ATT Write
+        # WRITE_CHAR (6c72) uses a Write Request (response=True). Over some
+        # transports (notably the ESPHome Bluetooth proxy), the ATT Write
         # Response is never relayed back, so a plain response=True write blocks
         # ~30s. Issue the Write Request but cap the wait; the notification drain
         # in send() is the real ack. Over a direct link the response arrives in
@@ -310,14 +332,36 @@ class BHyveBleConnection:
         except asyncio.TimeoutError:
             pass
 
+    async def _drain(self, drain_ms: int) -> None:
+        """Collect the device's reply, returning as soon as it goes quiet
+        instead of always sleeping the full drain window. Wake on the first
+        notification, then hold the window open only while frames keep arriving
+        (NOTIF_QUIET_SEC between them), hard-capped at drain_ms so a silent
+        device still returns on time. Call with _notif_buf freshly cleared."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + drain_ms / 1000.0
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+            # Clear before snapshotting the buffer: a frame arriving from here
+            # on re-sets the event and wakes us; a frame already buffered means
+            # we're settling and should wait only a short quiet window for more.
+            self._notif_event.clear()
+            timeout = min(NOTIF_QUIET_SEC, remaining) if self._notif_buf else remaining
+            try:
+                await asyncio.wait_for(self._notif_event.wait(), timeout)
+            except asyncio.TimeoutError:
+                return  # no new frame within the window -> reply complete (or silent)
+
     async def send(self, plaintext: bytes, *, drain_ms: int = 1500) -> list[bytes]:
-        """Encrypt + WRITE_REQ + drain notifications for `drain_ms`. Returns
-        the list of raw notification frames received."""
+        """Encrypt + WRITE_REQ + drain notifications until the reply goes quiet
+        (bounded by `drain_ms`). Returns the raw notification frames received."""
         async with self._lock:
             await self.ensure_connected()
             self._notif_buf.clear()
             await self._write_locked(plaintext)
-            await asyncio.sleep(drain_ms / 1000.0)
+            await self._drain(drain_ms)
             received = list(self._notif_buf)
             self._notif_buf.clear()
             self._arm_idle_timer()
@@ -333,10 +377,12 @@ class BHyveBleConnection:
     async def send_actuation(self, plaintext: bytes, *, drain_ms: int = 1500) -> list[bytes]:
         """Re-run the per-device init sequence, then send a command — atomically.
 
-        HT25 only honours a watering command in a freshly-initialised session:
-        a pooled connection's bind goes stale, so the command is ack'd but
-        SILENTLY IGNORED (no actuation). Re-run the full init before every
-        actuation rather than trusting the pooled session."""
+        Some devices only honour a watering command in a freshly-initialised
+        session: a pooled connection's per-class bind/init goes stale, so the
+        command is ack'd but SILENTLY IGNORED (no actuation). Re-run the init
+        hook before the command rather than trusting the pooled session. For a
+        device class with no post-handshake hook this is just ensure_connected
+        + send."""
         async with self._lock:
             if self.is_connected and self._handshaken:
                 # Pooled connection — refresh the (possibly stale) bind in place.
@@ -347,7 +393,7 @@ class BHyveBleConnection:
                 await self.ensure_connected()
             self._notif_buf.clear()
             await self._write_locked(plaintext)
-            await asyncio.sleep(drain_ms / 1000.0)
+            await self._drain(drain_ms)
             received = list(self._notif_buf)
             self._notif_buf.clear()
             self._arm_idle_timer()

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -43,11 +43,23 @@ CONF_DEFAULT_DURATION = "default_duration_sec"
 CONF_IDLE_DISCONNECT = "idle_disconnect_sec"
 CONF_POLL_IDLE = "poll_idle_sec"
 CONF_POLL_WATERING = "poll_watering_sec"
+CONF_FLOW_COUNTS_PER_GALLON = "flow_counts_per_gallon"
 
 DEFAULT_DURATION = 600
 DEFAULT_IDLE_DISCONNECT = 60
-DEFAULT_POLL_IDLE = 300
+DEFAULT_POLL_IDLE = 900  # 15 min — an idle status poll (#15) connects over BLE, so keep
+                         # the cadence gentle on the AA-powered valves; most program runs
+                         # last longer and get picked up at least once. Tunable in the
+                         # Configure dialog (Poll idle).
 DEFAULT_POLL_WATERING = 30
+
+# Flow (Gen2 #59.#3) is a CUMULATIVE per-run volume counter in raw device units,
+# not gpm. To convert the counter to gallons, divide by this factor (exposed as
+# the "Flow calibration" option so a user can re-calibrate their own install).
+# DEFAULT MEASURED 2026-07-03 on BTValve01: a 44.5 s flow window logged +1443
+# counts while a bucket collected 3.33 gal over the same window → 1443 / 3.33 ≈
+# 433 counts/gal (self-consistent: 3.33 gal / 44.5 s = 4.49 gpm matches the slope).
+DEFAULT_FLOW_COUNTS_PER_GALLON = 433
 
 # Stored shape per device under entry.data["devices"]:
 #   {

--- a/custom_components/orbit_bhyve/coordinator.py
+++ b/custom_components/orbit_bhyve/coordinator.py
@@ -78,6 +78,12 @@ class BHyveDeviceCoordinator(DataUpdateCoordinator[DeviceState]):
                 state.seconds_remaining = max(
                     0, int((state.expected_off_at - now).total_seconds())
                 )
+        # Rain-delay expiry (wall clock): once the stored end passes, clear the
+        # display immediately rather than waiting for the next status poll — so
+        # "Rain delay" and "Rain delay ends" don't linger past the delay's end.
+        if state.rain_delay_ends is not None and datetime.now(timezone.utc) >= state.rain_delay_ends:
+            state.rain_delay_minutes = 0
+            state.rain_delay_ends = None
         # Adjust polling cadence based on observed state. While watering, if
         # we're inside the final stretch (expiry+grace lands sooner than the
         # next watering-cadence tick would), shorten just enough to land the

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -38,24 +38,24 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         # the hardware suffix or fw so HT25-0000 (fw0041/0085) is untouched.
         if (hardware or "").startswith("HT25G2") or firmware == "0111":
             return BHyveHT25G2Device
-        # fw0085 (Deck) keeps the pre-fix code path that empirically actuated
-        # on 2026-05-03. fw0041 (Hill, Corner) and any future fw use the
-        # parameterized BHyveHT25Device.
+        # HT25-0000 mesh (d7-47) firmwares. fw0085 keeps upstream's thin
+        # subclass (retains _rebind_sid_delta=3, community-verified); fw0041 and
+        # any other fw use the parameterized base, which builds frames from the
+        # device's own mesh_device_id (not a hardcoded identity).
         if firmware == "0085":
             return BHyveHT25Fw0085Device
         return BHyveHT25Device
     if (hardware or "").startswith("HT34"):
         # Both HT34A-0001 and HT34-0001 (fw0058) use the protobuf XD protocol.
-        # HT34A-0001/fw0107 is hardware-verified (issue #16). The older HT34
-        # sharing it is the stuartdenne fork's claim (2026-06-27), still not
-        # independently verified on hardware here.
+        # The older HT34 sharing it is the stuartdenne fork's claim (2026-06-27),
+        # not independently verified on hardware here.
         return BHyveHT34ADevice
     if (hardware or "").startswith("HT32"):
         # HT32A-0001 (fw0107) is the 2-port XD sibling of the HT34A: same
         # firmware, same protobuf-over-CRC16 protocol (magic 0x11), fewer
         # stations. Station count flows from the cloud record, so the 4-port
-        # class handles a 2-port unit unchanged. Verified end-to-end on 3x
-        # HT32A units — open/close actuation confirmed (issue #13).
+        # class handles a 2-port unit unchanged. Untested on hardware here
+        # (issue #13) — same caveat as HT34A.
         return BHyveHT34ADevice
     raise UnsupportedModel(hardware or "?", firmware or "?")
 

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -50,6 +50,12 @@ class BHyveBleDeviceBase(abc.ABC):
     # Per-class overrides — defaults are HT25's values.
     frame_magic: int = 0x10
     trailer_const: int = 0x10
+    # First-frame reply header for the connection's CTR-desync self-heal.
+    # None (the mesh default) disables the header-based check: d7-47 mesh replies
+    # use a [mesh:2][type][seq][routing] shape, not the protobuf inner-message
+    # header, so the check would misfire on every mesh reply. The protobuf class
+    # sets this to b"\xaa\x77\x5a\x0f".
+    reply_header: bytes | None = None
     GATT_SETTLE_MS: int = 300
     # Whether the model exposes an inline flow sensor (#57/#59). Gen2 (HT25G2)
     # only per app captures; the XD has no flow screen. Verify on hardware
@@ -102,6 +108,7 @@ class BHyveBleDeviceBase(abc.ABC):
                 self.network_key,
                 frame_magic=self.frame_magic,
                 trailer_const=self.trailer_const,
+                reply_header=self.reply_header,
                 idle_disconnect_sec=idle_disconnect_sec,
                 gatt_settle_ms=self.GATT_SETTLE_MS,
             )

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import abc
+import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -9,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..connection import BHyveBleConnection
+from ..const import DEFAULT_FLOW_COUNTS_PER_GALLON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,12 +28,19 @@ class DeviceState:
     is_watering: bool = False
     active_zone: int | None = None
     seconds_remaining: int | None = None
+    flow_total: int | None = None  # #59.#3 raw cumulative counter (transient; feeds flow_gpm)
+    flow_gpm: float | None = None  # instantaneous flow rate from read_flow's slope (Gen2)
     started_at: datetime | None = None
     expected_off_at: datetime | None = None
     last_command_at: datetime | None = None
     last_command_label: str | None = None
     is_connected: bool = False
     notifications_last_cmd: int = 0
+    device_clock: int | None = None  # #7 device clock, Unix epoch seconds
+    rain_delay_minutes: int | None = None
+    rain_delay_ends: datetime | None = None
+    last_successful_poll: datetime | None = None
+    consecutive_timeouts: int = 0
     extra: dict[str, Any] = field(default_factory=dict)
 
 
@@ -41,6 +50,11 @@ class BHyveBleDeviceBase(abc.ABC):
     # Per-class overrides — defaults are HT25's values.
     frame_magic: int = 0x10
     trailer_const: int = 0x10
+    GATT_SETTLE_MS: int = 300
+    # Whether the model exposes an inline flow sensor (#57/#59). Gen2 (HT25G2)
+    # only per app captures; the XD has no flow screen. Verify on hardware
+    # before trusting (the `flow` CLI probes both) — see docs/ble_protocol.md.
+    has_flow: bool = False
 
     def __init__(
         self,
@@ -48,8 +62,12 @@ class BHyveBleDeviceBase(abc.ABC):
         record: dict[str, Any],
         *,
         idle_disconnect_sec: int = 60,
+        flow_counts_per_gallon: int = DEFAULT_FLOW_COUNTS_PER_GALLON,
     ):
         self.hass = hass
+        # Counts→gallons scale for the flow sensor (Gen2). Configurable per
+        # install via the options flow; read_flow divides the counter slope by it.
+        self.flow_counts_per_gallon = flow_counts_per_gallon
         self.cloud_id: str = record["cloud_id"]
         self.name: str = record["name"]
         self.mac: str = record["mac"]
@@ -60,8 +78,16 @@ class BHyveBleDeviceBase(abc.ABC):
         self.mesh_device_id: int | None = record.get("mesh_device_id")
         self.bridge_device_id: str | None = record.get("bridge_device_id")
         self.hub_mesh_device_id: int | None = record.get("hub_mesh_device_id")
-        self.battery_pct: int | None = record.get("battery_pct")
-        self.battery_mv: int | None = record.get("battery_mv")
+        # Battery is read LIVE over BLE (#16.#14.#3 / mesh info-ack) and is the
+        # only source we trust. Deliberately NOT seeded from the cloud snapshot in
+        # `record`: the cloud reports on a chemistry-aware discharge curve that
+        # disagrees with our linear _mv_to_pct (esp. for NiMH), so seeding it
+        # painted a wrong value — inconsistent with the voltage sensor — into the
+        # battery sensor's long-term statistics at every startup, until the first
+        # poll replaced it. Start unknown; apply_status_plaintext fills these in
+        # from the device on the first successful poll.
+        self.battery_pct: int | None = None
+        self.battery_mv: int | None = None
         self.network_key: str = record["network_key"]
         self.state = DeviceState()
         # Optional callback a coordinator registers so an out-of-band state
@@ -77,6 +103,7 @@ class BHyveBleDeviceBase(abc.ABC):
                 frame_magic=self.frame_magic,
                 trailer_const=self.trailer_const,
                 idle_disconnect_sec=idle_disconnect_sec,
+                gatt_settle_ms=self.GATT_SETTLE_MS,
             )
             self.connection.set_post_handshake_hook(self._post_handshake)
             self.connection.set_plaintext_observer(self._observe_plaintext)
@@ -94,6 +121,12 @@ class BHyveBleDeviceBase(abc.ABC):
     @property
     def unique_id(self) -> str:
         return f"orbit_bhyve_{self.mac.replace(':', '').lower()}"
+
+    @property
+    def _api_lock(self) -> asyncio.Lock:
+        if not hasattr(self, "_api_lock_var"):
+            self._api_lock_var = asyncio.Lock()
+        return self._api_lock_var
 
     async def async_setup(self) -> None:
         """Hook for device classes that want pre-warming. Default: no-op."""
@@ -115,28 +148,31 @@ class BHyveBleDeviceBase(abc.ABC):
         """Override to send per-class init frames after the AES handshake."""
 
     def _observe_plaintext(self, pt: bytes) -> None:
-        """Parse battery_mV out of every info-ack notification.
+        """Parse d7-47 mesh status replies: battery (seq 0x03) and watering
+        state (seq 0x02).
 
-        d7-47 frame layout: [mesh:2][type:1][seq:1][routing:1][payload:N].
-        seq=0x03 is the device-info command; the response (type byte has
-        the 0x40 reply bit set, routing=0x40) carries a 7-byte payload
-        whose bytes 4-5 are battery voltage as little-endian uint16.
-        Verified against fw0085 (Deck) and fw0041 (Hill, Corner) by
-        cross-checking with cloud snapshots: Hill 2601 vs 2602, Corner
-        2606 vs 2606, Deck May 2 sessions traced 2872→2835 mV (discharge)."""
-        if len(pt) < 12:
+        Frame layout: [mesh:2][type:1][seq:1][routing:1][payload:N]. Replies
+        set the 0x40 reply bit in the type byte and carry routing=0x40 (TX
+        echoes with the bit clear are skipped). Verified against fw0085 (Deck)
+        and fw0041 (Hill, Corner) cross-checked with cloud snapshots."""
+        if len(pt) < 6 or pt[4] != 0x40 or not (pt[2] & 0x40):
             return
-        if pt[3] != 0x03 or pt[4] != 0x40:
-            return
-        if not (pt[2] & 0x40):
-            # TX echoes (response bit clear) carry the same shape; skip.
-            return
-        mv = int.from_bytes(pt[9:11], "little")
-        if not 1500 <= mv <= 4000:
-            # Out-of-band — probably a malformed parse; don't poison state.
-            return
-        self.battery_mv = mv
-        self.battery_pct = _mv_to_pct(mv)
+        seq = pt[3]
+        if seq == 0x03 and len(pt) >= 12:
+            # Info-ack: payload bytes 4-5 (pt[9:11]) are battery mV, LE.
+            mv = int.from_bytes(pt[9:11], "little")
+            if 1500 <= mv <= 4000:  # out-of-band => malformed; don't poison state
+                self.battery_mv = mv
+                self.battery_pct = _mv_to_pct(mv)
+        elif seq == 0x02 and len(pt) >= 6:
+            # Status reply/push: payload[0] (pt[5]) is the watering mode —
+            # 0x04 = watering, 0x01 = idle. Authoritative device state, used to
+            # confirm an actuation actually took.
+            mode = pt[5]
+            if mode == 0x04:
+                self.state.is_watering = True
+            elif mode == 0x01:
+                self.state.is_watering = False
 
     @abc.abstractmethod
     async def start_watering(self, station: int, duration_sec: int) -> bool:

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -240,9 +240,12 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         return notifs
 
     async def refresh_state(self):
-        """Probe the device for an idle/watering status. Best-effort: the
-        watering-status response byte layout isn't fully decoded, so we only
-        update is_connected here. Local optimism (set in start/stop) drives
-        is_watering until full status decoding lands."""
+        """Best-effort liveness refresh: update is_connected from the pooled
+        connection without opening one. is_watering is driven by the device's
+        START/STOP ack (_observe_plaintext) and the coordinator's wall-clock
+        auto-close; the STATUS reply's mode byte is decoded too (base
+        _observe_plaintext, 0x04=watering/0x01=idle), but an idle poll doesn't
+        connect to elicit it, so live idle-poll status would need a connect +
+        STATUS query (future enhancement, needs hardware verification)."""
         await super().refresh_state()
         return self.state

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -189,28 +189,36 @@ class BHyveHT25Device(BHyveBleDeviceBase):
     async def start_watering(self, station: int, duration_sec: int) -> bool:
         if self.connection is None:
             return False
-        # HT25 is single-station; `station` is a no-op placeholder for API parity.
-        # Stash before sending so the START-ack (which can arrive after a write
-        # timeout) can arm the off-timer in _observe_plaintext.
-        self._pending_start_duration = duration_sec
-        self._pending_start_zone = station
-        plaintext = self._build_start(0xB6, duration_sec)
-        _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
-        notifs = await self._send_command(plaintext, "START")
-        self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-        # The off-timer is armed by the device's START-ack (_observe_plaintext),
-        # not by send()'s return — so this holds even when the write-response
-        # times out. Report whatever state the ack has produced by now.
-        return self.state.is_watering
+        try:
+            # HT25 is single-station; `station` is a no-op placeholder for API parity.
+            # Stash before sending so the START-ack (which can arrive after a write
+            # timeout) can arm the off-timer in _observe_plaintext.
+            self._pending_start_duration = duration_sec
+            self._pending_start_zone = station
+            plaintext = self._build_start(0xB6, duration_sec)
+            _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
+            notifs = await self._send_command(plaintext, "START")
+            self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+            # The off-timer is armed by the device's START-ack (_observe_plaintext),
+            # not by send()'s return — so this holds even when the write-response
+            # times out. Report whatever state the ack has produced by now.
+            return self.state.is_watering
+        finally:
+            if self.connection is not None:
+                await self.connection.disconnect()
 
     async def stop_watering(self, station: int | None = None) -> bool:
         if self.connection is None:
             return False
-        plaintext = self._build_stop(0xB7)
-        _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
-        notifs = await self._send_command(plaintext, "STOP")
-        self._stamp_command("stop", len(notifs))
-        return not self.state.is_watering
+        try:
+            plaintext = self._build_stop(0xB7)
+            _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
+            notifs = await self._send_command(plaintext, "STOP")
+            self._stamp_command("stop", len(notifs))
+            return not self.state.is_watering
+        finally:
+            if self.connection is not None:
+                await self.connection.disconnect()
 
     async def _send_command(self, plaintext: bytes, label: str) -> list[bytes]:
         """Send a command frame via send_actuation, which re-runs the bind/init

--- a/custom_components/orbit_bhyve/devices/ht25g2.py
+++ b/custom_components/orbit_bhyve/devices/ht25g2.py
@@ -7,11 +7,11 @@ protocol the older HT25-0000 hose timers (fw0041/0085) speak. Sharing a
 in common; the dispatcher in __init__.py disambiguates by hardware-suffix /
 firmware so these land here instead of on BHyveHT25Device.
 
-Sibling of BHyveHT34ADevice (not a subclass): both are single, independent
-BHyveBleDeviceBase classes that reuse the shared protobuf builder functions
-from ht34a. This keeps the device classes decoupled — matching the pattern
-the rest of devices/ follows — so XD-specific changes can't silently alter
-the Gen2 path.
+The protocol logic lives in `protobuf.BHyveProtobufDevice`, shared with the
+HT34A XD: both are protobuf-family valves differing only in log label and
+station count (1 here, via self.stations). Keeping a distinct class — rather
+than routing the Gen2 prefix straight to the base — preserves the per-model
+docstring/verification record and a stable name for the dispatcher.
 
 Hardware-verified start AND stop on fw0111 valves (BTValve01-04) via the
 standalone CLI, which drives byte-identical protobuf frames. Single station:
@@ -19,44 +19,14 @@ the device exposes one valve, addressed as wire station_id 0 (station 1 - 1).
 """
 from __future__ import annotations
 
-import logging
-
-from .base import BHyveBleDeviceBase
-from .ht34a import _STOP_PB, _build_message, _build_start_pb
-
-_LOGGER = logging.getLogger(__name__)
+from .protobuf import BHyveProtobufDevice
 
 
-class BHyveHT25G2Device(BHyveBleDeviceBase):
+class BHyveHT25G2Device(BHyveProtobufDevice):
     """Gen2 single-station valve (fw0111), protobuf protocol family."""
 
-    frame_magic = 0x11
-    trailer_const = 0x11
-
-    async def start_watering(self, station: int, duration_sec: int) -> bool:
-        if self.connection is None:
-            return False
-        # Single-station device: wire station_id is 0-indexed (station 1 -> 0).
-        plaintext = _build_message(_build_start_pb(station - 1, duration_sec))
-        notifs = await self.connection.send(plaintext, drain_ms=2000)
-        _LOGGER.debug("%s: HT25G2 START station=%d got %d notifications",
-                      self.mac, station, len(notifs))
-        self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-        if notifs:
-            self.state.is_watering = True
-            self.state.active_zone = station
-            self.state.seconds_remaining = duration_sec
-        return bool(notifs)
-
-    async def stop_watering(self, station: int | None = None) -> bool:
-        if self.connection is None:
-            return False
-        plaintext = _build_message(_STOP_PB)
-        notifs = await self.connection.send(plaintext, drain_ms=2000)
-        _LOGGER.debug("%s: HT25G2 STOP got %d notifications", self.mac, len(notifs))
-        self._stamp_command("stop", len(notifs))
-        if notifs:
-            self.state.is_watering = False
-            self.state.active_zone = None
-            self.state.seconds_remaining = None
-        return bool(notifs)
+    log_label = "HT25G2"
+    # Gen2 exposes an inline flow sensor (#57/#59); the XD does not. Verify on
+    # hardware (`bhyve.py flow`) before trusting the reading — see the Phase 3
+    # note in the capability-buildout plan.
+    has_flow = True

--- a/custom_components/orbit_bhyve/devices/ht34a.py
+++ b/custom_components/orbit_bhyve/devices/ht34a.py
@@ -1,221 +1,27 @@
 """HT34A / HT34 (XD timer) device class.
 
 Protobuf-over-CRC16 protocol (the `OrbitPbApi_Message` schema from the APK),
-shared across the XD family. Covers HT34A-0001 (fw0107, originally ported from
-upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) and HT34-0001 (fw0058). Also
-serves the 2-port HT32A-0001 (fw0107), routed here as the XD sibling of the
-4-port HT34A — station count comes from the cloud record, so the same class
-drives a 2-port unit unchanged. Verified end-to-end on 3x HT32A units:
-open/close actuation confirmed (issue #13). The cipher/handshake is shared
-with HT25; only the inner plaintext (protobuf) and magic byte (0x11) differ.
+shared across the XD family. HT34A-0001 (fw0107, originally ported from
+upstream `wxfield/Orbit_B-Hyve_4Port_Controller`) is community-verified against
+firmware 0107 (2026-06): zone start/stop actuate over BLE via Home Assistant,
+both through an ESPHome Bluetooth proxy and a direct adapter. Also covers
+HT34-0001 (fw0058) and the 2-port HT32A-0001 (fw0107), routed here as the XD
+sibling of the 4-port HT34A — station count comes from the cloud record, so the
+same class drives a 2-port unit unchanged (issue #13, untested on hardware). The
+cipher/handshake is shared with HT25; only the inner plaintext (protobuf) and
+magic byte (0x11) differ.
 
-Battery/status decode and watering-state confirmation were ported from the
-stuartdenne fork (PRs #4/#5). The HT34A path is hardware-verified: battery +
-status decode confirmed on a real HT34A-0001/fw0107 (issue #16), and the shared
-XD actuation path is proven via the HT32A sibling (issue #13). The older
-HT34-0001/fw0058 remains unverified — no such unit tested in this repo.
+The protocol logic (framing, cipher, timerMode start/stop, confirm-and-retry,
+protobuf RX status decode) lives in `protobuf.BHyveProtobufDevice`; this class
+only carries the model's log label. Station addressing comes from
+`self.stations` (4 here).
 """
 from __future__ import annotations
 
-import asyncio
-import logging
-import struct
-from datetime import datetime, timedelta, timezone
-
-from .base import BHyveBleDeviceBase, _mv_to_pct
-
-_LOGGER = logging.getLogger(__name__)
-
-MSG_HEADER = bytes([0xAA, 0x77, 0x5A, 0x0F])
+from .protobuf import BHyveProtobufDevice
 
 
-def _crc16_ccitt(data: bytes, init: int = 0) -> int:
-    crc = init
-    for b in data:
-        crc ^= b << 8
-        for _ in range(8):
-            crc = ((crc << 1) ^ 0x1021) if crc & 0x8000 else (crc << 1)
-            crc &= 0xFFFF
-    return crc
+class BHyveHT34ADevice(BHyveProtobufDevice):
+    """4-port XD timer. Ported from upstream; verified on fw0107 over BLE."""
 
-
-def _pb_varint(val: int) -> bytes:
-    r = bytearray()
-    while val > 0x7F:
-        r.append((val & 0x7F) | 0x80)
-        val >>= 7
-    r.append(val & 0x7F)
-    return bytes(r)
-
-
-def _pb_field_varint(f: int, v: int) -> bytes:
-    return _pb_varint((f << 3) | 0) + _pb_varint(v)
-
-
-def _pb_field_bytes(f: int, d: bytes) -> bytes:
-    return _pb_varint((f << 3) | 2) + _pb_varint(len(d)) + d
-
-
-def _build_message(protobuf: bytes) -> bytes:
-    payload_len = len(protobuf) + 2
-    msg = MSG_HEADER + bytes([payload_len, 0x00]) + protobuf
-    crc = struct.pack("<H", _crc16_ccitt(msg, 0))
-    return msg + crc
-
-
-def _build_start_pb(station_id: int, duration_sec: int) -> bytes:
-    station_info = _pb_field_varint(1, station_id) + _pb_field_varint(2, duration_sec)
-    manual_params = _pb_field_bytes(3, station_info)
-    timer_mode = _pb_field_varint(1, 2) + _pb_field_bytes(2, manual_params)
-    return _pb_field_bytes(14, timer_mode)
-
-
-_STOP_PB = bytes.fromhex("720408021200")
-# Read-only request messages (empty sub-messages): getDeviceStatusInfo (field
-# 15) and getBatteryStatus (field 45). The device answers both with the cached
-# key, which is how HT34-0001 compatibility was reported by the fork.
-_GET_STATUS_PB = bytes.fromhex("7a00")
-_GET_BATTERY_PB = bytes.fromhex("ea0200")
-
-
-def _rd_varint(b: bytes, i: int) -> tuple[int, int]:
-    v = 0
-    s = 0
-    while True:
-        x = b[i]
-        i += 1
-        v |= (x & 0x7F) << s
-        if not x & 0x80:
-            return v, i
-        s += 7
-
-
-def _pb_fields(data: bytes):
-    """Yield (field_num, wire_type, value) for one protobuf message level.
-    value is an int for varints, bytes for length-delimited fields."""
-    i = 0
-    n = len(data)
-    while i < n:
-        try:
-            tag, i = _rd_varint(data, i)
-        except IndexError:
-            return
-        fn, wt = tag >> 3, tag & 7
-        if wt == 0:
-            v, i = _rd_varint(data, i)
-            yield fn, 0, v
-        elif wt == 2:
-            ln, i = _rd_varint(data, i)
-            yield fn, 2, data[i:i + ln]
-            i += ln
-        elif wt == 5:
-            yield fn, 5, data[i:i + 4]
-            i += 4
-        elif wt == 1:
-            yield fn, 1, data[i:i + 8]
-            i += 8
-        else:
-            return
-
-
-class BHyveHT34ADevice(BHyveBleDeviceBase):
-    """4-port XD timer (HT34A / HT34), protobuf protocol."""
-
-    frame_magic = 0x11
-    trailer_const = 0x11
-
-    async def _post_handshake(self, conn) -> None:
-        """After the handshake, query battery + status so every connect (sync,
-        command) refreshes them. Replies are parsed in _observe_plaintext."""
-        for pb in (_GET_BATTERY_PB, _GET_STATUS_PB):
-            try:
-                await conn._write_locked(_build_message(pb))
-                await asyncio.sleep(0.4)
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("%s: HT34A post-handshake query failed: %s", self.mac, err)
-
-    def _observe_plaintext(self, pt: bytes) -> None:
-        """Parse protobuf notifications (OrbitPbApi_Message): battery mV from
-        batteryStatus (field 46 -> field 3) and watering state from
-        deviceStatusInfo (field 16)."""
-        if len(pt) < 8 or pt[:4] != MSG_HEADER:
-            return
-        body = pt[6:-2]  # strip AA775A0F + len + pad, and trailing CRC16
-        for fn, wt, val in _pb_fields(body):
-            if fn == 46 and wt == 2:  # batteryStatus
-                for sfn, swt, sval in _pb_fields(val):
-                    if sfn == 3 and swt == 0 and 1500 <= sval <= 4000:
-                        self.battery_mv = sval
-                        self.battery_pct = _mv_to_pct(sval)
-            elif fn == 16 and wt == 2:  # deviceStatusInfo
-                self._parse_status(val)
-
-    def _parse_status(self, val: bytes) -> None:
-        """deviceStatusInfo: field 1 is the run state (1=idle, 4=watering),
-        field 6 is the active-watering block (present only while watering) with
-        field 5 = seconds remaining (counts down) and field 7 = total run time
-        (constant). Hardware-verified on a timed run (HT34A fw0107 + HT25G2 fw0111):
-        6.5 counted 174->138->102 over a 180s run while 6.7 held at 180. These
-        match the vendor names currentTimeRemainingSec / totalRunTimeSec."""
-        status = None
-        remaining = None
-        for fn, wt, v in _pb_fields(val):
-            if fn == 1 and wt == 0:
-                status = v
-            elif fn == 6 and wt == 2:  # active watering block
-                for sfn, swt, sv in _pb_fields(v):
-                    if sfn == 5 and swt == 0:  # field 5 = seconds remaining
-                        remaining = sv
-        if status is not None:
-            self.state.is_watering = status == 4
-            if status != 4:
-                self.state.active_zone = None
-                self.state.seconds_remaining = None
-        if remaining is not None:
-            self.state.seconds_remaining = remaining
-
-    async def _refresh_status(self) -> None:
-        """Query device status; the reply updates state via _observe_plaintext."""
-        if self.connection is not None:
-            await self.connection.send(_build_message(_GET_STATUS_PB), drain_ms=1200)
-
-    async def start_watering(self, station: int, duration_sec: int) -> bool:
-        if self.connection is None:
-            return False
-        # Upstream uses 0-indexed stations on the wire.
-        plaintext = _build_message(_build_start_pb(station - 1, duration_sec))
-        for attempt in range(2):
-            notifs = await self.connection.send(plaintext, drain_ms=2000)
-            self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-            await self._refresh_status()
-            if self.state.is_watering:
-                now = datetime.now(timezone.utc)
-                self.state.active_zone = station
-                self.state.started_at = now
-                self.state.expected_off_at = now + timedelta(seconds=duration_sec)
-                if not self.state.seconds_remaining:
-                    self.state.seconds_remaining = duration_sec
-                _LOGGER.debug("%s: HT34A START confirmed watering", self.mac)
-                return True
-            _LOGGER.warning("%s: HT34A START not confirmed (attempt %d/2)", self.mac, attempt + 1)
-        _LOGGER.error("%s: HT34A START failed to confirm watering", self.mac)
-        return False
-
-    async def stop_watering(self, station: int | None = None) -> bool:
-        if self.connection is None:
-            return False
-        plaintext = _build_message(_STOP_PB)
-        for attempt in range(2):
-            notifs = await self.connection.send(plaintext, drain_ms=2000)
-            self._stamp_command("stop", len(notifs))
-            await self._refresh_status()
-            if not self.state.is_watering:
-                self.state.active_zone = None
-                self.state.seconds_remaining = None
-                self.state.started_at = None
-                self.state.expected_off_at = None
-                _LOGGER.debug("%s: HT34A STOP confirmed idle", self.mac)
-                return True
-            _LOGGER.warning("%s: HT34A STOP not confirmed (attempt %d/2)", self.mac, attempt + 1)
-        _LOGGER.error("%s: HT34A STOP failed to confirm idle", self.mac)
-        return False
+    log_label = "HT34A"

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -127,6 +127,9 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
 
     frame_magic = 0x11
     trailer_const = 0x11
+    # Protobuf replies start with the inner-message header; enables the
+    # connection's CTR-desync self-heal (mesh classes leave this None).
+    reply_header = b"\xaa\x77\x5a\x0f"
     log_label = "protobuf"
 
     def _observe_plaintext(self, pt: bytes) -> None:

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -1,0 +1,468 @@
+"""Protobuf-protocol device family (frame magic 0x11): HT34A XD + HT25G2 Gen2.
+
+These devices share one wire protocol end to end — the same framing, AES-CTR
+cipher, `timerMode` start/stop messages, and protobuf RX status decode. The
+only per-model differences are the human-readable log label and the station
+count (already carried as `self.stations`), so the actuation logic lives once
+here and the per-model modules (`ht34a.py`, `ht25g2.py`) are trivial subclasses.
+
+Per-*protocol* device modules are justified (mesh vs protobuf vs hub); per-
+*model* modules within a protocol are not — collapsing the two identical Gen2/XD
+classes removes a confirm-and-retry implementation that had been written twice.
+
+TX frame builders live here; the RX decode + CRC live in `status.py`. The CRC
+and inner-message header are shared with the RX side, imported rather than
+re-declared, so there is a single source for both directions.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+import time
+from datetime import datetime, timedelta, timezone
+
+from bleak.exc import BleakError
+
+from .base import BHyveBleDeviceBase
+from .status import MSG_HEADER, _crc16_ccitt, apply_status_plaintext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _pb_varint(val: int) -> bytes:
+    r = bytearray()
+    while val > 0x7F:
+        r.append((val & 0x7F) | 0x80)
+        val >>= 7
+    r.append(val & 0x7F)
+    return bytes(r)
+
+
+def _pb_field_varint(f: int, v: int) -> bytes:
+    return _pb_varint((f << 3) | 0) + _pb_varint(v)
+
+
+def _pb_field_bytes(f: int, d: bytes) -> bytes:
+    return _pb_varint((f << 3) | 2) + _pb_varint(len(d)) + d
+
+
+def _build_message(protobuf: bytes) -> bytes:
+    payload_len = len(protobuf) + 2
+    msg = MSG_HEADER + bytes([payload_len, 0x00]) + protobuf
+    crc = struct.pack("<H", _crc16_ccitt(msg, 0))
+    return msg + crc
+
+
+def _build_start_pb(station_id: int, duration_sec: int) -> bytes:
+    station_info = _pb_field_varint(1, station_id) + _pb_field_varint(2, duration_sec)
+    manual_params = _pb_field_bytes(3, station_info)
+    timer_mode = _pb_field_varint(1, 2) + _pb_field_bytes(2, manual_params)
+    return _pb_field_bytes(14, timer_mode)
+
+
+_STOP_PB = bytes.fromhex("720408021200")
+
+# #15 {} — empty getDeviceStatus request. Elicits a full #16 status burst even
+# mid-run (solicited RX is reliable; the unsolicited connect-time push is
+# suppressed while the device is active — watering or rain-delay). This is how
+# we read the REAL run-state after a command: the device
+# answers a start with a #16 status but answers a stop with only a bare #30 ack
+# (no #16), so without this poll a healthy stop can never be confirmed.
+_REQUEST_STATUS_PB = bytes.fromhex("7a00")
+
+# #57 { #1=1000 (intervalMs); #2=2 } — flow-sensor subscribe. The device then
+# streams periodic #59 { #1=flow-active, #3=cumulative } frames that
+# apply_status_plaintext folds into state.flow_total. Byte-identical to the app's
+# flow-screen subscribe (Gen2 capture). Gen2-only in the captures; gated by
+# has_flow so we don't poke a flow-less XD.
+_FLOW_SUBSCRIBE_PB = bytes.fromhex("ca030508e8071002")
+
+# #57 { #1=0 (intervalMs=0); #2=2 } — flow UNSUBSCRIBE. A subscribe leaves the
+# device streaming #59 continuously (it persists across reconnects), which starves
+# the #16 status read on later polls and, left unbounded, wedged a valve
+# (hardware, 2026-07-03). Interval 0 cancels the stream. read_flow always sends
+# this after sampling so we never leave a persistent subscription behind.
+_FLOW_UNSUBSCRIBE_PB = bytes.fromhex("ca030408001002")
+
+# read_flow re-subscribes this many times (~1 s each) to sample the cumulative
+# #59.#3 counter over a few seconds and derive an instantaneous rate from its
+# slope. 4 → ~4 s window: enough counts for a clean slope without holding the
+# radio long. The counter only advances while subscribed, so this is inherently
+# a spot check, not a continuous meter.
+_FLOW_SAMPLE_CYCLES = 4
+
+
+def _gpm_from_samples(samples: list[tuple[float, int]], counts_per_gallon: int) -> float:
+    """Instantaneous gpm from (monotonic_time, cumulative_counts) samples:
+    slope in counts/s × 60 / counts-per-gallon. Returns 0.0 if the counter
+    didn't advance (no flow) or there aren't two usable samples."""
+    if len(samples) >= 2 and counts_per_gallon > 0:
+        dt = samples[-1][0] - samples[0][0]
+        dcounts = samples[-1][1] - samples[0][1]
+        if dt > 0 and dcounts > 0:
+            return round(dcounts / dt * 60 / counts_per_gallon, 2)
+    return 0.0
+
+
+def _build_rain_delay_pb(minutes: int, expiry: int | None) -> bytes:
+    """Rain delay: #17 { #1=minutes; #3=expiryUnixUTC; #4=1 }.
+
+    `minutes=0` clears the delay (bare #17{#1=0}). The device echoes its own
+    authoritative expiry back in #16.#13, which apply_status_plaintext stores.
+    """
+    body = _pb_field_varint(1, minutes)
+    if minutes > 0 and expiry is not None:
+        body += _pb_field_varint(3, expiry) + _pb_field_varint(4, 1)
+    return _pb_field_bytes(17, body)
+
+
+class BHyveProtobufDevice(BHyveBleDeviceBase):
+    """Shared base for protobuf-protocol valves (frame magic 0x11).
+
+    Subclasses set `log_label` for human-readable logging; station count comes
+    from `self.stations` (1 for Gen2, 4 for the XD), so no other override is
+    needed for single- vs multi-station addressing.
+    """
+
+    frame_magic = 0x11
+    trailer_const = 0x11
+    log_label = "protobuf"
+
+    def _observe_plaintext(self, pt: bytes) -> None:
+        # Protobuf-family status decode (live battery + real watering state),
+        # not the d7-47 mesh battery parse the base class does.
+        apply_status_plaintext(self, pt)
+
+    async def refresh_status(self, drain_ms: int = 1500) -> None:
+        """Send #15{} to elicit a full #16 status burst; the decoded run-state,
+        battery, seconds-remaining, and rain-delay fold into self.state via
+        _observe_plaintext. This is the canonical mid-run / post-command read —
+        solicited RX is reliable; the unsolicited push is suppressed while the
+        device is active (watering or rain-delay)."""
+        if self.connection is None:
+            return
+        self._status_parsed = False
+        # For flow-capable devices (Gen2), proactively send #57{#1=0} unsubscribe
+        # before querying status. Otherwise, a lingering flow subscription from
+        # an earlier session/test will stream #59 and completely suppress #16.
+        if self.has_flow:
+            try:
+                await self.connection.send(_build_message(_FLOW_UNSUBSCRIBE_PB), drain_ms=500)
+            except Exception:  # noqa: BLE001
+                pass
+        await self.connection.send(_build_message(_REQUEST_STATUS_PB), drain_ms=drain_ms)
+        if self._status_parsed:
+            return
+        # Connected, but the device returned no #16. Two hardware-observed causes,
+        # both of which leave the BLE link healthy (so the poll otherwise looks
+        # "successful") yet update nothing — battery, run-state, everything stays
+        # frozen on whatever was last known (e.g. the initial cloud snapshot):
+        #   1. A persistent #57 flow subscription (left in device flash by an
+        #      interrupted flow read) streams #59 on every connect, starving the
+        #      #16 reply AND desyncing the pooled RX counter. A same-session retry
+        #      can't recover — only a fresh handshake re-bases the counter.
+        #   2. Some units simply don't answer the passive #15 query at all, but DO
+        #      echo a full #16 in reply to a benign setRainDelay write.
+        # Recover both over the air so a REMOTE operator never needs a physical
+        # battery pull (HW-verified un-wedging BTValve01 (cause 1) and BTValve04
+        # (cause 2) with no site visit).
+        _LOGGER.debug("%s: refresh_status got no status block — recovering", self.mac)
+        await self._recover_status(drain_ms)
+
+    async def _recover_status(self, drain_ms: int) -> None:
+        """Best-effort recovery for a poll that connected but decoded no #16.
+        Never raises — a failed recovery leaves the prior state untouched."""
+        if self.connection is None:
+            return
+        for attempt in range(2):
+            try:
+                # Fresh handshake re-bases the RX counter, clearing a connect-time
+                # #59-stream desync from a persistent subscription.
+                await self.connection.disconnect()
+                if self.has_flow:
+                    # Subscribe to catch the stream while it's synced, THEN
+                    # unsubscribe to both stop it and clear the flash subscription.
+                    # A cold unsubscribe on a desynced session doesn't take;
+                    # subscribing first (which resyncs) is what makes the
+                    # unsubscribe land — HW-proven on a stuck BTValve01.
+                    await self.connection.send(_build_message(_FLOW_SUBSCRIBE_PB), drain_ms=1500)
+                    await self.connection.send(_build_message(_FLOW_UNSUBSCRIBE_PB), drain_ms=800)
+                await self.connection.send(_build_message(_REQUEST_STATUS_PB), drain_ms=drain_ms)
+                if self._status_parsed:
+                    return
+                # #15 still silent: this unit ignores the passive query. A
+                # setRainDelay write echoes the full #16 status. Re-assert the
+                # CURRENTLY known rain-delay state so the write is a no-op that can
+                # never wipe an active delay (bare clear only when none is set).
+                await self.connection.send(
+                    _build_message(self._noop_rain_delay_pb()), drain_ms=drain_ms
+                )
+                if self._status_parsed:
+                    return
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "%s: status recovery attempt %d failed: %s", self.mac, attempt + 1, err
+                )
+
+    def _noop_rain_delay_pb(self) -> bytes:
+        """A setRainDelay (#17) payload that re-asserts the currently known
+        rain-delay state, so sending it is a no-op whose only effect is to elicit
+        the #16 status echo — used to read status from units that ignore #15."""
+        mins = self.state.rain_delay_minutes or 0
+        if mins > 0 and self.state.rain_delay_ends is not None:
+            return _build_rain_delay_pb(mins, int(self.state.rain_delay_ends.timestamp()))
+        return _build_rain_delay_pb(0, None)
+
+    async def read_flow(self) -> None:
+        """Spot-check the flow sensor and set state.flow_gpm (instantaneous rate).
+
+        #59.#3 is a cumulative counter that only advances while subscribed, so we
+        subscribe (#57) once and collect subsequent streamed notifications in the
+        background over ~4 s, sample the counter after each tick, and take its slope:
+        gpm = Δcounts/Δt · 60 / self.flow_counts_per_gallon (the configurable
+        "Flow calibration" option). No flow (or valve closed) → the counter doesn't
+        move → 0 gpm. Flow-capable models only (Gen2). Called on the watering poll
+        (live gauge) and by the Check-flow button / automation (on-demand). ALWAYS
+        unsubscribes (#57{#1=0}) afterwards so it never leaves a persistent #59 stream
+        that would starve the next poll's #16 read."""
+        if self.connection is None or not self.has_flow:
+            return
+        async with self._api_lock:
+            await self._read_flow_locked()
+
+    async def _read_flow_locked(self) -> None:
+        if self.connection is None or not self.has_flow:
+            return
+        try:
+            # Two attempts: a POOLED session whose RX counter has desynced (a dropped
+            # #59 during earlier streaming) decodes every #59 to garbage → no samples.
+            # That's distinct from a genuinely idle valve, which still returns a
+            # decodable #59 (flow 0). So "no decodable #59 at all" means resync: drop
+            # the connection and retry once. A healthy session succeeds on the first
+            # pass with no extra latency (the poll's normal case).
+            for attempt in range(2):
+                self.state.flow_total = None  # ignore any stale counter from before
+                samples: list[tuple[float, int]] = []
+                # Subscribe once
+                await self.connection.send(_build_message(_FLOW_SUBSCRIBE_PB), drain_ms=1200)
+                if self.state.flow_total is not None:
+                    samples.append((time.monotonic(), self.state.flow_total))
+                # Wait and collect subsequent streamed notifications in the background
+                for _ in range(_FLOW_SAMPLE_CYCLES - 1):
+                    await asyncio.sleep(1.2)
+                    if self.state.flow_total is not None:
+                        samples.append((time.monotonic(), self.state.flow_total))
+                if samples or attempt:
+                    self.state.flow_gpm = _gpm_from_samples(samples, self.flow_counts_per_gallon)
+                    return
+                _LOGGER.debug(
+                    "%s: flow read got no decodable #59 — reconnecting to resync", self.mac
+                )
+                await self.connection.disconnect()
+        finally:
+            # Cancel the stream so the next poll's #15 gets a clean #16. This
+            # finally also runs under task CANCELLATION (an HA restart/unload mid
+            # read), so it must be cancellation-safe:
+            #  - never reconnect from here — on a teardown a reconnect races the
+            #    unload and fights the device's single-BLE-session limit (and can
+            #    hang), so only unsubscribe if the session is STILL up;
+            #  - shield the write so a cancellation delivers it instead of dropping
+            #    it mid-flight (CancelledError is a BaseException — it would slip
+            #    past the BleakError/Exception guard otherwise).
+            # A leaked subscription is no longer sticky regardless: _recover_status
+            # self-heals it on a later poll.
+            conn = self.connection
+            if conn is not None and conn.is_connected:
+                try:
+                    await asyncio.shield(
+                        conn.send(_build_message(_FLOW_UNSUBSCRIBE_PB), drain_ms=500)
+                    )
+                except asyncio.CancelledError:
+                    _LOGGER.debug("%s: flow unsubscribe shielded through cancellation", self.mac)
+                except (BleakError, Exception) as err:  # noqa: BLE001
+                    _LOGGER.debug("%s: flow unsubscribe ignored loss: %s", self.mac, err)
+
+    async def refresh_state(self):
+        """Coordinator poll: actually read the device over BLE (#15{}) so HA
+        tracks state the device changed on its own — a scheduled PROGRAM run,
+        an app/button run, an on-device auto-close, or a rain delay expiring —
+        not just HA-issued commands. Runs on the 'Poll idle'/'Poll watering'
+        cadence. Best-effort: a failed poll leaves the last-known state rather
+        than raising, so one out-of-range moment doesn't mark the device
+        unavailable."""
+        async with self._api_lock:
+            if self.connection is not None:
+                try:
+                    await self.refresh_status()
+                    # "Connected" tracks whether the last poll REACHED the device,
+                    # not the momentary BLE link — under the ephemeral model we
+                    # disconnect immediately below, so the live link is always down
+                    # between polls. Poll-reachability is the meaningful signal.
+                    self.state.is_connected = True
+                    if getattr(self, "_status_parsed", False):
+                        # A real #16 was decoded this cycle: this is a genuinely
+                        # successful poll.
+                        self.state.last_successful_poll = datetime.now(timezone.utc)
+                        self.state.consecutive_timeouts = 0
+                        # Flow only means anything mid-run; poll it (Gen2 only)
+                        # once a run is confirmed so the reading tracks watering.
+                        if self.has_flow and self.state.is_watering:
+                            await self._read_flow_locked()
+                    else:
+                        # Reached the device but it returned NO status (a wedge
+                        # recovery couldn't clear this cycle). Do NOT stamp a
+                        # phantom "successful poll" — that false success is exactly
+                        # what masked frozen battery for a whole deploy. Count it so
+                        # the diagnostic sensors (Last successful poll / Consecutive
+                        # timeouts) surface the problem instead of hiding it.
+                        self.state.consecutive_timeouts += 1
+                        _LOGGER.debug(
+                            "%s: %s poll reached device but got no status (%d consecutive)",
+                            self.mac, self.log_label, self.state.consecutive_timeouts,
+                        )
+                except Exception as err:  # noqa: BLE001
+                    self.state.consecutive_timeouts += 1
+                    self.state.is_connected = False
+                    _LOGGER.debug(
+                        "%s: %s status poll failed (%d consecutive): %s",
+                        self.mac, self.log_label, self.state.consecutive_timeouts, err
+                    )
+                finally:
+                    await self.connection.disconnect()
+            return self.state
+
+    async def start_watering(self, station: int, duration_sec: int) -> bool:
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                # Stations are 0-indexed on the wire (station 1 -> 0).
+                plaintext = _build_message(_build_start_pb(station - 1, duration_sec))
+                # The start reply usually carries a #16 status that _observe_plaintext
+                # decodes into self.state.is_watering; if this one didn't, poll #15{} to
+                # read the real run-state before deciding. Retry once with a fresh
+                # session if still unconfirmed.
+                for attempt in range(2):
+                    notifs = await self.connection.send(plaintext, drain_ms=2000)
+                    self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+                    if not self.state.is_watering:
+                        # Give the physical valve solenoid time to actuate and settle
+                        # before querying the status echo.
+                        await asyncio.sleep(1.0)
+                        await self.refresh_status()
+                    if self.state.is_watering:
+                        now = datetime.now(timezone.utc)
+                        self.state.active_zone = station
+                        self.state.started_at = now
+                        # Arm the wall-clock auto-close: the coordinator flips the valve
+                        # closed at expected_off_at even if a later BLE read/stop fails,
+                        # so it can't sit stuck-open on the device's own timer.
+                        self.state.expected_off_at = now + timedelta(seconds=duration_sec)
+                        if not self.state.seconds_remaining:
+                            self.state.seconds_remaining = duration_sec
+                        _LOGGER.debug("%s: %s START confirmed watering", self.mac, self.log_label)
+                        return True
+                    _LOGGER.warning(
+                        "%s: %s START not confirmed (attempt %d/2) — fresh session",
+                        self.mac, self.log_label, attempt + 1,
+                    )
+                    if attempt < 1:
+                        await self.connection.disconnect()
+                _LOGGER.error(
+                    "%s: %s START failed to actuate after retries", self.mac, self.log_label
+                )
+                return False
+            finally:
+                await self.connection.disconnect()
+
+    async def stop_watering(self, station: int | None = None) -> bool:
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                plaintext = _build_message(_STOP_PB)
+                for attempt in range(2):
+                    notifs = await self.connection.send(plaintext, drain_ms=2000)
+                    self._stamp_command("stop", len(notifs))
+                    # Give the physical valve solenoid time to actuate and settle
+                    # before querying the status echo.
+                    await asyncio.sleep(1.0)
+                    # The device answers a stop with a bare #30 ack (no #16 status), so
+                    # the send alone never updates is_watering. Poll #15{} to read the
+                    # real run-state (idle, or run-state 3 if a rain delay is active —
+                    # both are "not watering") before deciding.
+                    await self.refresh_status()
+                    if not self.state.is_watering:
+                        self.state.active_zone = None
+                        self.state.seconds_remaining = None
+                        self.state.started_at = None
+                        self.state.expected_off_at = None
+                        _LOGGER.debug("%s: %s STOP confirmed idle", self.mac, self.log_label)
+                        return True
+                    _LOGGER.warning(
+                        "%s: %s STOP not confirmed (attempt %d/2) — fresh session",
+                        self.mac, self.log_label, attempt + 1,
+                    )
+                    if attempt < 1:
+                        await self.connection.disconnect()
+                _LOGGER.error(
+                    "%s: %s STOP failed to close after retries", self.mac, self.log_label
+                )
+                return False
+            finally:
+                await self.connection.disconnect()
+
+    async def set_rain_delay(self, minutes: int) -> bool:
+        """Set the rain delay to `minutes` (0 clears). Returns True once the
+        device's #16.#13 echo confirms the new state."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                if minutes <= 0:
+                    return await self._clear_rain_delay_unlocked()
+                # Absolute expiry the device enforces. A skew probe (2026-06-30) showed
+                # the device honors #3 LITERALLY (it does not recompute it from #1
+                # minutes), so #3 must be anchored to the *device* clock, not the host
+                # clock — otherwise a clock-skewed device ends the delay early/late by
+                # the skew. Read the device clock first via #15{} (stored on
+                # DeviceState.device_clock by apply_status_plaintext), and fall back to
+                # host UTC only if the device didn't report one this session.
+                await self.refresh_status()
+                base = self.state.device_clock or int(time.time())
+                expiry = base + minutes * 60
+                plaintext = _build_message(_build_rain_delay_pb(minutes, expiry))
+                notifs = await self.connection.send(plaintext, drain_ms=2000)
+                self._stamp_command(f"rain_delay set {minutes}m", len(notifs))
+                # Read back the authoritative #16.#13 echo via #15{} rather than trusting
+                # the set reply's push (which the device suppresses while active).
+                await self.refresh_status()
+                ok = bool(self.state.rain_delay_minutes)
+                _LOGGER.log(
+                    logging.DEBUG if ok else logging.WARNING,
+                    "%s: %s rain-delay set %dm %s",
+                    self.mac, self.log_label, minutes, "confirmed" if ok else "unconfirmed",
+                )
+                return ok
+            finally:
+                await self.connection.disconnect()
+
+    async def clear_rain_delay(self) -> bool:
+        """Clear the rain delay (#17{#1=0}). Returns True once #16.#13 reads off."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            return await self._clear_rain_delay_unlocked()
+
+    async def _clear_rain_delay_unlocked(self) -> bool:
+        try:
+            plaintext = _build_message(_build_rain_delay_pb(0, None))
+            notifs = await self.connection.send(plaintext, drain_ms=2000)
+            self._stamp_command("rain_delay clear", len(notifs))
+            # Confirm the cleared #16.#13 echo via a #15{} read-back.
+            await self.refresh_status()
+            return not self.state.rain_delay_minutes
+        finally:
+            if self.connection is not None:
+                await self.connection.disconnect()

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -1,0 +1,353 @@
+"""Protobuf-family RX status decode (HT34A / HT25G2).
+
+Ported from our standalone CLI's proven decoder (`scripts/bhyve.py`,
+`extract_status`) — hardware-validated against fw0107 (XD) and fw0111
+(Gen2). The device→host notification is an inner message
+`AA 77 5A 0F | payload_len | 00 | protobuf | CRC16-CCITT`; we parse the
+protobuf for battery mV and run-state.
+
+The CRC check is load-bearing here: a notification decrypted with a
+desynced RX counter yields garbage that fails CRC, so consuming only
+CRC-valid frames keeps a momentary counter desync from poisoning state.
+"""
+from __future__ import annotations
+
+import logging
+import struct
+from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
+
+from .base import _mv_to_pct
+
+_LOGGER = logging.getLogger(__name__)
+
+MSG_HEADER = bytes([0xAA, 0x77, 0x5A, 0x0F])
+
+# RX message field numbers (see docs/ble_protocol.md).
+RX_F_CLOCK = 7            # wrapper: device clock, Unix epoch seconds
+RX_F_STATUS = 16          # device status submessage
+RX_F_STATUS_MODE = 1      #   #16.#1: 1=idle, 3=rain-delay, 4=manual running
+RX_F_STATUS_RUNECHO = 2   #   #16.#2: active-run echo { #1=2, #2 { #3 { #1 stationId } } }
+RX_F_RUNECHO_PARAMS = 2   #     #16.#2.#2 manualParams
+RX_F_RUNECHO_STATION = 3  #     #16.#2.#2.#3 stationInfo
+RX_F_STATION_ID = 1       #     #16.#2.#2.#3.#1: stationId (0-indexed; zone = id + 1)
+RX_F_STATUS_PROGRESS = 6  #   #16.#6: run progress (present only while watering)
+# HW-verified 2026-07-05 on BOTH a Gen2 (fw0111) and the XD (fw0107): during a live 180s run
+# #16.#6.#5 counted down 174->138->102 (once per second) while #16.#6.#7 stayed a constant 180.
+# So #5 = remaining, #7 = total — matching knobunc's vendor names (currentTimeRemainingSec /
+# totalRunTimeSec). Our earlier decode read #7 as "remaining" and thus reported a static total;
+# that mislabel — not firmware — was the "static remaining" the auto-close drift-guard papered over.
+RX_F_PROGRESS_REMAINING = 5  # #16.#6.#5: seconds remaining in the active run (counts down)
+RX_F_PROGRESS_TOTAL = 7      # #16.#6.#7: total run-time seconds (constant during the run)
+RX_F_PROGRESS_STATION = 4    # #16.#6.#4: currentStationId — the running station (HW-verified
+                             #   2026-07-05: zone 3 -> 2). Shallow equivalent of #16.#2.#2.#3.#1.
+RX_F_STATUS_RAINDELAY = 13  # #16.#13: rain-delay block { #1=min, #3=expiry, #4=on }
+RX_F_RD_MINUTES = 1       #   #16.#13.#1: rain-delay minutes
+RX_F_RD_EXPIRY = 3        #   #16.#13.#3: rain-delay expiry, Unix epoch seconds
+RX_F_RD_ENABLED = 4       #   #16.#13.#4: rain-delay flag (knobunc: delayType enum, not a bool;
+                          #     any nonzero value = a delay is set). Often absent on a bare clear.
+RX_F_STATUS_BATT = 14     #   #16.#14: battery block { #3 = mV }
+RX_F_BATT_MV = 3          #   battery millivolts (#16.#14.#3 or #46.#3)
+RX_F_BATTERY_REPORT = 46  # standalone battery report { #3 = mV }
+RX_F_WATERING = 59        # flow sensor data (knobunc: FlowSensorData). Gen2 only; XD emits none.
+RX_F_WATERING_ACTIVE = 1  #   #59.#1: knobunc currentFlowRateFrequency_Hz — ~0 when no water moving,
+                          #     so we use it as a "water currently flowing" signal (not "valve open").
+RX_F_FLOW_TOTAL = 3       #   #59.#3: knobunc currentCycleVolumeTicks — CUMULATIVE per-run counter (gpm
+                          #     = its slope). #59.#4 currentFlowRateGpm (float) exists but is unused
+                          #     here pending HW confirmation that it populates.
+RX_F_WATERING_STATUS = 30  # WateringStatus notification { #1 = status enum } — the "stop ack"
+RX_F_WSTATUS_CODE = 1      #   #30.#1: 1=complete, 2=inProgress, 3=pumpDelay, 4=stationComplete,
+                           #   5=stationDelay, 6=programPreDelay, 7=programPostDelay
+                           #   (enum per knobunc's PROTOCOL_SPEC; 1=complete corroborated by our
+                           #   own stop reply #30{#1=1}). Terminal/absent => not watering.
+RX_WSTATUS_ACTIVE = (2, 3, 5, 6, 7)  # in-progress + delay states = a run is still active
+
+
+def _crc16_ccitt(data: bytes, init: int = 0) -> int:
+    crc = init
+    for b in data:
+        crc ^= b << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) if crc & 0x8000 else (crc << 1)
+            crc &= 0xFFFF
+    return crc
+
+
+def _read_varint(data: bytes, i: int):
+    shift = 0
+    result = 0
+    while i < len(data):
+        b = data[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            return result, i
+        shift += 7
+    return None, i
+
+
+def pb_parse(data: bytes):
+    """Parse protobuf to a list of (field, wire, value), or None if malformed."""
+    fields = []
+    i = 0
+    while i < len(data):
+        tag, i = _read_varint(data, i)
+        if tag is None:
+            return None
+        field, wire = tag >> 3, tag & 7
+        if wire == 0:
+            val, i = _read_varint(data, i)
+            if val is None:
+                return None
+            fields.append((field, wire, val))
+        elif wire == 2:
+            ln, i = _read_varint(data, i)
+            if ln is None or i + ln > len(data):
+                return None
+            fields.append((field, wire, data[i:i + ln]))
+            i += ln
+        elif wire == 5:
+            if i + 4 > len(data):
+                return None
+            fields.append((field, wire, data[i:i + 4]))
+            i += 4
+        elif wire == 1:
+            if i + 8 > len(data):
+                return None
+            fields.append((field, wire, data[i:i + 8]))
+            i += 8
+        else:
+            return None  # groups / unknown wire types
+    return fields
+
+
+def decode_inner(pt: bytes):
+    """Validate the inner message CRC and return its protobuf, or None."""
+    if len(pt) < 6 or pt[:4] != MSG_HEADER:
+        return None
+    payload_len = pt[4]
+    pb_end = 4 + payload_len
+    if payload_len < 2 or pb_end + 2 > len(pt):
+        return None
+    protobuf = pt[6:pb_end]
+    crc_rx = struct.unpack("<H", pt[pb_end:pb_end + 2])[0]
+    if crc_rx != _crc16_ccitt(pt[:pb_end], 0):
+        return None
+    return protobuf
+
+
+def _pb_field(fields, num):
+    for field, _wire, val in fields or ():
+        if field == num:
+            return val
+    return None
+
+
+def _pb_path(fields, *nums):
+    """Walk nested length-delimited submessages by field number, returning the
+    final field's value (or None if any hop is missing / not a submessage)."""
+    cur = fields
+    for n in nums[:-1]:
+        blob = _pb_field(cur, n)
+        if not isinstance(blob, (bytes, bytearray)):
+            return None
+        cur = pb_parse(blob)
+    return _pb_field(cur, nums[-1])
+
+
+def _pb_subfield(fields, outer, inner):
+    return _pb_path(fields, outer, inner)
+
+
+class DeviceStatus(NamedTuple):
+    run_state: int | None        # #16.#1: 1=idle, 3=rain-delay, 4=running
+    is_watering: bool | None     # derived from #16.#1 / #59.#1
+    battery_mv: int | None       # #16.#14.#3 or standalone #46.#3
+    device_clock: int | None = None        # #7 device clock, Unix epoch seconds
+    active_station: int | None = None      # #16.#6.#4 (fallback #16.#2.#2.#3.#1), 0-indexed (zone = +1)
+    seconds_remaining: int | None = None   # #16.#6.#5 (counts down), present only while watering
+    flow_total: int | None = None          # #59.#3 cumulative volume counter (Gen2)
+    rain_delay_minutes: int | None = None  # #16.#13.#1
+    rain_delay_expiry: int | None = None   # #16.#13.#3, Unix epoch seconds
+    rain_delay_active: bool | None = None  # #16.#13.#4
+
+
+def extract_status(protobuf: bytes) -> DeviceStatus:
+    top = pb_parse(protobuf)
+    if top is None:
+        return DeviceStatus(None, None, None)
+
+    run_state = battery_mv = is_watering = seconds_remaining = None
+    active_station = rd_minutes = rd_expiry = rd_active = None
+
+    device_clock = _pb_field(top, RX_F_CLOCK)     # #7 wrapper field
+    status = _pb_field(top, RX_F_STATUS)          # #16 submessage
+    if isinstance(status, (bytes, bytearray)):
+        sfields = pb_parse(status)
+        run_state = _pb_field(sfields, RX_F_STATUS_MODE)
+        battery_mv = _pb_subfield(sfields, RX_F_STATUS_BATT, RX_F_BATT_MV)
+        # Which zone is running: prefer the shallow #16.#6.#4 (currentStationId,
+        # HW-verified), fall back to the deep timerMode path #16.#2.#2.#3.#1.
+        active_station = _pb_subfield(sfields, RX_F_STATUS_PROGRESS, RX_F_PROGRESS_STATION)
+        if not isinstance(active_station, int):
+            active_station = _pb_path(
+                sfields, RX_F_STATUS_RUNECHO, RX_F_RUNECHO_PARAMS,
+                RX_F_RUNECHO_STATION, RX_F_STATION_ID,
+            )
+        # Remaining is #16.#6.#5 on both Gen2 and XD (HW-verified 2026-07-05). #16.#6.#7
+        # is the constant total, so it must NOT be used as a fallback here.
+        seconds_remaining = _pb_subfield(
+            sfields, RX_F_STATUS_PROGRESS, RX_F_PROGRESS_REMAINING
+        )
+        if not isinstance(seconds_remaining, int):
+            seconds_remaining = None
+        rd = _pb_field(sfields, RX_F_STATUS_RAINDELAY)   # #16.#13
+        if isinstance(rd, (bytes, bytearray)):
+            rdf = pb_parse(rd)
+            rd_minutes = _pb_field(rdf, RX_F_RD_MINUTES)
+            rd_expiry = _pb_field(rdf, RX_F_RD_EXPIRY)
+            enabled = _pb_field(rdf, RX_F_RD_ENABLED)
+            # A cleared delay echoes a bare #13{#1=0} (no #4), so don't leave
+            # active=None there or the clear is dropped — derive it from minutes
+            # when #4 is absent.
+            if enabled is not None:
+                rd_active = bool(enabled)
+            elif rd_minutes is not None:
+                rd_active = rd_minutes > 0
+            else:
+                rd_active = None
+            # Run-state is authoritative. #16.#13 is NOT cleared when a delay expires —
+            # it lingers stale as {#1:mins, #3:<past>, #4:1} (HW-verified 2026-07-05, both
+            # families), so the block alone would report a phantom active delay. A
+            # run-state other than 3 (rain-delay) means no delay is active, period.
+            if run_state is not None and run_state != 3:
+                rd_active = False
+
+    if battery_mv is None:                         # standalone #46.#3
+        battery_mv = _pb_subfield(top, RX_F_BATTERY_REPORT, RX_F_BATT_MV)
+
+    # ONLY #16.#1 run_state drives is_watering — it is authoritative for whether
+    # the valve is open. #59.#1 ("water currently flowing") deliberately does NOT
+    # touch is_watering: letting a #59 assert "watering" latched HA on when the
+    # #16 read was being starved by an active flow subscription, so the valve
+    # stayed "open" long after the run ended (hardware, 2026-07-03). #59 now
+    # contributes only the flow counter below.
+    if run_state is not None:
+        is_watering = run_state == 4
+    elif _pb_field(top, RX_F_WATERING_STATUS) is not None:
+        # A #30 WateringStatus notification (the "stop ack") arrives without a #16.
+        # Decode its status enum instead of blindly idling on any #30: terminal
+        # states (1=complete, 4=stationComplete) and a bare #30 mean not watering
+        # — our observed stop reply is #30{#1=1}=complete — while in-progress/delay
+        # states (2,3,5,6,7) mean a run is still active, so we must NOT idle the valve
+        # on those. (Enum per knobunc's PROTOCOL_SPEC; the non-terminal codes aren't
+        # yet observed here, so this only *refines* the old "any #30 => idle".)
+        ws = _pb_subfield(top, RX_F_WATERING_STATUS, RX_F_WSTATUS_CODE)
+        is_watering = ws in RX_WSTATUS_ACTIVE
+    flow_total = _pb_subfield(top, RX_F_WATERING, RX_F_FLOW_TOTAL)   # #59.#3 cumulative
+
+    return DeviceStatus(
+        run_state=run_state,
+        is_watering=is_watering,
+        battery_mv=battery_mv,
+        device_clock=device_clock,
+        active_station=active_station,
+        seconds_remaining=seconds_remaining,
+        flow_total=flow_total,
+        rain_delay_minutes=rd_minutes,
+        rain_delay_expiry=rd_expiry,
+        rain_delay_active=rd_active,
+    )
+
+
+def apply_status_plaintext(device, pt: bytes) -> None:
+    """Plaintext observer for protobuf-family devices: decode a CRC-valid
+    status notification and update the device's live battery + watering state.
+    Non-status / desynced frames fail CRC and are ignored."""
+    protobuf = decode_inner(pt)
+    if protobuf is None:
+        return
+    st = extract_status(protobuf)
+
+    if st.device_clock is not None:
+        # Device's own Unix clock — used to anchor the rain-delay absolute expiry
+        # (#3) to the device rather than the host, since the device honors #3
+        # literally (a host/device skew would otherwise end the delay early/late).
+        device.state.device_clock = st.device_clock
+
+    if st.battery_mv is not None and 1500 <= st.battery_mv <= 4000:
+        device.battery_mv = st.battery_mv
+        device.battery_pct = _mv_to_pct(st.battery_mv)
+
+    # Raw cumulative flow counter (#59.#3) — record whenever a #59 carries it,
+    # regardless of the flow-active flag, so read_flow can sample its slope even
+    # across a momentary #59.#1=0. It's transient; the gauge value is flow_gpm.
+    if st.flow_total is not None:
+        device.state.flow_total = st.flow_total
+
+    if st.is_watering is not None:
+        device.state.is_watering = st.is_watering
+        if hasattr(device, "_status_parsed"):
+            device._status_parsed = True
+        if st.is_watering:
+            # Which zone is running (#16.#2.#2.#3.#1). Without this a poll- or
+            # app-discovered run leaves active_zone=None, and every zone entity
+            # on a multi-station device (the XD) renders open — not just the one
+            # actually watering.
+            if st.active_station is not None:
+                device.state.active_zone = st.active_station + 1
+            if st.seconds_remaining is not None:
+                device.state.seconds_remaining = st.seconds_remaining
+                # Re-anchor the wall-clock auto-close to the device's own
+                # remaining, so a poll-discovered run (program/app/button) gets
+                # a live countdown and closes cleanly even between polls.
+                # Guard: only ever move expected_off_at EARLIER, never later, so
+                # a re-discovered / re-reported run can't keep postponing the
+                # close — a wall-clock backstop if the device stops answering
+                # mid-run. (#16.#6.#5 counts down correctly on both families, so
+                # in steady state new_off_at holds ~constant; the guard just
+                # bounds anomalies, not the old #6.#7 static-total mis-read.)
+                new_off_at = datetime.now(timezone.utc) + timedelta(seconds=st.seconds_remaining)
+                if (
+                    device.state.expected_off_at is None
+                    or new_off_at < device.state.expected_off_at - timedelta(seconds=15)
+                ):
+                    device.state.expected_off_at = new_off_at
+        else:
+            device.state.active_zone = None
+            device.state.seconds_remaining = None
+            device.state.flow_total = None
+            device.state.flow_gpm = 0.0  # valve closed → no flow
+            device.state.started_at = None
+            device.state.expected_off_at = None
+
+    if st.rain_delay_active is not None:
+        if st.rain_delay_active and st.rain_delay_minutes:
+            device.state.rain_delay_minutes = st.rain_delay_minutes
+            device.state.rain_delay_ends = (
+                datetime.fromtimestamp(st.rain_delay_expiry, tz=timezone.utc)
+                if st.rain_delay_expiry
+                else None
+            )
+        else:
+            device.state.rain_delay_minutes = 0
+            device.state.rain_delay_ends = None
+    elif st.run_state is not None and st.run_state != 3:
+        # Run-state says not rain-delayed and this status carried no #16.#13 block.
+        # (When a block IS present, extract_status already forces rain_delay_active
+        # False for run-state != 3 — the device does NOT clear #16.#13 on expiry, it
+        # lingers stale.) Clear any stale value so the number / "ends" don't linger
+        # after expiry (the "7 hours ago" bug).
+        device.state.rain_delay_minutes = 0
+        device.state.rain_delay_ends = None
+
+    if (
+        st.battery_mv is not None
+        or st.is_watering is not None
+        or st.rain_delay_active is not None
+    ):
+        _LOGGER.debug(
+            "%s: live status battery=%smv watering=%s run_state=%s remaining=%ss rain_delay=%s",
+            device.mac, st.battery_mv, st.is_watering, st.run_state,
+            st.seconds_remaining, st.rain_delay_minutes,
+        )

--- a/custom_components/orbit_bhyve/number.py
+++ b/custom_components/orbit_bhyve/number.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.number import (
+    NumberEntity,
     NumberMode,
     RestoreNumber,
 )
@@ -21,11 +22,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_DEFAULT_DURATION, DEFAULT_DURATION, DOMAIN
 from .coordinator import BHyveDeviceCoordinator
 from .devices import BHyveHubDevice
+from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 MIN_MINUTES = 1
 MAX_MINUTES = 1440  # 24h
+
+MAX_RAIN_DELAY_HOURS = 168  # 7 days — matches the B-Hyve app's ceiling
 
 
 async def async_setup_entry(
@@ -35,11 +39,14 @@ async def async_setup_entry(
 ) -> None:
     runtime = hass.data[DOMAIN][entry.entry_id]
     default_duration_sec = entry.options.get(CONF_DEFAULT_DURATION, DEFAULT_DURATION)
-    entities: list[BHyveDurationNumber] = []
+    entities: list[NumberEntity] = []
     for coord in runtime.coordinators.values():
         if isinstance(coord.device, BHyveHubDevice):
             continue
         entities.append(BHyveDurationNumber(coord, default_duration_sec))
+        # Rain delay is a protobuf-family (HT34A/HT25G2) capability.
+        if isinstance(coord.device, BHyveProtobufDevice):
+            entities.append(BHyveRainDelayNumber(coord))
     async_add_entities(entities)
 
 
@@ -86,3 +93,47 @@ class BHyveDurationNumber(CoordinatorEntity[BHyveDeviceCoordinator], RestoreNumb
         self._attr_native_value = float(minutes)
         self.coordinator.preferred_duration_sec = minutes * 60
         self.async_write_ha_state()
+
+
+class BHyveRainDelayNumber(CoordinatorEntity[BHyveDeviceCoordinator], NumberEntity):
+    """Rain delay in hours; 0 clears it. Reflects the device's live state
+    (the #16.#13 echo), so it is not a RestoreNumber — the device is truth."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Rain delay"
+    _attr_icon = "mdi:weather-rainy"
+    _attr_native_min_value = 0
+    _attr_native_max_value = MAX_RAIN_DELAY_HOURS
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_rain_delay"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        minutes = state.rain_delay_minutes
+        if not minutes:
+            return 0.0
+        return round(minutes / 60, 1)
+
+    async def async_set_native_value(self, value: float) -> None:
+        hours = max(0.0, min(MAX_RAIN_DELAY_HOURS, value))
+        device = self.coordinator.device
+        if hours <= 0:
+            await device.clear_rain_delay()
+        else:
+            await device.set_rain_delay(int(round(hours * 60)))
+        await self.coordinator.async_request_refresh()

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -7,13 +7,21 @@ discharge approximation (`devices.base._mv_to_pct`).
 """
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from datetime import datetime
+
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfElectricPotential,
+    UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,6 +29,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
+from .devices.base import _mv_to_pct
+from .devices.protobuf import BHyveProtobufDevice
 
 
 async def async_setup_entry(
@@ -32,15 +42,24 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
     for coord in runtime.coordinators.values():
         device = coord.device
+        # Every BLE device reports battery over RX; create both sensors so the
+        # percent entity exists regardless of whether the cloud snapshot
+        # happened to include a pct (the XD reports mv-only). Hubs / key-less
+        # records have no BLE connection and no battery/signal to read.
         if device.connection is None:
-            # Hubs / key-less records have no BLE battery or signal to report.
             continue
-        # Battery comes from the device's info-ack at runtime, so create the
-        # sensors unconditionally rather than gating on the cloud-cached value
-        # (which is None for BT-only devices the cloud never primed).
         entities.append(BHyveBatterySensor(coord))
         entities.append(BHyveBatteryVoltageSensor(coord))
         entities.append(BHyveRssiSensor(coord))
+        entities.append(BHyveLastSuccessfulPollSensor(coord))
+        entities.append(BHyveConsecutiveTimeoutsSensor(coord))
+        entities.append(BHyveWateringEndsSensor(coord))
+        # Rain delay is a protobuf-family (HT34A/HT25G2) capability.
+        if isinstance(device, BHyveProtobufDevice):
+            entities.append(BHyveRainDelayEndsSensor(coord))
+        # Flow-rate gauge only for models with a flow sensor (Gen2, not the XD).
+        if getattr(device, "has_flow", False):
+            entities.append(BHyveFlowRateSensor(coord))
     async_add_entities(entities)
 
 
@@ -60,7 +79,25 @@ class _BHyveDeviceSensorBase(CoordinatorEntity[BHyveDeviceCoordinator], SensorEn
         }
 
 
-class BHyveBatterySensor(_BHyveDeviceSensorBase):
+class _RestoreLastValueSensor(_BHyveDeviceSensorBase, RestoreSensor):
+    """Restores its last LIVE reading across a restart, so it shows the last real
+    value instead of blipping to `unavailable` until the first poll. Right for
+    slow-moving battery state (last-known is the sensible default) — and, since we
+    no longer seed battery from the cloud, this is what fills the startup gap. A
+    live device value always wins; `self._restored_value` is only the fallback."""
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._restored_value: float | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None and last.native_value is not None:
+            self._restored_value = last.native_value
+
+
+class BHyveBatterySensor(_RestoreLastValueSensor):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -72,11 +109,16 @@ class BHyveBatterySensor(_BHyveDeviceSensorBase):
         self._attr_name = "Battery"
 
     @property
-    def native_value(self) -> int | None:
-        return self.coordinator.device.battery_pct
+    def native_value(self) -> float | None:
+        device = self.coordinator.device
+        if device.battery_pct is not None:
+            return device.battery_pct
+        if device.battery_mv is not None:
+            return _mv_to_pct(device.battery_mv)
+        return self._restored_value
 
 
-class BHyveBatteryVoltageSensor(_BHyveDeviceSensorBase):
+class BHyveBatteryVoltageSensor(_RestoreLastValueSensor):
     _attr_device_class = SensorDeviceClass.VOLTAGE
     _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -89,8 +131,9 @@ class BHyveBatteryVoltageSensor(_BHyveDeviceSensorBase):
         self._attr_name = "Battery voltage"
 
     @property
-    def native_value(self) -> int | None:
-        return self.coordinator.device.battery_mv
+    def native_value(self) -> float | None:
+        mv = self.coordinator.device.battery_mv
+        return mv if mv is not None else self._restored_value
 
 
 class BHyveRssiSensor(_BHyveDeviceSensorBase):
@@ -109,3 +152,116 @@ class BHyveRssiSensor(_BHyveDeviceSensorBase):
     @property
     def native_value(self) -> int | None:
         return self.coordinator.device.rssi
+
+
+class BHyveFlowRateSensor(_BHyveDeviceSensorBase):
+    """Instantaneous flow rate (gpm) from the last flow spot-check (Gen2).
+
+    Deliberately NOT a cumulative water meter: #59.#3's counter only advances
+    while a #57 subscription is live, so HA never sees the whole run — a
+    cumulative total would badly undercount. Instead `read_flow` samples the
+    counter's slope over a few seconds and stores an instantaneous gpm here.
+    Updated automatically on the watering poll (live during a run) and on demand
+    (Check-flow button / automation).
+
+    `state_class = MEASUREMENT`: each reading is a real ~4 s slope of actual flow,
+    so long-term avg/min/max statistics are honest. For cumulative gallons, add
+    HA's built-in Riemann-sum Integration helper on this entity (see the README)
+    — that integrates the rate into a proper volume total; the raw counter can't
+    be a passive meter here. See docs/ble_protocol.md.
+    """
+
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
+    _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:water"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_flow_rate"
+        self._attr_name = "Flow rate"
+
+    @property
+    def native_value(self) -> float | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.flow_gpm
+
+
+class BHyveRainDelayEndsSensor(_BHyveDeviceSensorBase):
+    """Timestamp when the active rain delay expires; None when off."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:weather-rainy"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_rain_delay_ends"
+        self._attr_name = "Rain delay ends"
+
+    @property
+    def native_value(self) -> datetime | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.rain_delay_ends
+
+
+class BHyveLastSuccessfulPollSensor(_BHyveDeviceSensorBase):
+    """Timestamp of the last successful BLE status poll (#15{})."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:clock-check-outline"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_last_successful_poll"
+        self._attr_name = "Last successful poll"
+
+    @property
+    def native_value(self) -> datetime | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.last_successful_poll
+
+
+class BHyveConsecutiveTimeoutsSensor(_BHyveDeviceSensorBase):
+    """Number of consecutive failed BLE status polls."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:counter"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_consecutive_timeouts"
+        self._attr_name = "Consecutive timeouts"
+
+    @property
+    def native_value(self) -> int:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.consecutive_timeouts
+
+
+class BHyveWateringEndsSensor(_BHyveDeviceSensorBase):
+    """When the active run is expected to auto-close (state.expected_off_at).
+
+    A single wall-clock timestamp (HA renders it as a live relative countdown),
+    not a per-second integer — so it doesn't churn the recorder. Reads `unknown`
+    when the valve is idle. The coordinator arms expected_off_at on start,
+    re-anchors it via the drift-guard, and clears it on close."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:sprinkler"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_watering_ends"
+        self._attr_name = "Watering ends"
+
+    @property
+    def native_value(self) -> datetime | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.expected_off_at

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -43,7 +43,8 @@
           "default_duration_sec": "Default watering duration (seconds)",
           "idle_disconnect_sec": "Disconnect after idle (seconds)",
           "poll_idle_sec": "State polling interval — idle (seconds)",
-          "poll_watering_sec": "State polling interval — watering (seconds)"
+          "poll_watering_sec": "State polling interval — watering (seconds)",
+          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)"
         }
       }
     }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -43,7 +43,8 @@
           "default_duration_sec": "Default watering duration (seconds)",
           "idle_disconnect_sec": "Disconnect after idle (seconds)",
           "poll_idle_sec": "State polling interval — idle (seconds)",
-          "poll_watering_sec": "State polling interval — watering (seconds)"
+          "poll_watering_sec": "State polling interval — watering (seconds)",
+          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)"
         }
       }
     }

--- a/custom_components/orbit_bhyve/valve.py
+++ b/custom_components/orbit_bhyve/valve.py
@@ -80,6 +80,8 @@ class BHyveZoneValve(CoordinatorEntity[BHyveDeviceCoordinator], ValveEntity):
         return {
             "station": self._station,
             "seconds_remaining": state.seconds_remaining,
+            "rain_delay_minutes": state.rain_delay_minutes,
+            "rain_delay_ends": state.rain_delay_ends,
             "last_command": state.last_command_label,
             "last_command_at": state.last_command_at,
             "notifications_last_cmd": state.notifications_last_cmd,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Test bootstrap.
+
+The integration's package __init__ pulls in Home Assistant (voluptuous, etc.),
+which we don't want to require just to exercise the pure protocol/dispatch
+logic. Register a lightweight `orbit_bhyve` namespace package whose __path__
+points at the real source dir, so relative imports inside the submodules resolve
+without executing the HA-heavy __init__. connection.py's only HA import is
+function-local, so importing the device/protocol modules needs just bleak +
+cryptography, both available.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_CC = Path(__file__).resolve().parent.parent / "custom_components"
+
+if "orbit_bhyve" not in sys.modules:
+    pkg = types.ModuleType("orbit_bhyve")
+    pkg.__path__ = [str(_CC / "orbit_bhyve")]
+    sys.modules["orbit_bhyve"] = pkg

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,0 +1,7 @@
+# Test-only deps. The suite exercises the pure protocol/dispatch logic and does
+# NOT require Home Assistant — conftest.py registers a lightweight orbit_bhyve
+# namespace so the submodules import without the HA-heavy package __init__.
+pytest>=8.0
+# Runtime deps pulled in transitively by the device/connection modules:
+bleak-retry-connector>=3.5.0
+cryptography>=42.0

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,709 @@
+"""Device-class dispatch + structure tests.
+
+Verifies resolve_device_class() routes each hardware/firmware/type to the right
+class — in particular that Gen2 HT25G2 valves (which share the "HT25" prefix
+with the older mesh hose timers) land on the protobuf class, not the mesh one —
+and that the consolidated protobuf family keeps its expected shape. No hardware
+or Home Assistant required.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from orbit_bhyve.devices import (
+    BHyveHT25Device,
+    BHyveHT25Fw0085Device,
+    BHyveHT25G2Device,
+    BHyveHT34ADevice,
+    BHyveHubDevice,
+    UnsupportedModel,
+    resolve_device_class,
+)
+from orbit_bhyve.connection import BHyveBleConnection
+from orbit_bhyve.devices import protobuf as pb
+from orbit_bhyve.devices import status as rx
+from orbit_bhyve.devices.base import DeviceState, _mv_to_pct
+from orbit_bhyve.devices.protobuf import BHyveProtobufDevice
+
+
+@pytest.mark.parametrize(
+    "hardware,firmware,type_,expected",
+    [
+        ("", "", "bridge", BHyveHubDevice),               # hub wins on type
+        ("HT34A-0001", "0107", "", BHyveHT34ADevice),     # XD 4-port
+        ("HT25G2-0001", "0111", "", BHyveHT25G2Device),   # Gen2 by suffix
+        ("HT25-0001", "0111", "", BHyveHT25G2Device),       # Gen2 by fw0111
+        ("HT25-0001", "0085", "", BHyveHT25Fw0085Device),   # mesh fw0085 (upstream subclass)
+        ("HT25-0001", "0041", "", BHyveHT25Device),         # mesh base (fw0041)
+    ],
+)
+def test_resolve_routes(hardware, firmware, type_, expected):
+    assert resolve_device_class(hardware=hardware, firmware=firmware, type_=type_) is expected
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(UnsupportedModel):
+        resolve_device_class(hardware="ZZ99", firmware="0001", type_="")
+
+
+def test_protobuf_family_subclassing():
+    assert issubclass(BHyveHT34ADevice, BHyveProtobufDevice)
+    assert issubclass(BHyveHT25G2Device, BHyveProtobufDevice)
+
+
+@pytest.mark.parametrize(
+    "cls,label",
+    [(BHyveHT34ADevice, "HT34A"), (BHyveHT25G2Device, "HT25G2")],
+)
+def test_protobuf_family_attrs(cls, label):
+    assert cls.log_label == label
+    assert cls.frame_magic == 0x11
+    assert cls.trailer_const == 0x11
+
+
+@pytest.mark.parametrize(
+    "mv,pct",
+    [
+        (2400, 0),     # curve floor
+        (3000, 100),   # curve ceiling
+        (2700, 50),    # midpoint
+        (2000, 0),     # below floor clamps
+        (3500, 100),   # above ceiling clamps
+    ],
+)
+def test_mv_to_pct(mv, pct):
+    assert _mv_to_pct(mv) == pct
+
+
+def test_cloud_battery_snapshot_is_not_seeded():
+    # The cloud battery snapshot must NEVER seed the sensor: it's on a different
+    # discharge curve than _mv_to_pct, so it painted a wrong (voltage-inconsistent)
+    # value into long-term stats at every startup. Battery starts unknown and is
+    # only ever set by a live BLE decode.
+    record = {
+        "cloud_id": "abc", "name": "T", "mac": "AA:BB:CC:DD:EE:FF",
+        "hardware": "HT25G2-0001", "firmware": "0111", "stations": 1,
+        "network_key": "",  # no key -> no BLE connection created (no hass needed)
+        "battery_pct": 88, "battery_mv": 2999,  # cloud snapshot — must be ignored
+    }
+    dev = BHyveHT25G2Device(None, record)
+    assert dev.battery_pct is None
+    assert dev.battery_mv is None
+
+
+# --- actuation confirm-via-#15 (regression for stuck-open valve) ----------
+
+def _status_frame(run_state: int) -> bytes:
+    """A CRC-valid #16 status notification carrying only the run-state."""
+    inner = pb._pb_field_bytes(rx.RX_F_STATUS, pb._pb_field_varint(rx.RX_F_STATUS_MODE, run_state))
+    return pb._build_message(inner)
+
+
+def _flow_frame(active: int, total: int) -> bytes:
+    """A CRC-valid #59 watering/flow notification { #1=flow-active, #3=cumulative }."""
+    inner = pb._pb_field_bytes(
+        rx.RX_F_WATERING,
+        pb._pb_field_varint(rx.RX_F_WATERING_ACTIVE, active)
+        + pb._pb_field_varint(rx.RX_F_FLOW_TOTAL, total),
+    )
+    return pb._build_message(inner)
+
+
+_STATUS_REQ_FRAME = None  # set lazily to the #15{} frame the device emits
+
+
+class _FakeConn:
+    """Stand-in for BHyveBleConnection: records sent frames and feeds a canned
+    plaintext back through the device's own observer, exactly as _on_notify
+    would after decrypting an RX notification."""
+
+    def __init__(self, device, *, on_status=None, on_command=None):
+        self.device = device
+        self.on_status = on_status      # fed when the #15{} status request is sent
+        self.on_command = on_command    # fed on any other frame (start/stop/rain)
+        self.sent: list[bytes] = []
+        self.disconnects = 0
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        pt = self.on_status if frame == pb._build_message(pb._REQUEST_STATUS_PB) else self.on_command
+        if pt is not None:
+            self.device._observe_plaintext(pt)
+        return [b"\x01"]  # one notification (the bare #30 ack for a stop)
+
+    async def disconnect(self):
+        self.disconnects += 1
+
+    @property
+    def is_connected(self):
+        return True
+
+
+def _make_device(**state_kwargs):
+    dev = object.__new__(BHyveHT25G2Device)  # bypass HA-heavy __init__
+    dev.mac = "AA:BB:CC:DD:EE:FF"
+    dev.state = DeviceState(**state_kwargs)
+    dev.flow_counts_per_gallon = 433  # set by base __init__ from options normally
+    return dev
+
+
+def test_stop_confirms_via_status_poll_when_reply_lacks_status():
+    # The device answers a stop with a bare #30 ack (no #16), so the stop send
+    # alone can't confirm; the #15{} poll returns idle and closes the valve.
+    dev = _make_device(is_watering=True, active_zone=1, seconds_remaining=600)
+    dev.state.expected_off_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(1), on_command=None)
+
+    ok = asyncio.run(dev.stop_watering())
+
+    assert ok is True
+    assert dev.state.is_watering is False
+    assert dev.state.expected_off_at is None       # wall-clock auto-close disarmed
+    assert pb._build_message(pb._REQUEST_STATUS_PB) in dev.connection.sent
+
+
+def test_stop_confirms_immediately_via_stop_ack():
+    # If the stop command response contains the #30 stop command acknowledgment,
+    # it must confirm the stop immediately and bypass/skip needing status poll confirmations.
+    dev = _make_device(is_watering=True, active_zone=1, seconds_remaining=600)
+    dev.state.expected_off_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    
+    stop_ack = pb._pb_field_bytes(30, b"\x08\x01")
+    stop_ack_frame = pb._build_message(stop_ack)
+    
+    dev.connection = _FakeConn(dev, on_status=None, on_command=stop_ack_frame)
+    
+    ok = asyncio.run(dev.stop_watering())
+    
+    assert ok is True
+    assert dev.state.is_watering is False
+    assert dev.state.expected_off_at is None
+
+
+def test_stop_not_confirmed_when_device_still_watering():
+    # If the #15{} poll still shows run-state 4, the stop must NOT falsely
+    # confirm — it retries with a fresh session and reports failure.
+    dev = _make_device(is_watering=True, active_zone=1, seconds_remaining=600)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(4), on_command=None)
+
+    ok = asyncio.run(dev.stop_watering())
+
+    assert ok is False
+    assert dev.state.is_watering is True
+    assert dev.connection.disconnects == 2         # both attempts retried
+
+
+def test_refresh_state_polls_status_and_sees_out_of_band_run():
+    # The coordinator poll must actually read the device (#15{}) so a run HA
+    # didn't start (a scheduled program) becomes visible.
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(4), on_command=_status_frame(4))
+
+    state = asyncio.run(dev.refresh_state())
+
+    assert state.is_watering is True
+    assert pb._build_message(pb._REQUEST_STATUS_PB) in dev.connection.sent
+
+
+def test_start_arms_wall_clock_autoclose():
+    # A confirmed start must arm expected_off_at so the coordinator can close
+    # the valve on the wall clock even if a later BLE read/stop fails.
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(4), on_command=_status_frame(4))
+
+    ok = asyncio.run(dev.start_watering(1, 600))
+
+    assert ok is True
+    assert dev.state.is_watering is True
+    assert dev.state.active_zone == 1
+    assert dev.state.expected_off_at is not None
+
+
+def test_stop_confirms_when_rain_delay_active():
+    # After a stop with a rain delay active the device reports run-state 3
+    # (rain-delay), which is "not watering" — the stop should confirm.
+    dev = _make_device(is_watering=True, active_zone=1)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(3), on_command=None)
+
+    ok = asyncio.run(dev.stop_watering())
+
+    assert ok is True
+    assert dev.state.is_watering is False
+
+
+def _status_clock_and_rain_delay(clock: int, minutes: int) -> bytes:
+    """A #16 status carrying #7 device clock (top-level) + an active #16.#13
+    rain-delay block, as the device would answer a #15{} poll."""
+    rd = pb._pb_field_varint(rx.RX_F_RD_MINUTES, minutes)
+    rd += pb._pb_field_varint(rx.RX_F_RD_ENABLED, 1)
+    sub = pb._pb_field_varint(rx.RX_F_STATUS_MODE, 3)
+    sub += pb._pb_field_bytes(rx.RX_F_STATUS_RAINDELAY, rd)
+    top = pb._pb_field_varint(rx.RX_F_CLOCK, clock)
+    top += pb._pb_field_bytes(rx.RX_F_STATUS, sub)
+    return pb._build_message(top)
+
+
+def test_set_rain_delay_anchors_expiry_to_device_clock():
+    # The device honors the absolute #3 expiry literally, so set_rain_delay must
+    # read the device clock (#7) via a #15{} poll first and compute
+    # #3 = deviceClock + minutes*60 — NOT host time. A host/device skew would
+    # otherwise end the delay early/late.
+    clock = 1_700_000_000
+    minutes = 360
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(
+        dev, on_status=_status_clock_and_rain_delay(clock, minutes), on_command=None
+    )
+
+    ok = asyncio.run(dev.set_rain_delay(minutes))
+
+    assert ok is True
+    status_req = pb._build_message(pb._REQUEST_STATUS_PB)
+    unsub_req = pb._build_message(pb._FLOW_UNSUBSCRIBE_PB)
+    rd_frames = [f for f in dev.connection.sent if f != status_req and f != unsub_req]
+    assert len(rd_frames) == 1
+    rd_pb = rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(rd_frames[0])), 17))
+    assert rx._pb_field(rd_pb, rx.RX_F_RD_MINUTES) == minutes
+    assert rx._pb_field(rd_pb, rx.RX_F_RD_EXPIRY) == clock + minutes * 60
+
+
+# --- flow (#57/#59, Gen2-only) --------------------------------------------
+
+def test_has_flow_only_on_gen2():
+    # Gen2 (HT25G2) has an inline flow sensor; the XD (HT34A) does not.
+    assert BHyveHT25G2Device.has_flow is True
+    assert BHyveHT34ADevice.has_flow is False
+
+
+def test_flow_subscribe_pb_round_trips_and_matches_capture():
+    frame = pb._build_message(pb._FLOW_SUBSCRIBE_PB)
+    assert rx.decode_inner(frame) == pb._FLOW_SUBSCRIBE_PB
+    sub = rx.pb_parse(rx._pb_field(rx.pb_parse(pb._FLOW_SUBSCRIBE_PB), 57))
+    assert rx._pb_field(sub, 1) == 1000   # intervalMs (app capture)
+    assert rx._pb_field(sub, 2) == 2      # type (app capture)
+
+
+def test_read_flow_noop_on_flowless_device():
+    # The XD must never be poked with #57 — it has no flow path.
+    xd = object.__new__(BHyveHT34ADevice)
+    xd.mac = "AA:BB:CC:DD:EE:FF"
+    xd.state = DeviceState()
+    xd.connection = _FakeConn(xd)
+    asyncio.run(xd.read_flow())
+    assert xd.connection.sent == []
+
+
+def test_gpm_from_samples_computes_rate():
+    # 144 counts over 4.45 s = 32.4 counts/s → ~4.49 gpm at 433 counts/gal
+    # (matches the measured BTValve01 calibration run).
+    gpm = pb._gpm_from_samples([(0.0, 0), (4.45, 144)], 433)
+    assert 4.4 <= gpm <= 4.6
+
+
+def test_gpm_from_samples_scales_with_calibration():
+    # Halving counts-per-gallon doubles the reported gpm (the option is honoured).
+    base = pb._gpm_from_samples([(0.0, 0), (4.0, 200)], 400)
+    half = pb._gpm_from_samples([(0.0, 0), (4.0, 200)], 200)
+    assert round(half, 2) == round(base * 2, 2)
+
+
+def test_gpm_from_samples_zero_when_no_advance():
+    assert pb._gpm_from_samples([(0.0, 100), (4.0, 100)], 433) == 0.0  # counter flat
+    assert pb._gpm_from_samples([(0.0, 100)], 433) == 0.0              # one sample
+    assert pb._gpm_from_samples([], 433) == 0.0                         # no samples
+
+
+class _DesyncThenFreshConn:
+    """First flow subscribe decodes to nothing (simulates a desynced RX counter);
+    after a disconnect (fresh handshake) the #59 decodes cleanly."""
+
+    def __init__(self, device):
+        self.device = device
+        self.sent: list[bytes] = []
+        self.disconnects = 0
+        self._fresh = False
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        if self._fresh:
+            self.device._observe_plaintext(_flow_frame(active=1, total=500))
+        return [b"\x01"]
+
+    async def disconnect(self):
+        self.disconnects += 1
+        self._fresh = True
+
+    @property
+    def is_connected(self):
+        return True
+
+
+def test_read_flow_resyncs_after_desynced_session():
+    # No decodable #59 on the pooled session → read_flow drops the connection and
+    # retries once on a fresh handshake, which decodes (regression for "Check flow
+    # only updated at the next poll").
+    dev = _make_device(is_watering=True)
+    dev.connection = _DesyncThenFreshConn(dev)
+    asyncio.run(dev.read_flow())
+    assert dev.connection.disconnects == 1
+    assert dev.state.flow_gpm == 0.0  # a decodable #59 (flow 0 here) was committed
+    n_sub = dev.connection.sent.count(pb._build_message(pb._FLOW_SUBSCRIBE_PB))
+    assert n_sub == 2  # both attempts subscribed exactly once
+
+
+def test_read_flow_no_reconnect_when_healthy():
+    # A healthy session decodes #59 on the first pass → no wasteful reconnect.
+    dev = _make_device(is_watering=True)
+    dev.connection = _FakeConn(dev, on_status=None, on_command=_flow_frame(active=1, total=500))
+    asyncio.run(dev.read_flow())
+    assert dev.connection.disconnects == 0
+    assert dev.state.flow_gpm == 0.0
+
+
+def test_read_flow_always_unsubscribes():
+    # read_flow must cancel the stream (#57{#1=0}) as its last act, so it never
+    # leaves a persistent #59 subscription that starves the next poll's #16 read.
+    dev = _make_device(is_watering=True)
+    dev.connection = _FakeConn(dev, on_status=None, on_command=_flow_frame(active=1, total=500))
+    asyncio.run(dev.read_flow())
+    assert dev.connection.sent[-1] == pb._build_message(pb._FLOW_UNSUBSCRIBE_PB)
+
+
+class _FlowCancelConn:
+    """A flow connection that never feeds samples, so read_flow parks in its
+    sample-sleep loop and can be cancelled there — exposing what the finally does
+    under an HA-restart-style cancellation. Tracks reconnects and sends."""
+
+    def __init__(self):
+        self.sent: list[bytes] = []
+        self.ensure_connected_calls = 0
+        self.disconnects = 0
+        self._connected = True
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        return [b"\x01"]
+
+    async def ensure_connected(self):
+        self.ensure_connected_calls += 1
+        self._connected = True
+
+    async def disconnect(self):
+        self.disconnects += 1
+        self._connected = False
+
+    @property
+    def is_connected(self):
+        return self._connected
+
+
+def test_read_flow_cancelled_does_not_reconnect():
+    # An HA restart/unload can cancel read_flow mid-sample. Its finally must NOT
+    # reconnect (that races the teardown and fights the device's single-session
+    # limit) — it only unsubscribes if the session is still up, and the shielded
+    # write still lands so no #59 stream is left behind.
+    dev = _make_device(is_watering=True)
+    conn = _FlowCancelConn()
+    dev.connection = conn
+
+    async def run():
+        task = asyncio.create_task(dev.read_flow())
+        await asyncio.sleep(0.05)  # let it reach the sample sleep
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+    assert conn.ensure_connected_calls == 0  # never reconnected from the finally
+    assert conn.sent[-1] == pb._build_message(pb._FLOW_UNSUBSCRIBE_PB)  # still unsubscribed
+
+
+def test_refresh_state_subscribes_flow_while_watering():
+    # A Gen2 poll that finds a run in progress should also spot-check flow so the
+    # gauge tracks live: the #57 subscribe is issued and flow_gpm is computed.
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(
+        dev, on_status=_status_frame(4), on_command=_flow_frame(active=1, total=489)
+    )
+    state = asyncio.run(dev.refresh_state())
+    assert state.is_watering is True
+    assert pb._build_message(pb._FLOW_SUBSCRIBE_PB) in dev.connection.sent
+    assert state.flow_gpm is not None  # a numeric gauge value was set
+
+
+def test_refresh_state_skips_flow_when_idle():
+    # No run -> no flow subscribe (don't wake the radio for nothing).
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(1), on_command=None)
+    asyncio.run(dev.refresh_state())
+    assert pb._build_message(pb._FLOW_SUBSCRIBE_PB) not in dev.connection.sent
+
+
+# --- event-driven drain (connection.py) -----------------------------------
+
+def _make_conn() -> BHyveBleConnection:
+    return BHyveBleConnection(None, "AA:BB:CC:DD:EE:FF", "00" * 16)
+
+
+def test_on_notify_drops_duplicate_redelivery():
+    # A re-delivered (byte-identical) frame must not be decrypted again — doing
+    # so would advance the RX counter and desync the CTR stream. It's buffered
+    # once; the duplicate is dropped.
+    conn = _make_conn()
+    frame = b"\x11\x02\x00\x00"
+    conn._on_notify(None, frame)
+    conn._on_notify(None, frame)
+    assert conn._notif_buf == [frame]
+
+
+def test_drain_returns_at_cap_when_silent():
+    # No reply -> _drain waits out the (short) drain_ms cap and returns.
+    conn = _make_conn()
+
+    async def run():
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        await conn._drain(120)  # 120ms hard cap, no frames delivered
+        return loop.time() - t0
+
+    elapsed = asyncio.run(run())
+    assert 0.10 <= elapsed < 0.30
+
+
+def test_drain_returns_early_after_reply_goes_quiet():
+    # A frame at 20ms should let _drain return ~one quiet window later, far
+    # short of the 2s cap — this is the latency win over a fixed sleep.
+    conn = _make_conn()
+
+    async def run():
+        loop = asyncio.get_running_loop()
+
+        async def feed():
+            await asyncio.sleep(0.02)
+            conn._notif_buf.append(b"\x11\x02\x00\x00")
+            conn._notif_event.set()
+
+        t0 = loop.time()
+        task = asyncio.create_task(feed())
+        await conn._drain(2000)
+        elapsed = loop.time() - t0
+        await task
+        return elapsed
+
+    elapsed = asyncio.run(run())
+    assert elapsed < 1.0            # returned well before the 2s cap
+    assert conn._notif_buf         # the frame is retained for the caller
+
+
+def test_device_state_health_metrics():
+    state = DeviceState()
+    assert state.last_successful_poll is None
+    assert state.consecutive_timeouts == 0
+    now = datetime.now(timezone.utc)
+    state.last_successful_poll = now
+    state.consecutive_timeouts += 1
+    assert state.last_successful_poll == now
+    assert state.consecutive_timeouts == 1
+
+
+def test_configurable_gatt_settle_ms():
+    assert BHyveHT25G2Device.GATT_SETTLE_MS == 300
+    assert BHyveHT34ADevice.GATT_SETTLE_MS == 300
+
+
+# --- Connected = poll reachability (A1) ------------------------------------
+
+class _RaisingConn:
+    """A connection whose status send always fails, to exercise the poll-failure
+    path in refresh_state."""
+
+    def __init__(self):
+        self.disconnects = 0
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        raise RuntimeError("boom")
+
+    async def disconnect(self):
+        self.disconnects += 1
+
+    @property
+    def is_connected(self):
+        return False
+
+
+def test_connected_true_on_successful_poll():
+    # A poll that reads a clean #16 marks the device reachable and resets timeouts.
+    dev = _make_device(is_watering=False, consecutive_timeouts=3)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(1), on_command=None)
+    state = asyncio.run(dev.refresh_state())
+    assert state.is_connected is True
+    assert state.consecutive_timeouts == 0
+    assert dev.connection.disconnects >= 1  # ephemeral teardown
+
+
+def test_connected_false_on_failed_poll():
+    # A poll whose status read raises marks the device unreachable (not a stale
+    # "connected"), increments the timeout counter, and still disconnects cleanly.
+    dev = _make_device(is_watering=False, is_connected=True)
+    dev.connection = _RaisingConn()
+    state = asyncio.run(dev.refresh_state())
+    assert state.is_connected is False
+    assert state.consecutive_timeouts == 1
+    assert dev.connection.disconnects == 1
+
+
+# --- no-status polls aren't phantom successes; over-the-air wedge recovery ----
+
+def test_poll_without_status_is_not_a_success():
+    # A poll that CONNECTS but decodes no #16 (a wedge recovery couldn't clear
+    # this cycle) must NOT stamp a phantom "successful poll" — that false success
+    # is exactly what masked frozen battery on the stuck valves. It counts as a
+    # timeout so the diagnostic sensors surface it.
+    dev = _make_device(is_watering=False, consecutive_timeouts=2)
+    dev.connection = _FakeConn(dev, on_status=None, on_command=None)  # device silent
+    state = asyncio.run(dev.refresh_state())
+    assert state.last_successful_poll is None
+    assert state.consecutive_timeouts == 3
+    assert state.is_connected is True  # reached the device, just got no data
+
+
+class _IgnoresStatusQueryConn(_FakeConn):
+    """Models a unit (BTValve04) that ignores the passive #15 getDeviceStatus
+    query outright but DOES echo a full #16 in reply to a setRainDelay (#17)
+    write — the on_command frame is fed only for the rain-delay no-op."""
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        rd_noop = pb._build_message(pb._build_rain_delay_pb(0, None))
+        if frame == rd_noop and self.on_command is not None:
+            self.device._observe_plaintext(self.on_command)
+        return [b"\x01"]
+
+
+def test_recovers_status_via_rain_delay_noop_when_15_ignored():
+    # When #15 is ignored, recovery falls back to a benign #17 no-op that echoes
+    # the #16 status — turning a phantom-failed poll into a real success.
+    dev = _make_device(is_watering=False)
+    dev.connection = _IgnoresStatusQueryConn(dev, on_status=None, on_command=_status_frame(1))
+    state = asyncio.run(dev.refresh_state())
+    assert getattr(dev, "_status_parsed", False) is True
+    assert state.last_successful_poll is not None            # now a genuine success
+    assert pb._build_message(pb._build_rain_delay_pb(0, None)) in dev.connection.sent
+
+
+def test_status_recovery_noop_never_wipes_active_rain_delay():
+    # The #16-eliciting write must RE-ASSERT an active rain delay (a no-op), never
+    # send a bare clear that would silently cancel it.
+    ends = datetime.now(timezone.utc) + timedelta(hours=1)
+    dev = _make_device(is_watering=False, rain_delay_minutes=60, rain_delay_ends=ends)
+    frame = pb._build_message(dev._noop_rain_delay_pb())
+    rd = rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(frame)), 17))
+    assert rx._pb_field(rd, rx.RX_F_RD_MINUTES) == 60
+    assert rx._pb_field(rd, rx.RX_F_RD_EXPIRY) == int(ends.timestamp())
+
+
+# --- multi-frame-safe CTR self-heal (A2) -----------------------------------
+
+class _FakeHass:
+    def __init__(self):
+        self.jobs: list = []
+
+    def add_job(self, target, *args):
+        self.jobs.append(target)
+
+
+def _handshaken_conn() -> tuple[BHyveBleConnection, _FakeHass]:
+    conn = _make_conn()
+    conn._handshaken = True
+    conn._iv = b"\x00" * 12
+    conn._rx_ctr = 0
+    hass = _FakeHass()
+    conn.hass = hass
+    return conn, hass
+
+
+def _frame_decrypting_to(conn: BHyveBleConnection, pt: bytes, ctr: int) -> bytes:
+    """Build an RX frame that conn.decrypt() (at rx_ctr==ctr) recovers to `pt`."""
+    ks, _ = conn._aes_keystream(ctr, (len(pt) + 15) // 16)
+    ct = bytes(b ^ k for b, k in zip(pt, ks[: len(pt)]))
+    return bytes([conn._frame_magic, len(ct)]) + ct + b"\x00\x00"
+
+
+def test_ctr_selfheal_on_bad_first_frame():
+    # A garbage first frame (bad inner header) is a real CTR desync → self-heal.
+    conn, hass = _handshaken_conn()
+    frame = _frame_decrypting_to(conn, b"\xd0\x18\x29\x07deadbeef", 0)
+    conn._on_notify(None, frame)
+    assert len(hass.jobs) == 1  # disconnect scheduled
+
+
+def test_ctr_selfheal_ignores_bad_continuation_frame():
+    # A valid header frame first, then a non-header CONTINUATION frame (as a long
+    # CTR-streamed reply would produce). The continuation must NOT trip the
+    # self-heal — only the reply's first frame is required to carry the header.
+    conn, hass = _handshaken_conn()
+    good = _frame_decrypting_to(conn, rx.MSG_HEADER + b"\x00" * 8, 0)
+    conn._on_notify(None, good)             # first frame: header ok, buffered
+    cont = _frame_decrypting_to(conn, b"\x11\x22\x33\x44moredata", conn._rx_ctr)
+    conn._on_notify(None, cont)             # continuation: bad header, not first
+    assert hass.jobs == []                  # no disconnect scheduled
+
+
+# --- connect/handshake retry is single-level (connection.py) ---------------
+
+def test_ensure_connected_does_not_multiply_retries(monkeypatch):
+    # Regression guard: ensure_connected must NOT wrap _open in a second retry
+    # loop. _open already retries OPEN_MAX_ATTEMPTS times; a nested loop made it
+    # 3x3=9 connect+handshake attempts (~90-150s on a stalling device). A fully
+    # failing open must attempt connect exactly OPEN_MAX_ATTEMPTS times, not N^2.
+    import sys
+    import types as _types
+
+    from orbit_bhyve import connection as conn_mod
+    from orbit_bhyve.connection import BleHandshakeError, OPEN_MAX_ATTEMPTS
+
+    # Stub the function-local HA bluetooth import so _open resolves a device.
+    for name in ("homeassistant", "homeassistant.components",
+                 "homeassistant.components.bluetooth"):
+        monkeypatch.setitem(sys.modules, name, _types.ModuleType(name))
+    monkeypatch.setattr(
+        sys.modules["homeassistant.components.bluetooth"],
+        "async_ble_device_from_address",
+        lambda *a, **k: object(),  # any non-None "in range" device
+        raising=False,
+    )
+
+    calls = {"connect": 0}
+
+    class _FakeClient:
+        is_connected = True
+
+        async def disconnect(self):
+            pass
+
+        async def stop_notify(self, *_a):
+            pass
+
+    async def _fake_establish(*_a, **_k):
+        calls["connect"] += 1
+        return _FakeClient()
+
+    monkeypatch.setattr(conn_mod, "establish_connection", _fake_establish)
+    # No real gatt-settle / inter-attempt backoff sleeps — keep the test instant.
+    async def _no_sleep(*_a, **_k):
+        pass
+    monkeypatch.setattr(conn_mod.asyncio, "sleep", _no_sleep)
+
+    conn = _make_conn()
+
+    async def _always_fail_handshake():
+        raise BleHandshakeError("forced handshake failure")
+    monkeypatch.setattr(conn, "_handshake", _always_fail_handshake)
+
+    with pytest.raises(BleHandshakeError):
+        asyncio.run(conn.ensure_connected())
+
+    assert calls["connect"] == OPEN_MAX_ATTEMPTS  # 3, never 9

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -615,8 +615,11 @@ class _FakeHass:
         self.jobs.append(target)
 
 
-def _handshaken_conn() -> tuple[BHyveBleConnection, _FakeHass]:
+def _handshaken_conn(reply_header: bytes | None = rx.MSG_HEADER) -> tuple[BHyveBleConnection, _FakeHass]:
+    # Default to a protobuf connection (header-based self-heal enabled); pass
+    # reply_header=None for the mesh path, which has no header check.
     conn = _make_conn()
+    conn._reply_header = reply_header
     conn._handshaken = True
     conn._iv = b"\x00" * 12
     conn._rx_ctr = 0
@@ -650,6 +653,29 @@ def test_ctr_selfheal_ignores_bad_continuation_frame():
     cont = _frame_decrypting_to(conn, b"\x11\x22\x33\x44moredata", conn._rx_ctr)
     conn._on_notify(None, cont)             # continuation: bad header, not first
     assert hass.jobs == []                  # no disconnect scheduled
+
+
+def test_ctr_selfheal_skipped_for_mesh_replies():
+    # Regression (ljmerza PR #24 feedback): mesh d7-47 replies use a
+    # [mesh:2][type][seq][routing] shape, NOT the protobuf inner-message header,
+    # so a mesh connection (reply_header=None) must NOT misclassify its first
+    # bind-step reply as a CTR desync and schedule a disconnect mid-handshake.
+    conn, hass = _handshaken_conn(reply_header=None)
+    mesh_reply = _frame_decrypting_to(conn, bytes.fromhex("d747c10540") + b"\x00" * 6, 0)
+    conn._on_notify(None, mesh_reply)
+    assert hass.jobs == []                  # no disconnect scheduled
+
+
+def test_encrypt_raises_cleanly_when_session_cleared():
+    # A disconnect scheduled mid-handshake nulls _iv; encrypt() must raise a
+    # typed BleHandshakeError (open-retry catches it), not a TypeError from the
+    # keystream (the crash ljmerza hit on the mesh path).
+    from orbit_bhyve.connection import BleHandshakeError
+
+    conn = _make_conn()
+    conn._iv = None
+    with pytest.raises(BleHandshakeError):
+        conn.encrypt(b"\x00\x01\x02\x03")
 
 
 # --- connect/handshake retry is single-level (connection.py) ---------------

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,476 @@
+"""Protocol round-trip + RX decode tests for the protobuf device family.
+
+Covers the TX frame builders in devices/protobuf.py and the RX status decode in
+devices/status.py — the two ends of the wire protocol shared by the HT34A XD and
+HT25G2 Gen2 valves. No hardware or Home Assistant required.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from orbit_bhyve.devices import protobuf as tx
+from orbit_bhyve.devices import status as rx
+from orbit_bhyve.devices.base import DeviceState, _mv_to_pct
+
+
+# --- protobuf low-level helpers -------------------------------------------
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, b"\x00"),
+        (1, b"\x01"),
+        (127, b"\x7f"),
+        (128, b"\x80\x01"),
+        (300, b"\xac\x02"),
+        (16384, b"\x80\x80\x01"),
+    ],
+)
+def test_pb_varint(value, expected):
+    assert tx._pb_varint(value) == expected
+
+
+def test_pb_field_varint_and_bytes():
+    # field 1, varint 2 -> tag (1<<3|0)=0x08, value 0x02
+    assert tx._pb_field_varint(1, 2) == b"\x08\x02"
+    # field 14, length-delimited -> tag (14<<3|2)=0x72, len, data
+    assert tx._pb_field_bytes(14, b"\xaa\xbb") == b"\x72\x02\xaa\xbb"
+
+
+# --- TX frame round-trip --------------------------------------------------
+
+def _status_pb(
+    *, run_state=None, battery_mv=None, watering_active=None, remaining=None,
+    total=None, active_station=None, device_clock=None,
+) -> bytes:
+    """Build a device-status protobuf the way the device would emit it, using
+    the same field numbers status.py decodes."""
+    out = b""
+    if device_clock is not None:               # #7 top-level wrapper field
+        out += tx._pb_field_varint(rx.RX_F_CLOCK, device_clock)
+    if (
+        run_state is not None or battery_mv is not None
+        or remaining is not None or active_station is not None
+    ):
+        sub = b""
+        if run_state is not None:
+            sub += tx._pb_field_varint(rx.RX_F_STATUS_MODE, run_state)
+        if active_station is not None:
+            # #16.#2.#2.#3.#1 active-run echo — nest the stationId three deep.
+            station_info = tx._pb_field_varint(rx.RX_F_STATION_ID, active_station)
+            params = tx._pb_field_bytes(rx.RX_F_RUNECHO_STATION, station_info)
+            sub += tx._pb_field_bytes(
+                rx.RX_F_STATUS_RUNECHO, tx._pb_field_bytes(rx.RX_F_RUNECHO_PARAMS, params)
+            )
+        if remaining is not None:
+            # #16.#6 run-progress: #5 = remaining (counts down), #7 = total (constant).
+            # HW-verified 2026-07-05 on Gen2 fw0111 + XD fw0107. Emit a distinct #7 so a
+            # regression that reads total as remaining is caught.
+            prog = tx._pb_field_varint(rx.RX_F_PROGRESS_REMAINING, remaining)
+            prog += tx._pb_field_varint(
+                rx.RX_F_PROGRESS_TOTAL, total if total is not None else 900
+            )
+            sub += tx._pb_field_bytes(rx.RX_F_STATUS_PROGRESS, prog)
+        if battery_mv is not None:
+            sub += tx._pb_field_bytes(
+                rx.RX_F_STATUS_BATT, tx._pb_field_varint(rx.RX_F_BATT_MV, battery_mv)
+            )
+        out += tx._pb_field_bytes(rx.RX_F_STATUS, sub)
+    if watering_active is not None:
+        out += tx._pb_field_bytes(
+            rx.RX_F_WATERING, tx._pb_field_varint(rx.RX_F_WATERING_ACTIVE, watering_active)
+        )
+    return out
+
+
+def test_build_message_is_crc_valid_and_self_decodes():
+    frame = tx._build_message(tx._build_start_pb(station_id=0, duration_sec=60))
+    # decode_inner enforces header + CRC; a valid frame round-trips to its pb.
+    pb = rx.decode_inner(frame)
+    assert pb is not None
+    assert pb == tx._build_start_pb(0, 60)
+
+
+def test_start_pb_carries_station_and_duration():
+    pb = tx._build_start_pb(station_id=2, duration_sec=900)
+    top = rx.pb_parse(pb)
+    timer_mode = rx._pb_field(top, 14)            # outer timerMode field
+    tm = rx.pb_parse(timer_mode)
+    assert rx._pb_field(tm, 1) == 2               # mode = manual(2)
+    manual = rx.pb_parse(rx._pb_field(tm, 2))
+    station_info = rx.pb_parse(rx._pb_field(manual, 3))
+    assert rx._pb_field(station_info, 1) == 2     # wire station id (0-indexed)
+    assert rx._pb_field(station_info, 2) == 900   # duration seconds
+
+
+def test_stop_frame_is_crc_valid():
+    assert rx.decode_inner(tx._build_message(tx._STOP_PB)) == tx._STOP_PB
+
+
+# --- rain delay (#17) TX round-trip ---------------------------------------
+
+def test_rain_delay_set_carries_minutes_expiry_and_flag():
+    # 24h == 1440 minutes (the catalog-confirmed value).
+    pb = tx._build_rain_delay_pb(1440, 1_700_000_000)
+    rd = rx.pb_parse(rx._pb_field(rx.pb_parse(pb), 17))
+    assert rx._pb_field(rd, 1) == 1440             # minutes
+    assert rx._pb_field(rd, 3) == 1_700_000_000    # expiry (Unix)
+    assert rx._pb_field(rd, 4) == 1                # enable flag
+
+
+def test_rain_delay_clear_is_minutes_zero_only():
+    # A clear is a bare #17{#1=0} — no expiry, no enable flag.
+    pb = tx._build_rain_delay_pb(0, None)
+    rd = rx.pb_parse(rx._pb_field(rx.pb_parse(pb), 17))
+    assert rx._pb_field(rd, 1) == 0
+    assert rx._pb_field(rd, 3) is None
+    assert rx._pb_field(rd, 4) is None
+
+
+def test_rain_delay_message_round_trips_crc():
+    frame = tx._build_message(tx._build_rain_delay_pb(720, 1_700_000_000))
+    assert rx.decode_inner(frame) == tx._build_rain_delay_pb(720, 1_700_000_000)
+
+
+# --- RX status decode -----------------------------------------------------
+
+def test_extract_status_idle_with_battery():
+    pb = _status_pb(run_state=1, battery_mv=2712)
+    st = rx.extract_status(pb)
+    assert st.run_state == 1
+    assert st.is_watering is False
+    assert st.battery_mv == 2712
+
+
+def test_extract_status_running():
+    st = rx.extract_status(_status_pb(run_state=4, battery_mv=2644))
+    assert st.run_state == 4
+    assert st.is_watering is True
+    assert st.battery_mv == 2644
+
+
+def test_extract_status_decodes_seconds_remaining():
+    # #16.#6.#5 carries seconds remaining while watering (hardware: 600 at start).
+    st = rx.extract_status(_status_pb(run_state=4, remaining=600))
+    assert st.run_state == 4
+    assert st.is_watering is True
+    assert st.seconds_remaining == 600
+
+
+def test_extract_status_remaining_not_confused_with_total():
+    # HW-verified 2026-07-05 (Gen2 fw0111 + XD fw0107): #16.#6.#5 = remaining (counts
+    # down), #16.#6.#7 = total (constant). The decoder must read #5, never #7.
+    st = rx.extract_status(_status_pb(run_state=4, remaining=300, total=900))
+    assert st.run_state == 4
+    assert st.is_watering is True
+    assert st.seconds_remaining == 300
+
+
+def test_extract_status_decodes_active_station():
+    # #16.#2.#2.#3.#1 tells us which zone is running (0-indexed) — the deep timerMode
+    # path, which the decoder uses as a fallback when #16.#6.#4 is absent.
+    st = rx.extract_status(_status_pb(run_state=4, active_station=2))
+    assert st.is_watering is True
+    assert st.active_station == 2
+
+
+def test_extract_status_active_station_from_progress_block():
+    # Preferred source: the shallow #16.#6.#4 (currentStationId), HW-verified to track
+    # the running zone. #16.#6 also carries #5 remaining.
+    prog = tx._pb_field_varint(rx.RX_F_PROGRESS_STATION, 2)
+    prog += tx._pb_field_varint(rx.RX_F_PROGRESS_REMAINING, 90)
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 4)
+    sub += tx._pb_field_bytes(rx.RX_F_STATUS_PROGRESS, prog)
+    st = rx.extract_status(tx._pb_field_bytes(rx.RX_F_STATUS, sub))
+    assert st.active_station == 2
+    assert st.seconds_remaining == 90
+
+
+def test_extract_status_watering_status_30_enum():
+    # #30 WateringStatus (no #16): terminal states + a bare #30 => not watering;
+    # in-progress / delay states => a run is still active (must not idle the valve).
+    complete = tx._pb_field_bytes(30, tx._pb_field_varint(1, 1))   # our observed stop reply
+    assert rx.extract_status(complete).is_watering is False
+    station_complete = tx._pb_field_bytes(30, tx._pb_field_varint(1, 4))
+    assert rx.extract_status(station_complete).is_watering is False
+    bare = tx._pb_field_bytes(30, b"")                              # #30 with no #1
+    assert rx.extract_status(bare).is_watering is False
+    for code in (2, 3, 5, 6, 7):                                    # inProgress + delays
+        pb_data = tx._pb_field_bytes(30, tx._pb_field_varint(1, code))
+        assert rx.extract_status(pb_data).is_watering is True, code
+
+
+def test_extract_status_decodes_device_clock():
+    # #7 (top-level wrapper) is the device's own Unix clock, used to anchor the
+    # rain-delay absolute expiry to the device rather than the host.
+    st = rx.extract_status(_status_pb(run_state=1, device_clock=1_700_000_000))
+    assert st.device_clock == 1_700_000_000
+
+
+def test_extract_status_stale_raindelay_cleared_by_runstate():
+    # #16.#13 is NOT cleared when a delay expires — it lingers stale ({#1:60, #4:1})
+    # while run-state has returned to idle (HW-verified 2026-07-05). Run-state is
+    # authoritative: run-state != 3 => not active, regardless of the stale block.
+    rd = tx._pb_field_varint(rx.RX_F_RD_MINUTES, 60) + tx._pb_field_varint(rx.RX_F_RD_ENABLED, 1)
+    sub_idle = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 1)  # idle
+    sub_idle += tx._pb_field_bytes(rx.RX_F_STATUS_RAINDELAY, rd)
+    st_idle = rx.extract_status(tx._pb_field_bytes(rx.RX_F_STATUS, sub_idle))
+    assert st_idle.run_state == 1
+    assert st_idle.rain_delay_active is False
+    # With run-state 3 (rain-delay) the same block IS honored as active.
+    sub_rd = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 3)
+    sub_rd += tx._pb_field_bytes(rx.RX_F_STATUS_RAINDELAY, rd)
+    st_active = rx.extract_status(tx._pb_field_bytes(rx.RX_F_STATUS, sub_rd))
+    assert st_active.rain_delay_active is True
+    assert st_active.rain_delay_minutes == 60
+
+
+def test_watering_field_59_does_not_drive_is_watering():
+    # #59.#1 (flow-active) must NOT set is_watering — only #16.#1 is authoritative.
+    # A #59-asserted "watering" latched HA on when #16 reads were starved by the
+    # flow subscription (hardware 2026-07-03). So a lone #59 (either #1) leaves
+    # is_watering ambiguous (None); the valve state comes from the #16 poll.
+    assert rx.extract_status(_status_pb(watering_active=1)).is_watering is None
+    assert rx.extract_status(_flow_pb(active=1, total=100)).is_watering is None
+    assert rx.extract_status(_flow_pb(active=0, total=724)).is_watering is None
+
+
+def _flow_pb(active, total) -> bytes:
+    """A #59 watering/flow frame: { #1=flow-active, #3=cumulative } (Gen2)."""
+    return tx._pb_field_bytes(
+        rx.RX_F_WATERING,
+        tx._pb_field_varint(rx.RX_F_WATERING_ACTIVE, active)
+        + tx._pb_field_varint(rx.RX_F_FLOW_TOTAL, total),
+    )
+
+
+def test_extract_status_decodes_flow_total():
+    # #59.#3 is the CUMULATIVE per-run volume counter (flow gauge input).
+    st = rx.extract_status(_flow_pb(active=1, total=489))
+    assert st.flow_total == 489
+
+
+def test_standalone_battery_report_field_46():
+    pb = tx._pb_field_bytes(
+        rx.RX_F_BATTERY_REPORT, tx._pb_field_varint(rx.RX_F_BATT_MV, 2800)
+    )
+    st = rx.extract_status(pb)
+    assert st.battery_mv == 2800
+    assert st.run_state is None
+    assert st.is_watering is None
+
+
+def _status_with_rain_delay(minutes, expiry=None, enabled=1) -> bytes:
+    """Build a #16 status carrying a #16.#13 rain-delay block, as the device
+    emits it (run-state 3 while a delay is active)."""
+    rd = tx._pb_field_varint(rx.RX_F_RD_MINUTES, minutes)
+    if expiry is not None:
+        rd += tx._pb_field_varint(rx.RX_F_RD_EXPIRY, expiry)
+    rd += tx._pb_field_varint(rx.RX_F_RD_ENABLED, enabled)
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 3 if enabled else 1)
+    sub += tx._pb_field_bytes(rx.RX_F_STATUS_RAINDELAY, rd)
+    return tx._pb_field_bytes(rx.RX_F_STATUS, sub)
+
+
+def test_extract_status_rain_delay_active():
+    st = rx.extract_status(_status_with_rain_delay(1440, 1_700_000_000, 1))
+    assert st.run_state == 3
+    assert st.is_watering is False         # rain delay is not "watering"
+    assert st.rain_delay_minutes == 1440
+    assert st.rain_delay_expiry == 1_700_000_000
+    assert st.rain_delay_active is True
+
+
+def test_extract_status_rain_delay_idle_shape():
+    # Idle device reports {#1=0, #4=0}.
+    st = rx.extract_status(_status_with_rain_delay(0, expiry=None, enabled=0))
+    assert st.rain_delay_minutes == 0
+    assert st.rain_delay_active is False
+
+
+def _status_bare_rain_delay(minutes) -> bytes:
+    """#16 carrying a bare #13{#1=minutes} with NO #4 enabled field — the exact
+    shape a real device emits after a clear (hardware-confirmed 2026-06-30)."""
+    rd = tx._pb_field_varint(rx.RX_F_RD_MINUTES, minutes)
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 1)
+    sub += tx._pb_field_bytes(rx.RX_F_STATUS_RAINDELAY, rd)
+    return tx._pb_field_bytes(rx.RX_F_STATUS, sub)
+
+
+def test_extract_status_rain_delay_cleared_bare_block():
+    # Bare #13{#1=0} (no #4) must read as off, not ambiguous (active=None).
+    st = rx.extract_status(_status_bare_rain_delay(0))
+    assert st.rain_delay_minutes == 0
+    assert st.rain_delay_active is False
+
+
+def test_decode_inner_rejects_bad_crc():
+    frame = bytearray(tx._build_message(tx._STOP_PB))
+    frame[-1] ^= 0xFF  # corrupt CRC -> simulate an RX-counter-desynced frame
+    assert rx.decode_inner(bytes(frame)) is None
+
+
+def test_decode_inner_rejects_wrong_header():
+    assert rx.decode_inner(b"\x00\x01\x02\x03\x04\x05") is None
+
+
+def test_pb_parse_rejects_truncated_length_delim():
+    # tag 0x72 (field 14, len-delim) claims len 5 but no bytes follow.
+    assert rx.pb_parse(b"\x72\x05") is None
+
+
+# --- apply_status_plaintext (state mutation) ------------------------------
+
+def _fake_device():
+    return SimpleNamespace(
+        mac="AA:BB:CC:DD:EE:FF",
+        battery_mv=None,
+        battery_pct=None,
+        state=DeviceState(is_watering=True, active_zone=1, seconds_remaining=300),
+    )
+
+
+def test_apply_updates_battery_and_clears_zone_on_idle():
+    dev = _fake_device()
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1, battery_mv=2700)))
+    assert dev.battery_mv == 2700
+    assert dev.battery_pct == _mv_to_pct(2700)
+    assert dev.state.is_watering is False
+    assert dev.state.active_zone is None
+    assert dev.state.seconds_remaining is None
+
+
+def test_apply_sets_watering_true_on_running():
+    dev = _fake_device()
+    dev.state.is_watering = False
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=4, battery_mv=2644)))
+    assert dev.state.is_watering is True
+
+
+def test_apply_updates_seconds_remaining_while_watering():
+    # A mid-run #15 poll should refresh the live countdown, not freeze it.
+    dev = _fake_device()
+    dev.state.seconds_remaining = 600
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=4, remaining=540)))
+    assert dev.state.is_watering is True
+    assert dev.state.seconds_remaining == 540
+
+
+def test_apply_sets_active_zone_from_status():
+    # Regression for "one valve actuated but HA shows all valves": a poll- or
+    # app-discovered run must set active_zone (zone = stationId + 1) so only the
+    # running zone renders open on a multi-station device.
+    dev = _fake_device()
+    dev.state.is_watering = False
+    dev.state.active_zone = None
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=4, active_station=2)))
+    assert dev.state.is_watering is True
+    assert dev.state.active_zone == 3  # stationId 2 -> zone 3
+
+
+def test_apply_sets_flow_total_while_watering():
+    dev = _fake_device()
+    rx.apply_status_plaintext(dev, tx._build_message(_flow_pb(active=1, total=489)))
+    assert dev.state.is_watering is True
+    assert dev.state.flow_total == 489
+
+
+def test_apply_clears_flow_on_idle():
+    dev = _fake_device()
+    dev.state.flow_total = 489
+    dev.state.flow_gpm = 4.5
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1)))
+    assert dev.state.is_watering is False
+    assert dev.state.flow_total is None
+    assert dev.state.flow_gpm == 0.0  # valve closed → gauge reads 0
+
+
+def test_apply_ignores_zero_flow_frame_midrun():
+    # A #59{#1=0} during a run (valve open, supply momentarily off) must NOT
+    # flip is_watering False or clear the run's live fields.
+    dev = _fake_device()  # starts is_watering=True, active_zone=1, seconds=300
+    rx.apply_status_plaintext(dev, tx._build_message(_flow_pb(active=0, total=724)))
+    assert dev.state.is_watering is True
+    assert dev.state.active_zone == 1
+
+
+def test_apply_stores_device_clock():
+    # A #15 poll carrying #7 must land on DeviceState so set_rain_delay can
+    # anchor #3 to the device clock.
+    dev = _fake_device()
+    dev.state.device_clock = None
+    rx.apply_status_plaintext(
+        dev, tx._build_message(_status_pb(run_state=1, device_clock=1_700_000_000))
+    )
+    assert dev.state.device_clock == 1_700_000_000
+
+
+def test_apply_arms_expected_off_from_seconds_remaining():
+    # A poll-discovered run must arm the wall-clock auto-close so the entity
+    # counts down and closes even between polls.
+    dev = _fake_device()
+    dev.state.is_watering = False
+    dev.state.expected_off_at = None
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=4, remaining=300)))
+    assert dev.state.is_watering is True
+    assert dev.state.expected_off_at is not None
+
+
+def test_apply_clears_stale_rain_delay_on_idle_status_without_block():
+    # Regression for the "7 hours ago / still 3h" staleness: once a delay
+    # expires the device omits #16.#13, so an idle status (run-state 1) with no
+    # rain-delay block must clear the previously-set value.
+    from datetime import datetime, timezone
+    dev = _fake_device()
+    dev.state.rain_delay_minutes = 180
+    dev.state.rain_delay_ends = datetime.now(timezone.utc)
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1)))
+    assert dev.state.rain_delay_minutes == 0
+    assert dev.state.rain_delay_ends is None
+
+
+def test_apply_rejects_out_of_band_battery():
+    dev = _fake_device()
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1, battery_mv=5000)))
+    assert dev.battery_mv is None  # 5000 mV is out of the 1500..4000 sanity band
+
+
+def test_apply_sets_rain_delay_state():
+    dev = _fake_device()
+    frame = tx._build_message(_status_with_rain_delay(720, 1_700_000_000, 1))
+    rx.apply_status_plaintext(dev, frame)
+    assert dev.state.rain_delay_minutes == 720
+    assert dev.state.rain_delay_ends is not None
+    assert dev.state.rain_delay_ends.timestamp() == 1_700_000_000
+
+
+def test_apply_clears_rain_delay_on_idle_shape():
+    dev = _fake_device()
+    dev.state.rain_delay_minutes = 720  # pretend a delay was set
+    frame = tx._build_message(_status_with_rain_delay(0, expiry=None, enabled=0))
+    rx.apply_status_plaintext(dev, frame)
+    assert dev.state.rain_delay_minutes == 0
+    assert dev.state.rain_delay_ends is None
+
+
+def test_apply_clears_rain_delay_on_bare_block():
+    # Regression: a clear arriving as bare #13{#1=0} (no #4) must still clear a
+    # previously-set delay (HA showed a stale value before this fix, 2026-06-30).
+    dev = _fake_device()
+    dev.state.rain_delay_minutes = 60  # 1h was set
+    from datetime import datetime, timezone
+    dev.state.rain_delay_ends = datetime.now(timezone.utc)
+    rx.apply_status_plaintext(dev, tx._build_message(_status_bare_rain_delay(0)))
+    assert dev.state.rain_delay_minutes == 0
+    assert dev.state.rain_delay_ends is None
+
+
+def test_apply_ignores_desynced_frame():
+    dev = _fake_device()
+    frame = bytearray(tx._build_message(_status_pb(run_state=1, battery_mv=2700)))
+    frame[-1] ^= 0xFF  # CRC fails -> frame ignored, state untouched
+    rx.apply_status_plaintext(dev, bytes(frame))
+    assert dev.battery_mv is None
+    assert dev.state.is_watering is True  # unchanged from the fake's initial state


### PR DESCRIPTION
Implements the design proposal in #23 (you OK'd a single PR there).

Unifies the two protobuf-family device classes (Gen2 **HT25G2**, XD **HT34A/HT32A**) into one `BHyveProtobufDevice`, gives them real device-read state decoded from the HW-verified `#16` status block (per the protocol reference merged in #22), adds a systematic BLE-over-proxy reliability pass, and surfaces the rain-delay, flow, and battery capabilities. The mesh family (`ht25.py` / `ht25_fw0085.py`) is untouched except the shared ephemeral-session wrapper.

> **Scope note vs #23:** the issue framed this as foundation-first with *separate* follow-ups (rain delay / flow / battery). On extraction those turned out to be woven into the foundation at the protocol layer — flow/rain-delay are used as self-heal elicitors in the recovery path and decoded inline in the shared status parser — so splitting them would mean stripping and later re-weaving verified self-heal behavior. They come together here instead. Happy to slice differently if you'd prefer.

Hardware-verified across 4× Gen2 (HT25G2 fw0111) + the HT34A XD (fw0107) over ESPHome proxies.

## What's in it

**Consolidation**
- `devices/protobuf.py` (new): `BHyveProtobufDevice` — shared TX builders, actuation, `#15` `refresh_state`, self-heal recovery. `ht25g2.py` / `ht34a.py` become thin subclasses (frame magic + label). The two already shared the wire protocol (`ht25g2` imported `ht34a`'s builders); this finishes that coupling.
- `devices/status.py` (new): shared RX decoder (`extract_status`) — run-state (1 idle / 3 rain-delay / 4 running), battery mV (`#16.#14.#3`), `seconds_remaining` (`#16.#6.#5`, counts down), active zone (`#16.#6.#4`), `#30` `WateringStatus` enum, rain-delay (`#16.#13`), flow (`#59`).

**State-sync**
- `#15{}` is the canonical `refresh_state()`. The connect-time unsolicited push is reliable when idle but suppressed while the device is active (watering / rain-delay), so we elicit a full `#16` in any state — scheduled / app / physical-button runs become visible, not just HA commands.
- Wall-clock auto-close backstop (guarded to only ever move *earlier*); bare-`#30` stop-ack confirmed via a `#15` read-back; active zone so only the running station renders open on the XD.

**Reliability (BLE over ESPHome proxies)**
- Ephemeral connect-on-demand sessions under a per-device lock, disconnect in `finally`, so polls / commands don't share a session and desync the CTR stream.
- CTR-desync self-heal gated to a reply's first frame; GATT settle window; connection-health telemetry (`last_successful_poll` / `consecutive_timeouts`); single-level connect/handshake retry.

**Capabilities**
- **Rain delay** — `#17` TX + a "Rain delay" number (hours; 0 clears) + "Rain delay ends" sensor; active keyed on run-state, `#3` anchored to the device clock.
- **Flow (Gen2)** — `#57`/`#59` + a "Flow rate" gpm gauge (slope of the cumulative counter) + a "Check flow" button; a guaranteed `#57{0}` unsubscribe so a stream can't starve `#16`; configurable Flow-calibration option. The XD emits no `#59` (gated on `has_flow`).
- **Battery** — stop seeding from the cloud snapshot (BLE reports it live), restore the last live reading across restarts, "Watering ends" timestamp sensor.

## What this supersedes

On the **HT34A path this isn't purely additive** — it replaces the inline decoder you ported in #12. Your `ht34a.py` `_observe_plaintext`/`_parse_status` and the shared `status.py` decode the *same* `#16` fields with the same semantics (battery `#46→#3`, run-state `#16.#1`, remaining `#16.#6.#5` — your merged #21 fix); the shared decoder adds active-zone, rain-delay, `#30`, and flow, and brings the same real device-read state to **Gen2**, which today is optimistic-only (`start` ⇒ `is_watering = True`). So on the Gen2 side this is purely additive.

Two changes land on your hardware-verified XD path, flagged rather than buried in the diff:
1. **Rain-delay is now surfaced** — run-state `3` reads as rain-delay instead of just "not watering."
2. **Active zone comes from telemetry** — a program/app/button run (not initiated by HA) shows the actual running station (`#16.#6.#4`) instead of an optimistic guess.

## Backwards compatibility

- Mesh devices unchanged except the ephemeral-session wrapper.
- Existing entities keep their identities; this adds decoded state + a couple of diagnostic sensors.
- Gated by hardware/firmware/type via `resolve_device_class()`.
- `manifest.json` version left at `2.1.2` for you to bump on merge.

## Testing

Adds a `tests/` suite (new to the repo) that runs without Home Assistant or hardware — `conftest` registers a lightweight `orbit_bhyve` namespace package so the pure protocol/decode/dispatch logic is exercised directly. Covers frame/cipher round-trips, TX builders, RX status decode, device-class dispatch (notably Gen2 HT25G2 → protobuf, not the mesh class), ephemeral-session teardown, flow unsubscribe/cancel safety, and the single-level retry. **94 tests, all passing** (`python -m pytest`). Easy to drop from this PR if you'd rather land the suite separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
