### PR TITLE
fix(button): Sync button forces a BLE connect on mesh devices

### DIFF
--- a/custom_components/orbit_bhyve/button.py
+++ b/custom_components/orbit_bhyve/button.py
@@ -74,6 +74,10 @@ class BHyveSyncButton(CoordinatorEntity[BHyveDeviceCoordinator], ButtonEntity):
         if device.connection is None:
             return
         _LOGGER.info("%s: sync requested via button", device.mac)
+        # Force any device-class-specific on-demand refresh first (mesh forces a
+        # BLE connect so the connect-time init pulls fresh battery/state; protobuf
+        # is a no-op here since its refresh_state connects for a #15 read below).
+        await device.async_manual_sync()
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -138,6 +138,13 @@ class BHyveBleDeviceBase(abc.ABC):
     async def async_setup(self) -> None:
         """Hook for device classes that want pre-warming. Default: no-op."""
 
+    async def async_manual_sync(self) -> None:
+        """Extra work for an explicit Sync-button press, run before the
+        coordinator refresh. Default no-op: classes whose refresh_state already
+        connects (protobuf's #15 read) need nothing more. The mesh classes,
+        whose refresh_state is passive (no BLE), override this to force a
+        connect so the button actually pulls live state off the device."""
+
     async def async_unload(self) -> None:
         if self.connection is not None:
             await self.connection.disconnect()

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -14,6 +14,8 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 
+from bleak.exc import BleakError
+
 from ..connection import BHyveBleConnection
 from .base import BHyveBleDeviceBase
 
@@ -249,3 +251,20 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         STATUS query (future enhancement, needs hardware verification)."""
         await super().refresh_state()
         return self.state
+
+    async def async_manual_sync(self) -> None:
+        """Sync button: this mesh class's periodic refresh_state is passive (it
+        never opens BLE), so force a fresh connect here. The connect-time 8-step
+        init's status (seq 0x02) and info (seq 0x03) replies refresh watering
+        state and battery via _observe_plaintext — the on-demand refresh #24
+        dropped when it stopped forcing a connect on the button. Ephemeral:
+        disconnect afterwards so we don't hold the device's single session."""
+        if self.connection is None:
+            return
+        try:
+            await self.connection.disconnect()
+            await self.connection.ensure_connected()
+        except (BleakError, asyncio.TimeoutError, OSError) as err:
+            _LOGGER.warning("%s: manual sync connect failed: %s", self.mac, err)
+        finally:
+            await self.connection.disconnect()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -791,3 +791,51 @@ def test_send_actuation_reopens_when_pooled_bind_refresh_fails():
     assert calls["ensure_connected"] == 1    # fresh session reopened
     assert calls["writes"] == [b"\xaa\xbb"]  # command still written after recovery
     assert result == []
+
+
+# --- Sync button forces a connect on mesh (regression) ---------------------
+
+class _SyncConn:
+    """Minimal connection that counts connects/disconnects for the Sync test."""
+
+    def __init__(self):
+        self.ensure_connected_calls = 0
+        self.disconnects = 0
+        self._connected = False
+
+    async def ensure_connected(self):
+        self.ensure_connected_calls += 1
+        self._connected = True
+
+    async def disconnect(self):
+        self.disconnects += 1
+        self._connected = False
+
+    @property
+    def is_connected(self):
+        return self._connected
+
+
+def test_sync_button_forces_connect_on_mesh():
+    # Regression (ljmerza PR #24 feedback): #24 dropped the forced connect from
+    # the Sync button and routed it through refresh_state, which on mesh is
+    # passive (no BLE) — so the button became a no-op there (never refreshed
+    # battery/state). async_manual_sync must force a fresh connect (the 8-step
+    # init that refreshes battery/state via _observe_plaintext) and tear it down.
+    dev = object.__new__(BHyveHT25Device)  # bypass HA-heavy __init__
+    dev.mac = "44:67:55:52:94:A1"
+    conn = _SyncConn()
+    dev.connection = conn
+    asyncio.run(dev.async_manual_sync())
+    assert conn.ensure_connected_calls == 1   # forced a fresh connect
+    assert conn.disconnects >= 1              # torn down afterwards (ephemeral)
+
+
+def test_manual_sync_is_noop_for_protobuf():
+    # Protobuf refresh_state connects on its own (#15 read), so the base hook
+    # must NOT add a second connect on the Sync button.
+    dev = _make_device(is_watering=False)
+    conn = _SyncConn()
+    dev.connection = conn
+    asyncio.run(dev.async_manual_sync())
+    assert conn.ensure_connected_calls == 0


### PR DESCRIPTION
## What

Restores the **Sync button's on-demand refresh on mesh devices** — a regression from #24. Found while hardware-testing #24 on live mesh HT25 valves.

Independent of #26 (that's the `connection.py` stale-pool actuation self-heal); this touches `button.py` / `base.py` / `ht25.py`. Both target `main`.

## The bug

#24 changed the Sync button to just call `async_request_refresh()`, dropping the old forced connect:

```python
# before #24:
await conn.disconnect()
await conn.ensure_connected()   # ← forced connect; connect-time init refreshed battery
await self.coordinator.async_request_refresh()
```

On **protobuf** devices (Gen2/XD) that's fine — their `refresh_state()` connects for a `#15` status read. But the **mesh** `refresh_state()` is deliberately passive (*"update is_connected … without opening one"*), so on mesh the Sync button became a **no-op**: pressing it never connects to the valve, so battery/state are never refreshed. Confirmed on hardware — the press logs `Finished fetching … in 0.000 seconds` with no BLE connect. (The button's own docstring still promises the connect.)

## The fix

Add an `async_manual_sync()` hook, run by the button before the coordinator refresh:
- **base**: no-op (protobuf's `refresh_state` already connects — no double connect).
- **mesh (`ht25`)**: force a fresh connect, so the connect-time 8-step init's `status` (seq `0x02`) and `info` (seq `0x03`) replies refresh watering-state + battery via `_observe_plaintext`, then disconnect (ephemeral).

## Testing

`python -m pytest` → **98 passed**. Adds two regression tests: mesh `async_manual_sync` forces exactly one connect + tears it down; the base hook is a no-op for protobuf (no second connect).

Hardware validation on mesh HT25 to follow.

<sub>🤖 Generated with Claude Code</sub>
