### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/custom_components/orbit_bhyve/manifest.json
+++ b/custom_components/orbit_bhyve/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ljmerza/orbit-bhyve-ble/issues",
   "requirements": ["bleak-retry-connector>=3.5.0", "aiohttp>=3.9.0"],
-  "version": "2.1.2"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
Version bump for the v2.2.0 release (protobuf-family unification #24 + mesh fixes #26/#27/#29 + docs).