### PR TITLE
fix(mesh): make the Connected sensor event-driven (reflect reachability)

### DIFF
--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -158,6 +158,21 @@ class BHyveBleDeviceBase(abc.ABC):
         if self._state_changed_cb is not None:
             self._state_changed_cb()
 
+    def _mark_reached(self) -> None:
+        """Record a successful device reach for the connectivity diagnostics
+        (Connected / Last successful poll / Consecutive timeouts). Connectivity
+        is EVENT-DRIVEN under the ephemeral connect-on-demand model: the live
+        socket is torn down between operations, so "reachable" means the last
+        reach succeeded — not that a socket is open right now."""
+        self.state.is_connected = True
+        self.state.last_successful_poll = datetime.now(timezone.utc)
+        self.state.consecutive_timeouts = 0
+
+    def _mark_unreachable(self) -> None:
+        """Record a failed device reach (couldn't connect / talk to the device)."""
+        self.state.is_connected = False
+        self.state.consecutive_timeouts += 1
+
     async def _post_handshake(self, conn: BHyveBleConnection) -> None:
         """Override to send per-class init frames after the AES handshake."""
 
@@ -197,10 +212,14 @@ class BHyveBleDeviceBase(abc.ABC):
         ...
 
     async def refresh_state(self) -> DeviceState:
-        """Default: only refresh BLE-connection liveness. Subclasses can extend
-        with a status-request roundtrip."""
-        if self.connection is not None:
-            self.state.is_connected = self.connection.is_connected
+        """Default (mesh): passive — return the last-known state without opening
+        BLE. Connectivity is event-driven (stamped on each real device reach via
+        _mark_reached / _mark_unreachable), so a passive poll must NOT overwrite
+        state.is_connected with the transient live socket: under the ephemeral
+        model that socket is torn down between operations and would read False
+        even right after a successful reach, pinning the Connected sensor off.
+        Subclasses that connect every poll (protobuf's #15 read) override this
+        and stamp connectivity themselves."""
         return self.state
 
     @property

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -201,6 +201,7 @@ class BHyveHT25Device(BHyveBleDeviceBase):
             _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
             notifs = await self._send_command(plaintext, "START")
             self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+            self._mark_reached()  # connected + sent → device reached this cycle
             # The off-timer is armed by the device's START-ack (_observe_plaintext),
             # not by send()'s return — so this holds even when the write-response
             # times out. Report whatever state the ack has produced by now.
@@ -217,6 +218,7 @@ class BHyveHT25Device(BHyveBleDeviceBase):
             _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
             notifs = await self._send_command(plaintext, "STOP")
             self._stamp_command("stop", len(notifs))
+            self._mark_reached()  # connected + sent → device reached this cycle
             return not self.state.is_watering
         finally:
             if self.connection is not None:
@@ -242,13 +244,14 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         return notifs
 
     async def refresh_state(self):
-        """Best-effort liveness refresh: update is_connected from the pooled
-        connection without opening one. is_watering is driven by the device's
-        START/STOP ack (_observe_plaintext) and the coordinator's wall-clock
-        auto-close; the STATUS reply's mode byte is decoded too (base
-        _observe_plaintext, 0x04=watering/0x01=idle), but an idle poll doesn't
-        connect to elicit it, so live idle-poll status would need a connect +
-        STATUS query (future enhancement, needs hardware verification)."""
+        """Passive poll: return the last-known state without opening BLE.
+        Connectivity is event-driven (stamped by _mark_reached on each actual
+        connect: Sync / start / stop), so this poll deliberately does NOT touch
+        state.is_connected — reading the torn-down live socket would pin the
+        Connected sensor off. is_watering is driven by the device's START/STOP
+        ack (_observe_plaintext) and the coordinator's wall-clock auto-close;
+        eliciting live idle status would need a connect + STATUS query (future
+        enhancement, needs hardware verification)."""
         await super().refresh_state()
         return self.state
 
@@ -266,5 +269,8 @@ class BHyveHT25Device(BHyveBleDeviceBase):
             await self.connection.ensure_connected()
         except (BleakError, asyncio.TimeoutError, OSError) as err:
             _LOGGER.warning("%s: manual sync connect failed: %s", self.mac, err)
+            self._mark_unreachable()
+        else:
+            self._mark_reached()  # connect + init succeeded → device reached
         finally:
             await self.connection.disconnect()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -824,6 +824,7 @@ def test_sync_button_forces_connect_on_mesh():
     # init that refreshes battery/state via _observe_plaintext) and tear it down.
     dev = object.__new__(BHyveHT25Device)  # bypass HA-heavy __init__
     dev.mac = "44:67:55:52:94:A1"
