### PR TITLE
fix(connection): reopen a fresh session when a pooled actuation bind fails (mesh STOP over proxy)

### DIFF
--- a/custom_components/orbit_bhyve/connection.py
+++ b/custom_components/orbit_bhyve/connection.py
@@ -405,8 +405,22 @@ class BHyveBleConnection:
         async with self._lock:
             if self.is_connected and self._handshaken:
                 # Pooled connection — refresh the (possibly stale) bind in place.
-                if self._post_handshake_hook is not None:
-                    await self._post_handshake_hook(self)
+                # But over an ESPHome proxy the pooled link can already be dead at
+                # the GATT layer while is_connected still reads True, so the refresh
+                # writes fail with BleakError ("Not connected"). Don't let that
+                # surface as a failed actuation: drop the stale session and reopen
+                # a fresh one (ensure_connected re-runs the hook). HW-observed on a
+                # mesh HT25 STOP over a proxy — the very next fresh connect landed.
+                try:
+                    if self._post_handshake_hook is not None:
+                        await self._post_handshake_hook(self)
+                except (BleakError, OSError, asyncio.TimeoutError) as err:
+                    _LOGGER.debug(
+                        "%s: pooled bind refresh failed (%s) — reopening a fresh session",
+                        self.mac, err,
+                    )
+                    await self.disconnect()
+                    await self.ensure_connected()
             else:
                 # Cold — ensure_connected() retries the open and runs the hook.
                 await self.ensure_connected()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -733,3 +733,61 @@ def test_ensure_connected_does_not_multiply_retries(monkeypatch):
         asyncio.run(conn.ensure_connected())
 
     assert calls["connect"] == OPEN_MAX_ATTEMPTS  # 3, never 9
+
+
+# --- stale pooled session self-heals on actuation (connection.py) ----------
+
+def test_send_actuation_reopens_when_pooled_bind_refresh_fails():
+    # Regression (ljmerza PR #24 hardware feedback): over an ESPHome proxy a
+    # pooled session can be dead at the GATT layer while is_connected still reads
+    # True. send_actuation's in-place bind refresh then fails with BleakError
+    # ("Not connected") — which must NOT propagate to the caller (it surfaced as
+    # a failed close_valve service call in HA). Instead send_actuation drops the
+    # stale session and reopens a fresh one, then completes the command write.
+    from bleak.exc import BleakError
+
+    conn = _make_conn()
+    conn._handshaken = True
+
+    class _StaleClient:
+        is_connected = True  # is_connected property → True → pooled-refresh branch
+
+        async def disconnect(self):
+            pass
+
+    conn._client = _StaleClient()
+
+    calls = {"hook": 0, "disconnect": 0, "ensure_connected": 0, "writes": []}
+
+    async def _hook(_c):
+        calls["hook"] += 1
+        if calls["hook"] == 1:
+            # Stale pooled link: the first bind-refresh write fails at the proxy.
+            raise BleakError("Bluetooth GATT Error ... Not connected")
+
+    async def _disconnect():
+        calls["disconnect"] += 1
+
+    async def _ensure_connected():
+        calls["ensure_connected"] += 1
+
+    async def _write_locked(pt):
+        calls["writes"].append(pt)
+
+    async def _drain(_ms):
+        pass
+
+    conn.set_post_handshake_hook(_hook)
+    conn.disconnect = _disconnect
+    conn.ensure_connected = _ensure_connected
+    conn._write_locked = _write_locked
+    conn._drain = _drain
+    conn._arm_idle_timer = lambda: None
+
+    # Must not raise, even though the pooled bind refresh failed.
+    result = asyncio.run(conn.send_actuation(b"\xaa\xbb", drain_ms=1))
+
+    assert calls["disconnect"] == 1          # stale session dropped
+    assert calls["ensure_connected"] == 1    # fresh session reopened
+    assert calls["writes"] == [b"\xaa\xbb"]  # command still written after recovery
+    assert result == []


### PR DESCRIPTION
## What

Fixes the stale-pooled-session actuation failure I reported on #24 (https://github.com/ljmerza/orbit-bhyve-ble/pull/24#issuecomment-4894290334), found while hardware-testing #24 on live mesh HT25 valves over an ESPHome proxy.

> **Stacked on #24.** Base is `pr24-base`, a snapshot of #24's head (`f856bcc`), so this PR's diff is **just the one fix commit** — meant to be folded into #24 (cherry-pick `d398267`) or merged after it. `pr24-base` is a disposable branch. The bug pre-exists on `main` too (same uncaught pooled-refresh), so this can also target `main` if you'd rather land it independently.

## The bug

`send_actuation` refreshes the per-class bind **in place** on a pooled connection:

```python
if self.is_connected and self._handshaken:
    if self._post_handshake_hook is not None:
        await self._post_handshake_hook(self)   # ← writes over a possibly-dead link
```

Over an ESPHome proxy the pooled link can be **dead at the GATT layer while `is_connected` still reads `True`**, so those refresh writes fail:

```
aioesphomeapi BluetoothGATTAPIError: ... handle=11 error=-1 description=Not connected
  → bleak.exc.BleakError: ... Not connected
```

That `BleakError` propagated **uncaught** — the mesh `ht25._send_command` only tolerates a write-response `TimeoutError`, not a `BleakError` — up through `stop_watering` → `valve.async_close_valve`, surfacing in HA as an `Unexpected exception`. A manual retry (fresh connect → full init → `STOP ack`) then succeeded, confirming the pooled session was simply stale.

## The fix

Catch `BleakError` / `OSError` / `TimeoutError` from the pooled bind-refresh in `send_actuation`, drop the stale session, and reopen a fresh one (`ensure_connected` re-runs the hook) before writing the command — mirroring the recovery that already worked by hand. It's a shared-connection-layer fix; the mesh path (which relies on `send_actuation`) is the one that broke. Protobuf classes go through `send()` + their own disconnect/retry and are unaffected.

## Testing

- `python -m pytest` → **97 passed** (adds one regression test: simulate a `BleakError` on the pooled bind-refresh, assert `send_actuation` drops the session, reopens fresh, and still writes the command instead of raising).
- Hardware validation on mesh HT25 is pending — the failure is intermittent (needs a genuinely dead pooled link), so I'm relying on the unit test plus the matching hardware trace from the report. Happy to deploy + soak it on my fleet.

<sub>🤖 Generated with Claude Code</sub>