+    dev.state = DeviceState()
     conn = _SyncConn()
     dev.connection = conn
     asyncio.run(dev.async_manual_sync())
@@ -839,3 +840,65 @@ def test_manual_sync_is_noop_for_protobuf():
     dev.connection = conn
     asyncio.run(dev.async_manual_sync())
     assert conn.ensure_connected_calls == 0
+
+
+# --- event-driven mesh connectivity (Connected sensor) ---------------------
+
+def test_manual_sync_marks_connected_on_success():
+    # A Sync that reaches the device must flip the Connected diagnostic on and
+    # stamp last_successful_poll / clear consecutive_timeouts. Event-driven,
+    # because the ephemeral disconnect closes the socket before the coordinator
+    # refresh runs — reading the live socket then would read False.
+    dev = object.__new__(BHyveHT25Device)
+    dev.mac = "44:67:55:52:94:A1"
+    dev.state = DeviceState(consecutive_timeouts=3)
+    dev.connection = _SyncConn()
+    asyncio.run(dev.async_manual_sync())
+    assert dev.state.is_connected is True
+    assert dev.state.consecutive_timeouts == 0
+    assert dev.state.last_successful_poll is not None
+
+
+class _FailSyncConn:
+    """A connection whose connect always fails (device unreachable)."""
+
+    async def disconnect(self):
+        pass
+
+    async def ensure_connected(self):
+        from bleak.exc import BleakError
+        raise BleakError("Not connected")
+
+    @property
+    def is_connected(self):
+        return False
+
+
+def test_manual_sync_marks_unreachable_on_failure():
+    # A Sync that can't reach the device flips Connected off and counts a timeout
+    # (and must not raise — the button/service call stays healthy).
+    dev = object.__new__(BHyveHT25Device)
+    dev.mac = "44:67:55:52:94:A1"
+    dev.state = DeviceState(is_connected=True, consecutive_timeouts=0)
+    dev.connection = _FailSyncConn()
+    asyncio.run(dev.async_manual_sync())
+    assert dev.state.is_connected is False
+    assert dev.state.consecutive_timeouts == 1
+
+
+def test_mesh_passive_poll_does_not_clobber_connected():
+    # The passive mesh poll must NOT overwrite event-driven connectivity with the
+    # torn-down live socket (which reads False under the ephemeral model) — doing
+    # so pinned the Connected sensor off right after a successful reach.
+    dev = object.__new__(BHyveHT25Device)
+    dev.mac = "44:67:55:52:94:A1"
+    dev.state = DeviceState(is_connected=True)
+
+    class _DownConn:
+        @property
+        def is_connected(self):
+            return False   # socket torn down between operations
+
+    dev.connection = _DownConn()
+    asyncio.run(dev.refresh_state())
+    assert dev.state.is_connected is True   # not clobbered


### PR DESCRIPTION
## What

Makes the **Connected** binary sensor reflect actual device reachability on mesh devices — a regression from #24, exposed while hardware-testing the Sync button (#27).

> **Stacked on #27** (it modifies the `async_manual_sync` that #27 adds). Base is `fix/mesh-sync-button-connect`; GitHub will auto-retarget this to `main` once #27 merges. Review #27 first.

## The bug

The Connected sensor's `is_on` reads `state.is_connected`, and its docstring says that means *"True when the last status poll REACHED the device … reflects poll-reachability rather than a live socket."* But on mesh the value was set by `base.refresh_state` from the **live socket**:

```python
self.state.is_connected = self.connection.is_connected
```

Under #24's ephemeral connect-on-demand model the socket is torn down between operations, so this reads `False` almost always — the Connected sensor was effectively **pinned off on mesh**, even right after a successful Sync/connect. (Pressing Sync connects fine, but `async_manual_sync` disconnects in its `finally`, then the coordinator refresh samples the dead socket → `False`.)

## The fix

Make connectivity **event-driven**:
- `_mark_reached()` — stamps `is_connected=True` + `last_successful_poll` and clears `consecutive_timeouts` on each real device reach (**Sync, start, stop**).
- `_mark_unreachable()` — flips it off + counts a timeout on a failed reach.
- The passive mesh poll (`base.refresh_state`) no longer clobbers `is_connected` with the torn-down socket.

Protobuf is unaffected — its `refresh_state` connects every poll (a `#15` read) and already stamps its own connectivity.

## Testing

`python -m pytest` → **101 passed**. Adds three tests: a successful Sync marks connected (+ stamps last-poll / clears timeouts), a failed Sync marks unreachable (+ counts a timeout, doesn't raise), and the passive poll no longer clobbers a good `is_connected`.

Hardware validation on mesh HT25 to follow.

<sub>🤖 Generated with Claude Code</sub>
