### PR TITLE
Watering programs + protobuf-family capability round-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Per discovered sprinkler device:
 - **Sync** button per device — forces a fresh BLE connect + init
   handshake. Useful after a long idle, or to refresh the battery
   reading on demand without waiting for the next poll.
+- **Identify** button (protobuf family) — flashes the device LED (#47)
+  so you can physically locate it. No-op on the XD, which ignores it.
+- **Automatic watering** switch — the device-global controller mode
+  (auto vs. off). When off, stored programs don't run.
+- **Program A–D** enable switches + summary sensors — each stored
+  program slot's on/off enable bit, plus a sensor showing its schedule
+  (days, start times, per-zone durations). A slot with no stored program
+  reads `unavailable`.
+- **Next run** sensor — the device-computed next scheduled program start
+  (timestamp), with the program letter(s) as an attribute.
 - Manufacturer / model / firmware / MAC are exposed via the device's
   "Device info" panel.
 
@@ -75,6 +85,20 @@ registry.
 - `orbit_bhyve.stop_all` — stop everything on the targeted device
 - `orbit_bhyve.refresh_devices` — re-query the cloud (for new devices, key
   rotation, or fw changes); manual, no background polling
+- `orbit_bhyve.get_program` — read back a program slot (A–F) as structured
+  data (`SupportsResponse.ONLY`): days, start times, per-zone durations
+- `orbit_bhyve.set_program` — store/replace a program in a slot: watering
+  days (weekdays / even / odd / every-N-days), start time(s), per-zone
+  run durations. Optionally enable it in the same call
+- `orbit_bhyve.delete_program` — clear a program slot
+
+> **Watering programs are for non-Smart slots.** The device stores up to six
+> program slots; this integration reads and writes their schedules over BLE.
+> Slots are read back from the device's `#10` sync dump (a multi-frame reply
+> reassembled over the connection), so `get_program` and the Program sensors
+> reflect what's actually stored — including programs created in the B-Hyve
+> app. For richer scheduling logic, drive `start_watering` from
+> `irrigation_unlimited` or HA's Smart Irrigation instead.
 
 ## Options flow
 

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -6,11 +6,13 @@ only at setup time and on user-triggered refresh; runtime is BLE-only.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
 
 import voluptuous as vol
+from bleak.exc import BleakError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
@@ -43,7 +45,13 @@ from .const import (
 )
 from .coordinator import BHyveDeviceCoordinator
 from .devices import UnsupportedModel, build_device
-from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, ProgramSpec, ProgramSummary
+from .devices.base import (
+    PROGRAM_SLOTS,
+    SLOT_LETTERS,
+    ProgramSpec,
+    ProgramSummary,
+    parse_start_minutes,
+)
 from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -212,10 +220,10 @@ def _spec_from_call(call: ServiceCall) -> ProgramSpec:
         # Symmetric with the weekdays check: don't let a missing interval_days
         # silently fall back to every-1-day in _build_program_pb.
         raise ServiceValidationError("interval mode needs interval_days")
-    start_mins: list[int] = []
-    for tok in call.data["start_times"]:
-        h, _, m = str(tok).partition(":")
-        start_mins.append((int(h) * 60 + int(m or 0)) % 1440)
+    try:
+        start_mins = [parse_start_minutes(tok) for tok in call.data["start_times"]]
+    except ValueError as err:
+        raise ServiceValidationError(str(err)) from err
     zones: list[tuple[int, int]] = []
     for z in call.data["zones"]:
         zones.append((int(z["zone"]) - 1, int(z["minutes"]) * 60))
@@ -494,7 +502,15 @@ def _register_services(hass: HomeAssistant) -> None:
         slot_filter = call.data.get("slot")
         result: dict[str, Any] = {}
         for coord in coords:
-            programs = await coord.device.get_programs()
+            try:
+                programs = await coord.device.get_programs()
+            except (BleakError, asyncio.TimeoutError) as err:
+                # On-demand read over a marginal BLE link: surface a clean HA error
+                # instead of a raw BleakError to the service caller (mirrors the write
+                # path's _ble_write_guard).
+                raise HomeAssistantError(
+                    f"could not read programs from {coord.device.name}: {err}"
+                ) from err
             # get_programs() already refreshed state.programs over its own ephemeral
             # session; push that to the entities without a second BLE connect (a
             # full async_request_refresh would re-poll the device for a read-only call).
@@ -503,9 +519,12 @@ def _register_services(hass: HomeAssistant) -> None:
             if slot_filter:
                 sid = PROGRAM_SLOTS[slot_filter.upper()]
                 slots = {sid: programs[sid]} if sid in programs else {}
-            result[coord.device.name] = [
-                _summary_to_dict(programs[sid]) for sid in sorted(slots)
-            ]
+            # Key by the device MAC (unique) with a name field, so two same-named
+            # devices can't clobber each other in the response.
+            result[coord.device.mac] = {
+                "name": coord.device.name,
+                "programs": [_summary_to_dict(programs[sid]) for sid in sorted(slots)],
+            }
         return {"devices": result}
 
     hass.services.async_register(

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -203,6 +203,10 @@ def _spec_from_call(call: ServiceCall) -> ProgramSpec:
             weekday_mask |= 1 << _WEEKDAY_BITS[d[:3].lower()]
         if not weekday_mask:
             raise HomeAssistantError("weekdays mode needs at least one weekday")
+    elif day_mode == "interval" and not call.data.get("interval_days"):
+        # Symmetric with the weekdays check: don't let a missing interval_days
+        # silently fall back to every-1-day in _build_program_pb.
+        raise HomeAssistantError("interval mode needs interval_days")
     start_mins: list[int] = []
     for tok in call.data["start_times"]:
         h, _, m = str(tok).partition(":")
@@ -486,7 +490,10 @@ def _register_services(hass: HomeAssistant) -> None:
         result: dict[str, Any] = {}
         for coord in coords:
             programs = await coord.device.get_programs()
-            await coord.async_request_refresh()
+            # get_programs() already refreshed state.programs over its own ephemeral
+            # session; push that to the entities without a second BLE connect (a
+            # full async_request_refresh would re-poll the device for a read-only call).
+            coord.async_set_updated_data(coord.device.state)
             slots = programs
             if slot_filter:
                 sid = PROGRAM_SLOTS[slot_filter.upper()]

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -13,9 +13,10 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .cloud import CloudAuthError, CloudConnectionError, OrbitCloudClient
@@ -37,8 +38,12 @@ from .const import (
 )
 from .coordinator import BHyveDeviceCoordinator
 from .devices import UnsupportedModel, build_device
+from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, ProgramSpec, ProgramSummary
+from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+_WEEKDAY_BITS = {"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6}
 
 PLATFORMS: list[Platform] = [
     Platform.VALVE,
@@ -46,6 +51,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.BUTTON,
+    Platform.SWITCH,
 ]
 
 
@@ -155,6 +161,87 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             seconds=poll_watering if coord.device.state.is_watering else poll_idle
         )
     _LOGGER.debug("%s: options applied in place (no reload)", entry.entry_id)
+
+
+def _protobuf_coordinators_for_call(
+    hass: HomeAssistant, call: ServiceCall
+) -> list[BHyveDeviceCoordinator]:
+    """Resolve the targeted device_id(s) to protobuf-family coordinators.
+
+    Program services target a device; map its registry id -> our cloud_id (the
+    device_info identifier) -> coordinator. Non-protobuf targets (hub/mesh) are
+    skipped — programs are a protobuf-family capability."""
+    device_ids = call.data.get("device_id", [])
+    if isinstance(device_ids, str):
+        device_ids = [device_ids]
+    reg = dr.async_get(hass)
+    wanted_cloud_ids: set[str] = set()
+    for did in device_ids:
+        entry = reg.async_get(did)
+        if entry is None:
+            continue
+        wanted_cloud_ids |= {ident[1] for ident in entry.identifiers if ident[0] == DOMAIN}
+    coords: list[BHyveDeviceCoordinator] = []
+    for runtime in hass.data.get(DOMAIN, {}).values():
+        for cloud_id, coord in runtime.coordinators.items():
+            if cloud_id in wanted_cloud_ids and isinstance(coord.device, BHyveProtobufDevice):
+                coords.append(coord)
+    return coords
+
+
+def _spec_from_call(call: ServiceCall) -> ProgramSpec:
+    """Build a ProgramSpec from the set_program service data. Zones are given in
+    MINUTES (user-friendly) and start times as HH:MM, both mapped to the wire's
+    0-indexed stations / seconds / minutes-from-midnight."""
+    slot = PROGRAM_SLOTS[call.data["slot"].upper()]
+    day_mode = call.data["day_mode"]
+    weekday_mask = None
+    if day_mode == "weekdays":
+        days = call.data.get("weekdays") or []
+        weekday_mask = 0
+        for d in days:
+            weekday_mask |= 1 << _WEEKDAY_BITS[d[:3].lower()]
+        if not weekday_mask:
+            raise HomeAssistantError("weekdays mode needs at least one weekday")
+    start_mins: list[int] = []
+    for tok in call.data["start_times"]:
+        h, _, m = str(tok).partition(":")
+        start_mins.append((int(h) * 60 + int(m or 0)) % 1440)
+    zones: list[tuple[int, int]] = []
+    for z in call.data["zones"]:
+        zones.append((int(z["zone"]) - 1, int(z["minutes"]) * 60))
+    return ProgramSpec(
+        slot=slot,
+        day_mode=day_mode,
+        weekday_mask=weekday_mask,
+        interval_days=call.data.get("interval_days"),
+        interval_anchor=call.data.get("interval_anchor"),
+        start_mins=tuple(start_mins),
+        zones=tuple(zones),
+        name=call.data.get("name", ""),
+        budget=int(call.data.get("budget", 100)),
+        enabled=bool(call.data.get("enabled", False)),
+    )
+
+
+def _summary_to_dict(summary: ProgramSummary) -> dict[str, Any]:
+    """A JSON-serializable view of a decoded program slot for the get_program
+    service response (zones back to 1-indexed, run time in minutes)."""
+    if summary.empty:
+        return {"slot": SLOT_LETTERS.get(summary.slot, summary.slot), "empty": True}
+    return {
+        "slot": SLOT_LETTERS.get(summary.slot, summary.slot),
+        "empty": False,
+        "enabled": summary.enabled,
+        "name": summary.name,
+        "day_mode": summary.day_mode,
+        "weekday_mask": summary.weekday_mask,
+        "interval_days": summary.interval_days,
+        "interval_anchor": summary.interval_anchor,
+        "start_times": [f"{m // 60:02d}:{m % 60:02d}" for m in summary.start_mins],
+        "zones": [{"zone": sid + 1, "minutes": round(sec / 60, 2)} for sid, sec in summary.zones],
+        "budget": summary.budget,
+    }
 
 
 def _register_services(hass: HomeAssistant) -> None:
@@ -332,4 +419,90 @@ def _register_services(hass: HomeAssistant) -> None:
             vol.Optional("drain_ms", default=2000):
                 vol.All(vol.Coerce(int), vol.Range(min=100, max=10000)),
         }),
+    )
+
+    # ─── Watering programs (protobuf family: HT34A / HT25G2) ──────────────────
+
+    async def set_program(call: ServiceCall) -> None:
+        coords = _protobuf_coordinators_for_call(hass, call)
+        if not coords:
+            raise HomeAssistantError("no protobuf B-Hyve device matched the target")
+        spec = _spec_from_call(call)
+        for coord in coords:
+            ok = await coord.device.set_program(spec)
+            await coord.async_request_refresh()
+            if not ok:
+                _LOGGER.warning(
+                    "%s: set_program slot %s not confirmed by the device",
+                    coord.device.mac, call.data["slot"],
+                )
+
+    hass.services.async_register(
+        DOMAIN,
+        "set_program",
+        set_program,
+        schema=vol.Schema({
+            vol.Required("device_id"): vol.All(cv.ensure_list, [cv.string]),
+            vol.Required("slot"): vol.In(list(PROGRAM_SLOTS)),
+            vol.Required("day_mode"): vol.In(["weekdays", "interval", "odd", "even", "once"]),
+            vol.Optional("weekdays"): vol.All(cv.ensure_list, [vol.In(list(_WEEKDAY_BITS))]),
+            vol.Optional("interval_days"): vol.All(vol.Coerce(int), vol.Range(min=1, max=31)),
+            vol.Optional("interval_anchor"): cv.string,
+            vol.Required("start_times"): vol.All(cv.ensure_list, [cv.string]),
+            vol.Required("zones"): vol.All(cv.ensure_list, [vol.Schema({
+                vol.Required("zone"): vol.All(vol.Coerce(int), vol.Range(min=1, max=16)),
+                vol.Required("minutes"): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+            })]),
+            vol.Optional("name", default=""): cv.string,
+            vol.Optional("budget", default=100): vol.All(vol.Coerce(int), vol.Range(min=0, max=300)),
+            vol.Optional("enabled", default=False): cv.boolean,
+        }),
+    )
+
+    async def delete_program(call: ServiceCall) -> None:
+        coords = _protobuf_coordinators_for_call(hass, call)
+        if not coords:
+            raise HomeAssistantError("no protobuf B-Hyve device matched the target")
+        slot = PROGRAM_SLOTS[call.data["slot"].upper()]
+        for coord in coords:
+            await coord.device.delete_program(slot)
+            await coord.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        "delete_program",
+        delete_program,
+        schema=vol.Schema({
+            vol.Required("device_id"): vol.All(cv.ensure_list, [cv.string]),
+            vol.Required("slot"): vol.In(list(PROGRAM_SLOTS)),
+        }),
+    )
+
+    async def get_program(call: ServiceCall) -> ServiceResponse:
+        coords = _protobuf_coordinators_for_call(hass, call)
+        if not coords:
+            raise HomeAssistantError("no protobuf B-Hyve device matched the target")
+        slot_filter = call.data.get("slot")
+        result: dict[str, Any] = {}
+        for coord in coords:
+            programs = await coord.device.get_programs()
+            await coord.async_request_refresh()
+            slots = programs
+            if slot_filter:
+                sid = PROGRAM_SLOTS[slot_filter.upper()]
+                slots = {sid: programs[sid]} if sid in programs else {}
+            result[coord.device.name] = [
+                _summary_to_dict(programs[sid]) for sid in sorted(slots)
+            ]
+        return {"devices": result}
+
+    hass.services.async_register(
+        DOMAIN,
+        "get_program",
+        get_program,
+        schema=vol.Schema({
+            vol.Required("device_id"): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional("slot"): vol.In(list(PROGRAM_SLOTS)),
+        }),
+        supports_response=SupportsResponse.ONLY,
     )

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -14,7 +14,12 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -202,11 +207,11 @@ def _spec_from_call(call: ServiceCall) -> ProgramSpec:
         for d in days:
             weekday_mask |= 1 << _WEEKDAY_BITS[d[:3].lower()]
         if not weekday_mask:
-            raise HomeAssistantError("weekdays mode needs at least one weekday")
+            raise ServiceValidationError("weekdays mode needs at least one weekday")
     elif day_mode == "interval" and not call.data.get("interval_days"):
         # Symmetric with the weekdays check: don't let a missing interval_days
         # silently fall back to every-1-day in _build_program_pb.
-        raise HomeAssistantError("interval mode needs interval_days")
+        raise ServiceValidationError("interval mode needs interval_days")
     start_mins: list[int] = []
     for tok in call.data["start_times"]:
         h, _, m = str(tok).partition(":")

--- a/custom_components/orbit_bhyve/button.py
+++ b/custom_components/orbit_bhyve/button.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
 from .devices import BHyveHubDevice
+from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +48,10 @@ async def async_setup_entry(
         # than waiting for the watering poll's passive update.
         if getattr(coord.device, "has_flow", False):
             entities.append(BHyveCheckFlowButton(coord))
+        # LED-locate is a protobuf-family capability (#47). It's a no-op on the XD
+        # but harmless, so expose it on the whole family for a consistent card.
+        if isinstance(coord.device, BHyveProtobufDevice):
+            entities.append(BHyveIdentifyButton(coord))
     async_add_entities(entities)
 
 
@@ -112,3 +117,36 @@ class BHyveCheckFlowButton(CoordinatorEntity[BHyveDeviceCoordinator], ButtonEnti
         await device.read_flow()
         # Push the freshly-sampled flow_gpm to entities without a full #15 poll.
         self.coordinator.async_set_updated_data(device.state)
+
+
+class BHyveIdentifyButton(CoordinatorEntity[BHyveDeviceCoordinator], ButtonEntity):
+    """Flash the device's LED to physically locate it (#47 identifyDevice).
+
+    Gen2 (HT25G2) flashes red for a few seconds; a no-op on the XD (HT34A), which
+    ignores #47 — harmless, so the button exists across the protobuf family for a
+    uniform device card."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Identify"
+    _attr_icon = "mdi:led-on"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_identify"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    async def async_press(self) -> None:
+        device = self.coordinator.device
+        if device.connection is None:
+            return
+        _LOGGER.info("%s: identify requested via button", device.mac)
+        await device.identify()

--- a/custom_components/orbit_bhyve/connection.py
+++ b/custom_components/orbit_bhyve/connection.py
@@ -94,6 +94,12 @@ class BHyveBleConnection:
         self._rx_ctr: int = 0
         self._lock = asyncio.Lock()
         self._notif_buf: list[bytes] = []
+        # Decrypted plaintext of each notification in the current burst, in arrival
+        # order — parallel to _notif_buf. send_stream() concatenates these into one
+        # CTR stream so a multi-frame reply (a #19 program body that spans frames)
+        # can be reassembled. Populated in _on_notify right after a successful
+        # decrypt; cleared with _notif_buf before every write.
+        self._notif_pt: list[bytes] = []
         self._notif_event = asyncio.Event()  # set on every notification; drives _drain
         self._last_rx_frame: bytes | None = None  # last raw RX frame, for de-dup
         self._handshaken = False
@@ -225,6 +231,11 @@ class BHyveBleConnection:
                 "%s: notif pt=%s (ct=%s)",
                 self.mac, pt.hex(), frame.hex(),
             )
+            # Accumulate the decrypted plaintext for send_stream's multi-frame
+            # reassembly. Do this BEFORE the header check below returns early on a
+            # continuation frame — a long reply's continuation blocks legitimately
+            # don't carry the inner-message header but ARE part of the stream.
+            self._notif_pt.append(pt)
             if (
                 self._reply_header is not None
                 and len(pt) >= 4
@@ -277,6 +288,7 @@ class BHyveBleConnection:
         self._handshaken = False
         self._iv = None
         self._last_rx_frame = None
+        self._notif_pt.clear()
 
     def _arm_idle_timer(self) -> None:
         if self._idle_sec <= 0:
@@ -373,18 +385,47 @@ class BHyveBleConnection:
             except asyncio.TimeoutError:
                 return  # no new frame within the window -> reply complete (or silent)
 
+    async def _write_and_drain(self, plaintext: bytes, drain_ms: int) -> list[bytes]:
+        """Write a command and collect its reply. Caller MUST hold self._lock and
+        have an established, initialised session."""
+        self._notif_buf.clear()
+        self._notif_pt.clear()
+        await self._write_locked(plaintext)
+        await self._drain(drain_ms)
+        received = list(self._notif_buf)
+        self._notif_buf.clear()
+        self._arm_idle_timer()
+        return received
+
     async def send(self, plaintext: bytes, *, drain_ms: int = 1500) -> list[bytes]:
         """Encrypt + WRITE_REQ + drain notifications until the reply goes quiet
         (bounded by `drain_ms`). Returns the raw notification frames received."""
         async with self._lock:
             await self.ensure_connected()
+            return await self._write_and_drain(plaintext, drain_ms)
+
+    async def send_stream(self, plaintext: bytes, *, drain_ms: int = 4000) -> bytes:
+        """Send a request and return the concatenated decrypted plaintext of the
+        WHOLE reply burst, for multi-frame reassembly by the caller.
+
+        A long inner message (a #19 program body in a #10 sync dump) streams as
+        consecutive 16-byte CTR blocks, each in its own outer frame, the RX counter
+        advancing per block across all of them. _on_notify decrypts each frame at
+        the running counter, so joining the per-frame plaintexts reproduces the
+        original stream; the caller (status.split_inner_messages / parse_sync_dump)
+        scans it for the aa775a0f-headed inner messages. Single-frame fast paths
+        (#16/#30/#59) are untouched — they still flow through send()/the observer."""
+        async with self._lock:
+            await self.ensure_connected()
             self._notif_buf.clear()
+            self._notif_pt.clear()
             await self._write_locked(plaintext)
             await self._drain(drain_ms)
-            received = list(self._notif_buf)
+            stream = b"".join(self._notif_pt)
             self._notif_buf.clear()
+            self._notif_pt.clear()
             self._arm_idle_timer()
-            return received
+            return stream
 
     async def send_raw(self, plaintext: bytes) -> None:
         """Encrypt + WRITE_REQ with no notification drain. For init-step
@@ -425,6 +466,7 @@ class BHyveBleConnection:
                 # Cold — ensure_connected() retries the open and runs the hook.
                 await self.ensure_connected()
             self._notif_buf.clear()
+            self._notif_pt.clear()
             await self._write_locked(plaintext)
             await self._drain(drain_ms)
             received = list(self._notif_buf)

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -27,6 +27,9 @@ def _mv_to_pct(mv: int) -> int:
 # the app exposes A-D. A=bit0 in the #20 activeProgramFlags enable bitmask.
 PROGRAM_SLOTS = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6}
 SLOT_LETTERS = {v: k for k, v in PROGRAM_SLOTS.items()}
+# The slots surfaced as HA entities (the app-visible A-D), one per program switch
+# and summary sensor.
+UI_SLOTS = ("A", "B", "C", "D")
 
 
 @dataclass

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -23,6 +23,47 @@ def _mv_to_pct(mv: int) -> int:
     return max(0, min(100, pct))
 
 
+# Watering-program slots (A=1 .. F=6). The device carries six schedule slots;
+# the app exposes A-D. A=bit0 in the #20 activeProgramFlags enable bitmask.
+PROGRAM_SLOTS = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6}
+SLOT_LETTERS = {v: k for k, v in PROGRAM_SLOTS.items()}
+
+
+@dataclass
+class ProgramSpec:
+    """A watering program to WRITE (#19 setProgramSchedule).
+
+    Zones are 0-indexed station ids on the wire (the CLI/service layer maps its
+    1-indexed zones down). Exactly one day-mode is expressed by which of the
+    weekday/interval/odd/even/once fields is populated (per `day_mode`)."""
+    slot: int                            # 1=A .. 6=F
+    day_mode: str                        # "weekdays" | "interval" | "odd" | "even" | "once"
+    weekday_mask: int | None = None      # weekdays: bit0=Sun .. bit6=Sat
+    interval_days: int | None = None     # interval: N
+    interval_anchor: str | None = None   # interval: ISO-8601 anchor
+    start_mins: tuple[int, ...] = ()     # minutes-from-midnight (device-local)
+    zones: tuple[tuple[int, int], ...] = ()   # (station_id_0idx, run_sec)
+    name: str = ""
+    budget: int = 100
+    enabled: bool = False                # drive the enable handshake after storing
+
+
+@dataclass
+class ProgramSummary:
+    """A #19 program body decoded from a device read (connect burst / sync dump)."""
+    slot: int
+    empty: bool = True                   # #2 programTypeNotSet present -> empty slot
+    enabled: bool | None = None          # from the #20 bitmask, not the #19 body
+    day_mode: str | None = None
+    weekday_mask: int | None = None
+    interval_days: int | None = None
+    interval_anchor: str | None = None
+    start_mins: tuple[int, ...] = ()
+    zones: tuple[tuple[int, int], ...] = ()   # (station_id_0idx, run_sec)
+    name: str | None = None
+    budget: int | None = None
+
+
 @dataclass
 class DeviceState:
     is_watering: bool = False
@@ -41,6 +82,11 @@ class DeviceState:
     rain_delay_ends: datetime | None = None
     last_successful_poll: datetime | None = None
     consecutive_timeouts: int = 0
+    # Controller / program state (protobuf family).
+    controller_mode: int | None = None   # #16.#2.#1 timerMode.mode: 0=off, 1=auto, 2=manual
+    next_start_flags: int | None = None  # #16.#9 nextStartProgramFlags (slot bitmask, A=bit0)
+    next_start_at: datetime | None = None  # #16.#10 nextStartTimeSecEpochUTC as an aware datetime
+    programs: dict[int, ProgramSummary] = field(default_factory=dict)  # slot(1-6) -> summary
     extra: dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -32,6 +32,30 @@ SLOT_LETTERS = {v: k for k, v in PROGRAM_SLOTS.items()}
 UI_SLOTS = ("A", "B", "C", "D")
 
 
+def parse_start_minutes(tok: object) -> int:
+    """Parse one program start-time token to minutes-from-midnight (0..1439).
+
+    Guards two YAML/service footguns instead of silently wrapping with `% 1440`:
+    an *unquoted* HH:MM inside a YAML list is parsed as a sexagesimal INT
+    (`18:00` -> `1080`, later coerced to the string ``"1080"``), and an
+    ``HH:MM:SS`` string (what HA time selectors emit) is not something ``int()``
+    accepts. Require an explicit ``HH:MM[:SS]`` string and reject out-of-range /
+    non-time tokens — the old ``(int(h)*60+int(m)) % 1440`` turned ``18:00`` into
+    midnight. Raises ``ValueError`` on bad input (the service layer maps that to a
+    ``ServiceValidationError``); kept HA-free so it is unit-testable standalone."""
+    s = str(tok).strip()
+    parts = s.split(":")
+    if len(parts) not in (2, 3) or not all(p.isdigit() for p in parts):
+        raise ValueError(
+            f"start_times entries must be HH:MM (or HH:MM:SS); got {tok!r}. "
+            "Quote bare times in YAML so 18:00 isn't read as the integer 1080."
+        )
+    hour, minute = int(parts[0]), int(parts[1])
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"start_times entry out of range: {tok!r}")
+    return hour * 60 + minute
+
+
 @dataclass
 class ProgramSpec:
     """A watering program to WRITE (#19 setProgramSchedule).

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -17,6 +17,7 @@ re-declared, so there is a single source for both directions.
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import struct
 import time
@@ -32,6 +33,31 @@ from .base import (
 from .status import MSG_HEADER, _crc16_ccitt, apply_status_plaintext, parse_sync_dump
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _ble_write_guard(method):
+    """Make a bool-returning BLE write method fail gracefully on a marginal link.
+
+    A CTR-desync self-heal tears the session down mid-sequence (its disconnect is
+    scheduled on the loop), so a following write raises BleakError("Not connected")
+    — over an ESPHome proxy this is a routine, transient event. Catch it (and a
+    proxy write-response timeout) and return False instead of surfacing a raw
+    exception to the service/switch call: the coordinator refresh that follows
+    re-reads the device's actual state, and the user/automation can retry. Mirrors
+    the read path's best-effort behavior (get_programs falls back to last-known).
+    The method's own try/finally has already run its disconnect by the time we
+    catch here."""
+    @functools.wraps(method)
+    async def _wrapped(self, *args, **kwargs):
+        try:
+            return await method(self, *args, **kwargs)
+        except (BleakError, asyncio.TimeoutError) as err:
+            _LOGGER.warning(
+                "%s: %s %s failed on a BLE error (%s) — marginal link, not confirmed",
+                self.mac, self.log_label, method.__name__, err,
+            )
+            return False
+    return _wrapped
 
 
 def _pb_varint(val: int) -> bytes:
@@ -654,6 +680,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             finally:
                 await self.connection.disconnect()
 
+    @_ble_write_guard
     async def set_program(self, spec: ProgramSpec) -> bool:
         """Store a program (#19) and, if spec.enabled, drive the 3-write run
         handshake (store -> enable #20 -> autoMode #14{1} -> re-send store+enable).
@@ -707,6 +734,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             finally:
                 await self.connection.disconnect()
 
+    @_ble_write_guard
     async def delete_program(self, slot: int) -> bool:
         """Clear a slot: drop its enable bit, write the #19 NotSet body, keep the
         controller in autoMode. Returns True once the read-back shows it empty."""
@@ -728,6 +756,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             finally:
                 await self.connection.disconnect()
 
+    @_ble_write_guard
     async def set_program_enabled(self, slot: int, on: bool) -> bool:
         """Toggle a stored program's enable bit (#20 bitmask) and keep the
         controller in autoMode. On enable, re-send the bitmask while in autoMode so
@@ -766,6 +795,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
         next-start is reported."""
         return await self.set_program_enabled(slot, True)
 
+    @_ble_write_guard
     async def set_controller_mode(self, on: bool) -> bool:
         """Device-global controller mode via #14 timerMode: on -> autoMode(1)
         ('Enable Watering', scheduled programs run), off -> offMode(0) (automatic
@@ -783,6 +813,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             finally:
                 await self.connection.disconnect()
 
+    @_ble_write_guard
     async def identify(self, seconds: int = 6) -> bool:
         """Flash the device's LED to locate it (#47 identifyDevice). The flash
         LATCHES on Gen2 (identifyTimeSec isn't a reliable auto-off), so we start it,

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -664,7 +664,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
         stream = await self.connection.send_stream(
             _build_message(_build_sync_request_pb()), drain_ms=6000
         )
-        programs, mask, _status = parse_sync_dump(stream)
+        programs, mask, status = parse_sync_dump(stream)
         if programs:
             if mask is None:
                 # Mask frame dropped on this burst — keep each slot's known enable
@@ -674,6 +674,15 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                     if sch.enabled is None and prev is not None:
                         sch.enabled = prev.enabled
             self.state.programs = programs
+        elif mask is not None or status is not None:
+            # ZERO #19 bodies but the burst DID decode a coherent frame (the #20 enable
+            # mask and/or the #16 status): the device answered fully and stores no
+            # programs — e.g. every slot deleted via the app on hardware that omits
+            # deleted slots rather than echoing NotSet bodies. Clear last-known so a
+            # stale schedule doesn't linger forever. A truncated / CTR-desynced burst
+            # decodes NEITHER (mask and status both None), so it still preserves state
+            # — the presence of a decoded frame is the distinguishing signal.
+            self.state.programs = {}
         return programs, mask
 
     async def get_programs(self) -> dict:
@@ -809,7 +818,12 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 )
                 await self.refresh_status()
                 _programs2, mask2 = await self._read_programs()
-                return bool((mask2 or 0) & bit) == on
+                # Route the confirm read through _enable_mask so a dropped #20 frame
+                # (mask2=None) fails safe in BOTH directions: `(mask2 or 0)` would let a
+                # DISABLE confirm True without verifying anything (0 & bit == 0 == "off"),
+                # asymmetric with enable. Reconstructing from last-known flags reports the
+                # unverified toggle as unconfirmed instead — the safe direction.
+                return bool(self._enable_mask(mask2) & bit) == on
             finally:
                 await self.connection.disconnect()
 

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -180,13 +180,23 @@ def _build_set_epoch_time_pb(epoch_utc: int | None = None, tz_offset_sec: int | 
     #16 run-state, battery, clock, controller-mode, next-start), so it doubles as
     the coordinator-poll status elicitor while keeping the device clock honest
     (program start-times, rain-delay #3, and auto-close all key off this clock).
-    Defaults to the host's current time / UTC offset."""
-    now = datetime.now().astimezone()
-    if epoch_utc is None:
-        epoch_utc = int(now.timestamp())
-    if tz_offset_sec is None:
-        off = now.utcoffset()
-        tz_offset_sec = int(off.total_seconds()) if off is not None else 0
+    Defaults to HA's configured local time / UTC offset — NOT the container OS
+    timezone, which can diverge from the user's HA setting and would skew the
+    device's schedule next-start computation."""
+    if epoch_utc is None or tz_offset_sec is None:
+        try:
+            # HA's configured local time, not the container OS timezone. Local
+            # import so the module still loads without Home Assistant (the
+            # standalone protocol tests, which pass explicit epoch/offset).
+            from homeassistant.util import dt as dt_util
+            now = dt_util.now()
+        except ImportError:
+            now = datetime.now().astimezone()
+        if epoch_utc is None:
+            epoch_utc = int(now.timestamp())
+        if tz_offset_sec is None:
+            off = now.utcoffset()
+            tz_offset_sec = int(off.total_seconds()) if off is not None else 0
     body = _pb_field_varint(1, epoch_utc) + _pb_field_varint_signed(2, tz_offset_sec)
     return _pb_field_bytes(75, body)
 
@@ -680,6 +690,17 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             finally:
                 await self.connection.disconnect()
 
+    def _enable_mask(self, mask: int | None) -> int:
+        """The current #20 enable bitmask to base a write on. A program read can
+        decode the #19 bodies but drop the trailing #20 mask frame (mask=None) on
+        a marginal link; falling back to 0 there would clear every OTHER slot's
+        enable bit on the next write. _read_programs already carries each slot's
+        enabled flag forward into state.programs, so reconstruct the mask from it
+        instead of collapsing to 0."""
+        if mask is not None:
+            return mask
+        return sum(1 << (sid - 1) for sid, s in self.state.programs.items() if s.enabled)
+
     @_ble_write_guard
     async def set_program(self, spec: ProgramSpec) -> bool:
         """Store a program (#19) and, if spec.enabled, drive the 3-write run
@@ -692,7 +713,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             try:
                 letter = SLOT_LETTERS.get(spec.slot, str(spec.slot))
                 _programs, mask = await self._read_programs()
-                mask = mask or 0
+                mask = self._enable_mask(mask)
                 pb = _build_program_pb(spec)
                 await self.connection.send(_build_message(pb), drain_ms=2000)
                 self._stamp_command(f"program set {letter}", 0)
@@ -722,9 +743,14 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 await self.connection.send(
                     _build_message(_build_set_active_programs_pb(newmask))
                 )
-                # Confirm via #16.#9/#10 next-start (folded into state by the observer).
+                # Confirm via #16.#9/#10 next-start (folded into state by the
+                # observer). next_start_flags is a bitmask of whichever slot(s)
+                # start NEXT, so anchor the confirm to THIS slot's bit — otherwise
+                # an already-enabled program with an earlier start would confirm a
+                # slot that didn't actually arm. (A slot that armed but isn't the
+                # soonest reads as unconfirmed; the poll then re-reads real state.)
                 await self.refresh_status()
-                ok = bool(self.state.next_start_flags)
+                ok = bool(self.state.next_start_flags and self.state.next_start_flags & bit)
                 _LOGGER.log(
                     logging.DEBUG if ok else logging.WARNING,
                     "%s: %s program set %s enabled %s",
@@ -745,7 +771,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 _programs, mask = await self._read_programs()
                 bit = 1 << (slot - 1)
                 await self.connection.send(
-                    _build_message(_build_set_active_programs_pb((mask or 0) & ~bit))
+                    _build_message(_build_set_active_programs_pb(self._enable_mask(mask) & ~bit))
                 )
                 await self.connection.send(_build_message(_build_program_delete_pb(slot)))
                 await self.connection.send(_build_message(_build_set_timer_mode_pb(1)))
@@ -767,7 +793,7 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 return False
             try:
                 _programs, mask = await self._read_programs()
-                mask = mask or 0
+                mask = self._enable_mask(mask)
                 bit = 1 << (slot - 1)
                 newmask = (mask | bit) if on else (mask & ~bit)
                 await self.connection.send(
@@ -786,14 +812,6 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 return bool((mask2 or 0) & bit) == on
             finally:
                 await self.connection.disconnect()
-
-    async def run_program(self, slot: int) -> bool:
-        """Arm a program to run: enable it (#20) + autoMode (#14{1}), so the device
-        computes and honours its next scheduled start. NOTE: this is an *arm*, not a
-        verified immediate 'run now' — no immediate-run BLE path was confirmed in
-        W0, so the button fires the program at its next start. Returns True once a
-        next-start is reported."""
-        return await self.set_program_enabled(slot, True)
 
     @_ble_write_guard
     async def set_controller_mode(self, on: bool) -> bool:

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -24,8 +24,12 @@ from datetime import datetime, timedelta, timezone
 
 from bleak.exc import BleakError
 
-from .base import BHyveBleDeviceBase
-from .status import MSG_HEADER, _crc16_ccitt, apply_status_plaintext
+from .base import (
+    SLOT_LETTERS,
+    BHyveBleDeviceBase,
+    ProgramSpec,
+)
+from .status import MSG_HEADER, _crc16_ccitt, apply_status_plaintext, parse_sync_dump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +49,13 @@ def _pb_field_varint(f: int, v: int) -> bytes:
 
 def _pb_field_bytes(f: int, d: bytes) -> bytes:
     return _pb_varint((f << 3) | 2) + _pb_varint(len(d)) + d
+
+
+def _pb_field_varint_signed(f: int, v: int) -> bytes:
+    """int32/int64 field (non-zigzag). Negatives sign-extend to 64 bits (10-byte
+    varint), matching protobuf's wire format — the device reads #2 tz offset as a
+    signed int32, so e.g. -14400 (EDT) must encode with the low 32 bits 0xFFFFC7C0."""
+    return _pb_varint((f << 3) | 0) + _pb_varint(v & 0xFFFFFFFFFFFFFFFF if v < 0 else v)
 
 
 def _build_message(protobuf: bytes) -> bytes:
@@ -117,6 +128,103 @@ def _build_rain_delay_pb(minutes: int, expiry: int | None) -> bytes:
     return _pb_field_bytes(17, body)
 
 
+# ─── Watering programs (#19 / #20 / #14 / #10) + clock (#75) ──────────────────
+#
+# Mirrors the CLI reference (scripts/bhyve.py) byte-for-byte — the CLI is the
+# proven encode/decode contract, and tests assert HA bytes == CLI bytes. Reads use
+# #10 syncRequest (a one-shot dump of every #19 slot + the #20 enable bitmask + a
+# #16 status), reassembled across a multi-frame RX burst. Writes/runs use the
+# 3-write handshake: store #19 -> enable #20 -> autoMode #14{1} -> re-send
+# store+enable, confirmed via #16.#9/#10 next-start.
+
+# Day-mode field numbers inside a #19 body (exactly one is present).
+_DM_WEEKDAYS = 3   # { #1 dayFlags }  bit0=Sun .. bit6=Sat
+_DM_INTERVAL = 4   # { #1 intervalDays, #2 anchorIso }
+_DM_ODD = 5        # {} empty marker
+_DM_EVEN = 6       # {} empty marker
+_DM_RUNONCE = 7    # { #1 programFlags }
+
+
+def _build_set_epoch_time_pb(epoch_utc: int | None = None, tz_offset_sec: int | None = None) -> bytes:
+    """Clock-sync: #75 setEpochTime { #1 timeSecEpochUTC, #2 timezoneOffsetSec }.
+
+    This — NOT #18 setDateTime (a no-op over BLE, HW-verified) — sets the device
+    clock, and the app also uses it to trigger the first status burst on connect.
+    Its reply is content-identical to a #15 status (HW-verified 2026-07-06: same
+    #16 run-state, battery, clock, controller-mode, next-start), so it doubles as
+    the coordinator-poll status elicitor while keeping the device clock honest
+    (program start-times, rain-delay #3, and auto-close all key off this clock).
+    Defaults to the host's current time / UTC offset."""
+    now = datetime.now().astimezone()
+    if epoch_utc is None:
+        epoch_utc = int(now.timestamp())
+    if tz_offset_sec is None:
+        off = now.utcoffset()
+        tz_offset_sec = int(off.total_seconds()) if off is not None else 0
+    body = _pb_field_varint(1, epoch_utc) + _pb_field_varint_signed(2, tz_offset_sec)
+    return _pb_field_bytes(75, body)
+
+
+def _build_sync_request_pb() -> bytes:
+    """#10 syncRequest {} — empty; the device replies with a full state dump
+    (every #19 program body + the #20 enable bitmask + a #16 status)."""
+    return _pb_field_bytes(10, b"")
+
+
+def _build_set_active_programs_pb(flags: int) -> bytes:
+    """#20 setActivePrograms { #1 activeProgramFlags } — the enable BITMASK
+    (A=bit0: 1<<(slot-1)). The device fills #2/#3 lastChange* itself."""
+    return _pb_field_bytes(20, _pb_field_varint(1, flags))
+
+
+def _build_set_timer_mode_pb(mode: int) -> bytes:
+    """#14 timerMode { #1 mode, #2 {} EMPTY } — DEVICE-GLOBAL controller mode.
+
+    mode 0=offMode ("controller off / automatic watering disabled"), 1=autoMode
+    ("Enable Watering", the normal resting state — scheduled programs run),
+    2=manualMode (empty #2 => stop the current run). The empty #2 marker (`12 00`)
+    is REQUIRED — a #14 that omits it is silently ignored (W0-verified)."""
+    return _pb_field_bytes(14, _pb_field_varint(1, mode) + _pb_field_bytes(2, b""))
+
+
+def _build_program_pb(spec: ProgramSpec) -> bytes:
+    """#19 setProgramSchedule from a ProgramSpec (a full, runnable program)."""
+    body = _pb_field_varint(1, spec.slot)
+    if spec.day_mode == "weekdays":
+        body += _pb_field_bytes(_DM_WEEKDAYS, _pb_field_varint(1, spec.weekday_mask or 0))
+    elif spec.day_mode == "interval":
+        iv = _pb_field_varint(1, spec.interval_days or 1)
+        if spec.interval_anchor:
+            iv += _pb_field_bytes(2, spec.interval_anchor.encode())
+        body += _pb_field_bytes(_DM_INTERVAL, iv)
+    elif spec.day_mode == "odd":
+        body += _pb_field_bytes(_DM_ODD, b"")
+    elif spec.day_mode == "even":
+        body += _pb_field_bytes(_DM_EVEN, b"")
+    elif spec.day_mode == "once":
+        body += _pb_field_bytes(_DM_RUNONCE, _pb_field_varint(1, 1 << (spec.slot - 1)))
+    for m in spec.start_mins:
+        body += _pb_field_varint(8, m)
+    for sid, sec in spec.zones:
+        body += _pb_field_bytes(9, _pb_field_varint(1, sid) + _pb_field_varint(2, sec))
+    body += _pb_field_varint(10, spec.budget)
+    if spec.name:
+        body += _pb_field_bytes(17, spec.name.encode())
+    return _pb_field_bytes(19, body)
+
+
+def _build_program_delete_pb(slot: int) -> bytes:
+    """Clear a slot to empty: #19 { #1 slot, #2 {} } (programTypeNotSet, no #8/#9)."""
+    return _pb_field_bytes(19, _pb_field_varint(1, slot) + _pb_field_bytes(2, b""))
+
+
+def _build_identify_pb(seconds: int) -> bytes:
+    """#47 identifyDevice { #1 identifyTimeSec } — LED locate. #1>0 starts the
+    flash (it LATCHES — identifyTimeSec is not a reliable auto-off, HW 2026-07-06
+    on Gen2 fw0111), #1=0 stops it. XD (HT34A) treats it as a no-op."""
+    return _pb_field_bytes(47, _pb_field_varint(1, seconds))
+
+
 class BHyveProtobufDevice(BHyveBleDeviceBase):
     """Shared base for protobuf-protocol valves (frame magic 0x11).
 
@@ -137,12 +245,18 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
         # not the d7-47 mesh battery parse the base class does.
         apply_status_plaintext(self, pt)
 
-    async def refresh_status(self, drain_ms: int = 1500) -> None:
-        """Send #15{} to elicit a full #16 status burst; the decoded run-state,
-        battery, seconds-remaining, and rain-delay fold into self.state via
-        _observe_plaintext. This is the canonical mid-run / post-command read —
-        solicited RX is reliable; the unsolicited push is suppressed while the
-        device is active (watering or rain-delay)."""
+    async def refresh_status(self, drain_ms: int = 1500, *, sync_clock: bool = False) -> None:
+        """Elicit a full #16 status burst; the decoded run-state, battery,
+        seconds-remaining, controller-mode, next-start, and rain-delay fold into
+        self.state via _observe_plaintext. This is the canonical mid-run /
+        post-command read — solicited RX is reliable; the unsolicited push is
+        suppressed while the device is active (watering or rain-delay).
+
+        `sync_clock` (used by the coordinator poll) sends #75 setEpochTime(host-now)
+        instead of the bare #15{}: its reply is content-identical to #15's, so it
+        reads status AND keeps the device clock honest in one message (like the
+        app). Post-command confirm reads keep the pure #15{} (no side effects
+        mid-command). See _build_set_epoch_time_pb."""
         if self.connection is None:
             return
         self._status_parsed = False
@@ -154,7 +268,8 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 await self.connection.send(_build_message(_FLOW_UNSUBSCRIBE_PB), drain_ms=500)
             except Exception:  # noqa: BLE001
                 pass
-        await self.connection.send(_build_message(_REQUEST_STATUS_PB), drain_ms=drain_ms)
+        elicitor = _build_set_epoch_time_pb() if sync_clock else _REQUEST_STATUS_PB
+        await self.connection.send(_build_message(elicitor), drain_ms=drain_ms)
         if self._status_parsed:
             return
         # Connected, but the device returned no #16. Two hardware-observed causes,
@@ -297,7 +412,10 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
         async with self._api_lock:
             if self.connection is not None:
                 try:
-                    await self.refresh_status()
+                    # Poll with #75 setEpochTime: reads the full #16 status AND
+                    # syncs the device clock to HA-now (schedules/rain-delay/auto-
+                    # close all key off the device clock), mirroring the app.
+                    await self.refresh_status(sync_clock=True)
                     # "Connected" tracks whether the last poll REACHED the device,
                     # not the momentary BLE link — under the ephemeral model we
                     # disconnect immediately below, so the live link is always down
@@ -312,6 +430,17 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                         # once a run is confirmed so the reading tracks watering.
                         if self.has_flow and self.state.is_watering:
                             await self._read_flow_locked()
+                        # Refresh the A–D program schedules on IDLE polls only —
+                        # they don't change mid-run, and this keeps the watering
+                        # cadence lean. Best-effort: a failed #10 sync read leaves
+                        # the last-known programs rather than failing the poll.
+                        if not self.state.is_watering:
+                            try:
+                                await self._read_programs()
+                            except Exception as err:  # noqa: BLE001
+                                _LOGGER.debug(
+                                    "%s: program refresh skipped: %s", self.mac, err
+                                )
                     else:
                         # Reached the device but it returned NO status (a wedge
                         # recovery couldn't clear this cycle). Do NOT stamp a
@@ -468,4 +597,205 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             return not self.state.rain_delay_minutes
         finally:
             if self.connection is not None:
+                await self.connection.disconnect()
+
+    # ─── Watering programs (#19 / #20 / #14 / #10) ────────────────────────────
+    #
+    # These mirror the CLI reference (scripts/bhyve.py) op-for-op. A pooled BLE
+    # session's RX counter continues across sequential send()/send_stream() calls,
+    # so the store->enable->autoMode->re-send handshake and the multi-frame sync
+    # read all run on one connection with correct counter accounting; the wrapper
+    # holds _api_lock and disconnects in finally (ephemeral-session model).
+
+    async def _read_programs(self) -> tuple[dict, int | None]:
+        """Read every program slot in one shot via #10 syncRequest, reassembled
+        across the multi-frame RX burst, and update self.state.programs. Returns
+        (programs {slot:ProgramSummary}, active_mask). The #16 status in the dump
+        is applied to state by the per-frame observer; parse_sync_dump here pulls
+        the multi-frame #19 program bodies + the #20 enable bitmask.
+
+        Only overwrite state when program BODIES decode: a truncated / CTR-desynced
+        burst (the header self-heal already disconnects on a bad first frame) yields
+        nothing and must NOT blank the last-known schedules. If the bodies decode
+        but the small #20 mask frame dropped (mask=None), carry the known enabled
+        flags forward so a partial burst doesn't spuriously de-enable a slot.
+
+        Do NOT retry with an immediate reconnect here. Orbit valves allow only ONE
+        BLE session, so a fast disconnect+reconnect races the device's session
+        release and can wedge the link into a desync cascade (hardware-observed);
+        the next scheduled poll retries cleanly instead, and get_programs / the
+        sensors read through the retained last-known state.programs meanwhile."""
+        stream = await self.connection.send_stream(
+            _build_message(_build_sync_request_pb()), drain_ms=6000
+        )
+        programs, mask, _status = parse_sync_dump(stream)
+        if programs:
+            if mask is None:
+                # Mask frame dropped on this burst — keep each slot's known enable
+                # state rather than reporting it as unknown/off.
+                for sid, sch in programs.items():
+                    prev = self.state.programs.get(sid)
+                    if sch.enabled is None and prev is not None:
+                        sch.enabled = prev.enabled
+            self.state.programs = programs
+        return programs, mask
+
+    async def get_programs(self) -> dict:
+        """Public read: connect, dump all slots, disconnect. Returns
+        {slot(1-6): ProgramSummary} — the freshly-read schedules, or the last-known
+        state.programs if this read came back partial, so a marginal-link miss never
+        returns empty or de-enabled."""
+        async with self._api_lock:
+            if self.connection is None:
+                return {}
+            try:
+                await self._read_programs()
+                return dict(self.state.programs)
+            finally:
+                await self.connection.disconnect()
+
+    async def set_program(self, spec: ProgramSpec) -> bool:
+        """Store a program (#19) and, if spec.enabled, drive the 3-write run
+        handshake (store -> enable #20 -> autoMode #14{1} -> re-send store+enable).
+        Returns True once the store read-back lands (store-only) or the device
+        reports a next-start (enabled). Never leaves the controller in offMode."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                letter = SLOT_LETTERS.get(spec.slot, str(spec.slot))
+                _programs, mask = await self._read_programs()
+                mask = mask or 0
+                pb = _build_program_pb(spec)
+                await self.connection.send(_build_message(pb), drain_ms=2000)
+                self._stamp_command(f"program set {letter}", 0)
+
+                programs, _ = await self._read_programs()
+                stored = programs.get(spec.slot)
+                stored_ok = stored is not None and not stored.empty
+
+                bit = 1 << (spec.slot - 1)
+                if not spec.enabled:
+                    # Store only: clear this slot's enable bit, keep the controller
+                    # in autoMode (never drop it to offMode). Other slots unchanged.
+                    await self.connection.send(
+                        _build_message(_build_set_active_programs_pb(mask & ~bit))
+                    )
+                    await self.connection.send(_build_message(_build_set_timer_mode_pb(1)))
+                    return stored_ok
+
+                newmask = mask | bit
+                # The device computes a next-start only when store+enable arrive
+                # while already in autoMode: enable -> autoMode -> re-send store+enable.
+                await self.connection.send(
+                    _build_message(_build_set_active_programs_pb(newmask))
+                )
+                await self.connection.send(_build_message(_build_set_timer_mode_pb(1)))
+                await self.connection.send(_build_message(pb), drain_ms=2000)
+                await self.connection.send(
+                    _build_message(_build_set_active_programs_pb(newmask))
+                )
+                # Confirm via #16.#9/#10 next-start (folded into state by the observer).
+                await self.refresh_status()
+                ok = bool(self.state.next_start_flags)
+                _LOGGER.log(
+                    logging.DEBUG if ok else logging.WARNING,
+                    "%s: %s program set %s enabled %s",
+                    self.mac, self.log_label, letter, "confirmed" if ok else "no next-start",
+                )
+                return ok
+            finally:
+                await self.connection.disconnect()
+
+    async def delete_program(self, slot: int) -> bool:
+        """Clear a slot: drop its enable bit, write the #19 NotSet body, keep the
+        controller in autoMode. Returns True once the read-back shows it empty."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                _programs, mask = await self._read_programs()
+                bit = 1 << (slot - 1)
+                await self.connection.send(
+                    _build_message(_build_set_active_programs_pb((mask or 0) & ~bit))
+                )
+                await self.connection.send(_build_message(_build_program_delete_pb(slot)))
+                await self.connection.send(_build_message(_build_set_timer_mode_pb(1)))
+                self._stamp_command(f"program delete {SLOT_LETTERS.get(slot, slot)}", 0)
+                programs, _ = await self._read_programs()
+                sch = programs.get(slot)
+                return sch is None or sch.empty
+            finally:
+                await self.connection.disconnect()
+
+    async def set_program_enabled(self, slot: int, on: bool) -> bool:
+        """Toggle a stored program's enable bit (#20 bitmask) and keep the
+        controller in autoMode. On enable, re-send the bitmask while in autoMode so
+        the device computes a next-start. Returns True once the read-back mask
+        matches. (The stored #19 body is untouched — enabling an existing program.)"""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                _programs, mask = await self._read_programs()
+                mask = mask or 0
+                bit = 1 << (slot - 1)
+                newmask = (mask | bit) if on else (mask & ~bit)
+                await self.connection.send(
+                    _build_message(_build_set_active_programs_pb(newmask))
+                )
+                await self.connection.send(_build_message(_build_set_timer_mode_pb(1)))
+                if on:
+                    await self.connection.send(
+                        _build_message(_build_set_active_programs_pb(newmask))
+                    )
+                self._stamp_command(
+                    f"program {'enable' if on else 'disable'} {SLOT_LETTERS.get(slot, slot)}", 0
+                )
+                await self.refresh_status()
+                _programs2, mask2 = await self._read_programs()
+                return bool((mask2 or 0) & bit) == on
+            finally:
+                await self.connection.disconnect()
+
+    async def run_program(self, slot: int) -> bool:
+        """Arm a program to run: enable it (#20) + autoMode (#14{1}), so the device
+        computes and honours its next scheduled start. NOTE: this is an *arm*, not a
+        verified immediate 'run now' — no immediate-run BLE path was confirmed in
+        W0, so the button fires the program at its next start. Returns True once a
+        next-start is reported."""
+        return await self.set_program_enabled(slot, True)
+
+    async def set_controller_mode(self, on: bool) -> bool:
+        """Device-global controller mode via #14 timerMode: on -> autoMode(1)
+        ('Enable Watering', scheduled programs run), off -> offMode(0) (automatic
+        watering disabled). Confirms via #16.#2.#1. offMode is only ever reached
+        through an explicit off here — run/stop/cleanup paths keep autoMode."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                mode = 1 if on else 0
+                notifs = await self.connection.send(_build_message(_build_set_timer_mode_pb(mode)))
+                self._stamp_command(f"controller mode {'auto' if on else 'off'}", len(notifs))
+                await self.refresh_status()
+                return self.state.controller_mode == mode
+            finally:
+                await self.connection.disconnect()
+
+    async def identify(self, seconds: int = 6) -> bool:
+        """Flash the device's LED to locate it (#47 identifyDevice). The flash
+        LATCHES on Gen2 (identifyTimeSec isn't a reliable auto-off), so we start it,
+        hold the session for `seconds`, then send the explicit stop (#47{#1=0}).
+        A no-op on the XD (HT34A). Returns True if the start write went out."""
+        async with self._api_lock:
+            if self.connection is None:
+                return False
+            try:
+                await self.connection.send(_build_message(_build_identify_pb(seconds)))
+                self._stamp_command("identify", 0)
+                await asyncio.sleep(seconds)
+                await self.connection.send(_build_message(_build_identify_pb(0)))
+                return True
+            finally:
                 await self.connection.disconnect()

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -17,7 +17,7 @@ import struct
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
-from .base import _mv_to_pct
+from .base import ProgramSummary, _mv_to_pct
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,8 @@ MSG_HEADER = bytes([0xAA, 0x77, 0x5A, 0x0F])
 RX_F_CLOCK = 7            # wrapper: device clock, Unix epoch seconds
 RX_F_STATUS = 16          # device status submessage
 RX_F_STATUS_MODE = 1      #   #16.#1: 1=idle, 3=rain-delay, 4=manual running
-RX_F_STATUS_RUNECHO = 2   #   #16.#2: active-run echo { #1=2, #2 { #3 { #1 stationId } } }
+RX_F_STATUS_RUNECHO = 2   #   #16.#2: active-run echo { #1=mode, #2 { #3 { #1 stationId } } }
+RX_F_RUNECHO_MODE = 1     #     #16.#2.#1: timerMode.mode (0=off, 1=auto, 2=manual)
 RX_F_RUNECHO_PARAMS = 2   #     #16.#2.#2 manualParams
 RX_F_RUNECHO_STATION = 3  #     #16.#2.#2.#3 stationInfo
 RX_F_STATION_ID = 1       #     #16.#2.#2.#3.#1: stationId (0-indexed; zone = id + 1)
@@ -61,6 +62,25 @@ RX_F_WSTATUS_CODE = 1      #   #30.#1: 1=complete, 2=inProgress, 3=pumpDelay, 4=
                            #   (enum per knobunc's PROTOCOL_SPEC; 1=complete corroborated by our
                            #   own stop reply #30{#1=1}). Terminal/absent => not watering.
 RX_WSTATUS_ACTIVE = (2, 3, 5, 6, 7)  # in-progress + delay states = a run is still active
+RX_F_STATUS_NEXTSTART_FLAGS = 9   # #16.#9: nextStartProgramFlags (slot bitmask, A=bit0)
+RX_F_STATUS_NEXTSTART = 10        # #16.#10: nextStartTimeSecEpochUTC
+
+# --- watering-program (#19 WateringProgram) decode ------------------------
+# Field numbers inside a #19 body. Exactly one day-mode field is present.
+RX_F_PROGRAM = 19          # #19 setProgramSchedule / connect-burst program body
+_PRG_SLOT = 1              # #19.#1: slot (A=1 .. F=6)
+_PRG_NOTSET = 2            # #19.#2: programTypeNotSet (present -> empty slot)
+_DM_WEEKDAYS = 3          # #19.#3 weekdays { #1 dayFlags }  bit0=Sun .. bit6=Sat
+_DM_INTERVAL = 4          # #19.#4 interval { #1 intervalDays, #2 anchorIso }
+_DM_ODD = 5              # #19.#5 odd {} empty marker
+_DM_EVEN = 6             # #19.#6 even {} empty marker
+_DM_RUNONCE = 7          # #19.#7 runOnce { #1 programFlags }
+_PRG_START = 8            # #19.#8 repeated start-times (mins-from-midnight; echoed PACKED)
+_PRG_ZONES = 9           # #19.#9 repeated StationInfo { #1 stationId(0-idx), #2 runTimeSec }
+_PRG_BUDGET = 10         # #19.#10 seasonal budget %
+_PRG_NAME = 17           # #19.#17 name (UTF-8)
+RX_F_ACTIVE_PROGRAMS = 20  # #20 setActivePrograms { #1 activeProgramFlags bitmask }
+_AP_FLAGS = 1              # #20.#1 activeProgramFlags
 
 
 def _crc16_ccitt(data: bytes, init: int = 0) -> int:
@@ -170,6 +190,9 @@ class DeviceStatus(NamedTuple):
     rain_delay_minutes: int | None = None  # #16.#13.#1
     rain_delay_expiry: int | None = None   # #16.#13.#3, Unix epoch seconds
     rain_delay_active: bool | None = None  # #16.#13.#4
+    controller_mode: int | None = None     # #16.#2.#1 timerMode.mode: 0=off, 1=auto, 2=manual
+    next_start_flags: int | None = None    # #16.#9 nextStartProgramFlags (slot bitmask, A=bit0)
+    next_start_epoch: int | None = None    # #16.#10 nextStartTimeSecEpochUTC
 
 
 def extract_status(protobuf: bytes) -> DeviceStatus:
@@ -179,6 +202,7 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
 
     run_state = battery_mv = is_watering = seconds_remaining = None
     active_station = rd_minutes = rd_expiry = rd_active = None
+    controller_mode = next_start_flags = next_start_epoch = None
 
     device_clock = _pb_field(top, RX_F_CLOCK)     # #7 wrapper field
     status = _pb_field(top, RX_F_STATUS)          # #16 submessage
@@ -186,6 +210,10 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         sfields = pb_parse(status)
         run_state = _pb_field(sfields, RX_F_STATUS_MODE)
         battery_mv = _pb_subfield(sfields, RX_F_STATUS_BATT, RX_F_BATT_MV)
+        # Controller mode (#16.#2.#1) + the next scheduled program run (#16.#9/#10).
+        controller_mode = _pb_path(sfields, RX_F_STATUS_RUNECHO, RX_F_RUNECHO_MODE)
+        next_start_flags = _pb_field(sfields, RX_F_STATUS_NEXTSTART_FLAGS)
+        next_start_epoch = _pb_field(sfields, RX_F_STATUS_NEXTSTART)
         # Which zone is running: prefer the shallow #16.#6.#4 (currentStationId,
         # HW-verified), fall back to the deep timerMode path #16.#2.#2.#3.#1.
         active_station = _pb_subfield(sfields, RX_F_STATUS_PROGRESS, RX_F_PROGRESS_STATION)
@@ -257,7 +285,130 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         rain_delay_minutes=rd_minutes,
         rain_delay_expiry=rd_expiry,
         rain_delay_active=rd_active,
+        controller_mode=controller_mode,
+        next_start_flags=next_start_flags,
+        next_start_epoch=next_start_epoch,
     )
+
+
+# --- watering-program decode (multi-frame reads) --------------------------
+
+def _decode_packed_varints(data: bytes) -> list[int]:
+    """Decode a packed-repeated-varint byte run into a list of ints."""
+    out: list[int] = []
+    i = 0
+    while i < len(data):
+        v, i = _read_varint(data, i)
+        if v is None:
+            break
+        out.append(v)
+    return out
+
+
+def parse_program_body(pb: bytes) -> ProgramSummary | None:
+    """Decode a #19 WateringProgram body -> ProgramSummary (or None if malformed).
+
+    Mirrors the CLI reference (`scripts/bhyve.py::parse_program_body`) byte-for-byte,
+    including the read-back quirk that #8 start-times come back as a PACKED repeated
+    varint (wire 2) even though we WRITE them as individual varints (HW-confirmed on
+    fw0111)."""
+    f = pb_parse(pb)
+    if f is None:
+        return None
+    slot = _pb_field(f, _PRG_SLOT)
+    empty = isinstance(_pb_field(f, _PRG_NOTSET), (bytes, bytearray))  # #2 present
+
+    day_mode = weekday_mask = interval_days = interval_anchor = None
+    wk = _pb_field(f, _DM_WEEKDAYS)
+    if isinstance(wk, (bytes, bytearray)):
+        day_mode, weekday_mask = "weekdays", _pb_field(pb_parse(wk), 1)
+    iv = _pb_field(f, _DM_INTERVAL)
+    if isinstance(iv, (bytes, bytearray)):
+        ivf = pb_parse(iv)
+        day_mode, interval_days = "interval", _pb_field(ivf, 1)
+        anchor = _pb_field(ivf, 2)
+        if isinstance(anchor, (bytes, bytearray)):
+            interval_anchor = anchor.decode(errors="replace")
+    if _pb_field(f, _DM_ODD) is not None:
+        day_mode = "odd"
+    if _pb_field(f, _DM_EVEN) is not None:
+        day_mode = "even"
+    if _pb_field(f, _DM_RUNONCE) is not None:
+        day_mode = "once"
+
+    start_mins: list[int] = []
+    for num, wire, v in f:
+        if num != _PRG_START:
+            continue
+        if wire == 0:
+            start_mins.append(v)
+        elif isinstance(v, (bytes, bytearray)):
+            start_mins.extend(_decode_packed_varints(v))
+
+    zones: list[tuple[int, int]] = []
+    for num, _wire, v in f:
+        if num == _PRG_ZONES and isinstance(v, (bytes, bytearray)):
+            zf = pb_parse(v)
+            zones.append((_pb_field(zf, 1), _pb_field(zf, 2)))
+
+    name = _pb_field(f, _PRG_NAME)
+    if isinstance(name, (bytes, bytearray)):
+        name = name.decode(errors="replace")
+    return ProgramSummary(
+        slot=slot, empty=empty, day_mode=day_mode, weekday_mask=weekday_mask,
+        interval_days=interval_days, interval_anchor=interval_anchor,
+        start_mins=tuple(start_mins), zones=tuple(zones), name=name,
+        budget=_pb_field(f, _PRG_BUDGET),
+    )
+
+
+def split_inner_messages(stream: bytes) -> list[bytes]:
+    """Scan a reassembled decrypted byte stream for every CRC-valid inner message,
+    returning each one's protobuf. The device packs back-to-back messages
+    contiguously (NOT block-padded), so one outer frame is not necessarily one
+    message and a message may span frames — this rejoins them from the stream."""
+    out: list[bytes] = []
+    i = 0
+    while i + 6 <= len(stream):
+        hdr = stream.find(MSG_HEADER, i)
+        if hdr < 0 or hdr + 6 > len(stream):
+            break
+        payload_len = stream[hdr + 4]
+        total = payload_len + 6
+        if payload_len < 2 or hdr + total > len(stream):
+            break  # incomplete trailing message
+        pb = decode_inner(stream[hdr:hdr + total])
+        if pb is not None:
+            out.append(pb)
+        i = hdr + total
+    return out
+
+
+def parse_sync_dump(stream: bytes):
+    """From a reassembled #10 sync dump (concatenated plaintext), return
+    (programs {slot:ProgramSummary}, active_mask int|None, status DeviceStatus|None).
+    `enabled` is filled on each program from the #20 bitmask (A=bit0)."""
+    programs: dict[int, ProgramSummary] = {}
+    active_mask: int | None = None
+    status: DeviceStatus | None = None
+    for pb in split_inner_messages(stream):
+        top = pb_parse(pb)
+        if top is None:
+            continue
+        p19 = _pb_field(top, RX_F_PROGRAM)
+        if isinstance(p19, (bytes, bytearray)):
+            sch = parse_program_body(p19)
+            if sch and sch.slot is not None:
+                programs[sch.slot] = sch
+        p20 = _pb_field(top, RX_F_ACTIVE_PROGRAMS)
+        if isinstance(p20, (bytes, bytearray)):
+            active_mask = _pb_field(pb_parse(p20), _AP_FLAGS)
+        if isinstance(_pb_field(top, RX_F_STATUS), (bytes, bytearray)):
+            status = extract_status(pb)
+    if active_mask is not None:
+        for sid, sch in programs.items():
+            sch.enabled = bool(active_mask & (1 << (sid - 1)))
+    return programs, active_mask, status
 
 
 def apply_status_plaintext(device, pt: bytes) -> None:
@@ -340,6 +491,22 @@ def apply_status_plaintext(device, pt: bytes) -> None:
         # after expiry (the "7 hours ago" bug).
         device.state.rain_delay_minutes = 0
         device.state.rain_delay_ends = None
+
+    # Controller mode (#16.#2.#1: 0=off, 1=auto, 2=manual) — the "Automatic
+    # watering" switch reads this. Present whenever a #16 status block is decoded.
+    if st.controller_mode is not None:
+        device.state.controller_mode = st.controller_mode
+
+    # Next scheduled program run (#16.#9/#10). The device reports it once a
+    # program is stored+enabled while in autoMode; feeds the "Next run" sensor and
+    # confirms the enable handshake. Absent (flags 0/None) => no next start armed.
+    if st.next_start_flags is not None:
+        device.state.next_start_flags = st.next_start_flags or None
+        device.state.next_start_at = (
+            datetime.fromtimestamp(st.next_start_epoch, tz=timezone.utc)
+            if st.next_start_flags and st.next_start_epoch
+            else None
+        )
 
     if (
         st.battery_mv is not None

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -507,6 +507,15 @@ def apply_status_plaintext(device, pt: bytes) -> None:
             if st.next_start_flags and st.next_start_epoch
             else None
         )
+    elif st.run_state is not None:
+        # A #16 status block was decoded but carried no #16.#9 nextStartProgramFlags.
+        # Protobuf omits zero-valued scalars, so when the last enabled program is
+        # disabled/deleted the device stops emitting #9 entirely (rather than #9=0),
+        # which would otherwise freeze the "Next run" sensor at the old timestamp and
+        # leave stale flags that let set_program falsely confirm. Clear it — symmetric
+        # to the rain-delay clear above (the "7 hours ago" bug).
+        device.state.next_start_flags = None
+        device.state.next_start_at = None
 
     if (
         st.battery_mv is not None

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -30,11 +30,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
-from .devices.base import SLOT_LETTERS, ProgramSummary, _mv_to_pct
+from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, UI_SLOTS, ProgramSummary, _mv_to_pct
 from .devices.protobuf import BHyveProtobufDevice
 
-# The app exposes program slots A–D.
-_UI_SLOTS = ["A", "B", "C", "D"]
 _WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 
@@ -81,7 +79,7 @@ async def async_setup_entry(
         if isinstance(device, BHyveProtobufDevice):
             entities.append(BHyveRainDelayEndsSensor(coord))
             entities.append(BHyveNextRunSensor(coord))
-            for letter in _UI_SLOTS:
+            for letter in UI_SLOTS:
                 entities.append(BHyveProgramSummarySensor(coord, letter))
         # Flow-rate gauge only for models with a flow sensor (Gen2, not the XD).
         if getattr(device, "has_flow", False):
@@ -330,7 +328,7 @@ class BHyveProgramSummarySensor(_BHyveDeviceSensorBase):
         super().__init__(coordinator)
         device = coordinator.device
         self._letter = letter
-        self._slot = {"A": 1, "B": 2, "C": 3, "D": 4}[letter]
+        self._slot = PROGRAM_SLOTS[letter]
         self._attr_unique_id = f"{device.unique_id}_program_{letter.lower()}"
         self._attr_name = f"Program {letter}"
 

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -8,6 +8,7 @@ discharge approximation (`devices.base._mv_to_pct`).
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -29,8 +30,29 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
-from .devices.base import _mv_to_pct
+from .devices.base import SLOT_LETTERS, ProgramSummary, _mv_to_pct
 from .devices.protobuf import BHyveProtobufDevice
+
+# The app exposes program slots A–D.
+_UI_SLOTS = ["A", "B", "C", "D"]
+_WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+
+def _fmt_days(summary: ProgramSummary) -> str:
+    """Human day-mode summary for a program's extra attributes."""
+    if summary.day_mode == "weekdays":
+        mask = summary.weekday_mask or 0
+        if mask == 0x7F:
+            return "Every day"
+        return ", ".join(_WEEKDAY_NAMES[b] for b in range(7) if mask & (1 << b)) or "(none)"
+    if summary.day_mode == "interval":
+        base = f"Every {summary.interval_days} days"
+        if summary.interval_anchor:
+            base += f" from {summary.interval_anchor[:10]}"
+        return base
+    return {"odd": "Odd days", "even": "Even days", "once": "Once"}.get(
+        summary.day_mode, str(summary.day_mode)
+    )
 
 
 async def async_setup_entry(
@@ -54,9 +76,13 @@ async def async_setup_entry(
         entities.append(BHyveLastSuccessfulPollSensor(coord))
         entities.append(BHyveConsecutiveTimeoutsSensor(coord))
         entities.append(BHyveWateringEndsSensor(coord))
-        # Rain delay is a protobuf-family (HT34A/HT25G2) capability.
+        # Rain delay + watering programs are protobuf-family (HT34A/HT25G2)
+        # capabilities.
         if isinstance(device, BHyveProtobufDevice):
             entities.append(BHyveRainDelayEndsSensor(coord))
+            entities.append(BHyveNextRunSensor(coord))
+            for letter in _UI_SLOTS:
+                entities.append(BHyveProgramSummarySensor(coord, letter))
         # Flow-rate gauge only for models with a flow sensor (Gen2, not the XD).
         if getattr(device, "has_flow", False):
             entities.append(BHyveFlowRateSensor(coord))
@@ -265,3 +291,73 @@ class BHyveWateringEndsSensor(_BHyveDeviceSensorBase):
     def native_value(self) -> datetime | None:
         state = self.coordinator.data or self.coordinator.device.state
         return state.expected_off_at
+
+
+class BHyveNextRunSensor(_BHyveDeviceSensorBase):
+    """When the next scheduled program run starts (#16.#10), None when none is
+    armed. The `programs` attribute lists which slot(s) start then (#16.#9)."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_next_run"
+        self._attr_name = "Next run"
+
+    @property
+    def native_value(self) -> datetime | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.next_start_at
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        state = self.coordinator.data or self.coordinator.device.state
+        flags = state.next_start_flags or 0
+        slots = [SLOT_LETTERS[b + 1] for b in range(6) if flags & (1 << b) and (b + 1) in SLOT_LETTERS]
+        return {"programs": slots}
+
+
+class BHyveProgramSummarySensor(_BHyveDeviceSensorBase):
+    """Read-only summary of one program slot (A–D). State is enabled/disabled/empty;
+    the schedule detail (days, start times, per-zone minutes, name) is in the
+    attributes. Populated from the idle-poll #10 sync read."""
+
+    _attr_icon = "mdi:calendar-text"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator, letter: str):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._letter = letter
+        self._slot = {"A": 1, "B": 2, "C": 3, "D": 4}[letter]
+        self._attr_unique_id = f"{device.unique_id}_program_{letter.lower()}"
+        self._attr_name = f"Program {letter}"
+
+    @property
+    def _summary(self) -> ProgramSummary | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.programs.get(self._slot)
+
+    @property
+    def native_value(self) -> str:
+        summary = self._summary
+        if summary is None or summary.empty:
+            return "empty"
+        return "enabled" if summary.enabled else "disabled"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        summary = self._summary
+        if summary is None or summary.empty:
+            return {"empty": True}
+        return {
+            "empty": False,
+            "name": summary.name,
+            "days": _fmt_days(summary),
+            "start_times": [f"{m // 60:02d}:{m % 60:02d}" for m in summary.start_mins],
+            "zones": [
+                {"zone": sid + 1, "minutes": round(sec / 60, 2)} for sid, sec in summary.zones
+            ],
+            "budget": summary.budget,
+        }

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -32,7 +32,8 @@ set_program:
   description: Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2). Choose exactly one day-mode.
   target:
     device:
-      integration: orbit_bhyve
+      filter:
+        - integration: orbit_bhyve
   fields:
     slot:
       name: Program slot
@@ -122,7 +123,8 @@ delete_program:
   description: Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).
   target:
     device:
-      integration: orbit_bhyve
+      filter:
+        - integration: orbit_bhyve
   fields:
     slot:
       name: Program slot
@@ -138,7 +140,8 @@ get_program:
   description: Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2). Returns a response.
   target:
     device:
-      integration: orbit_bhyve
+      filter:
+        - integration: orbit_bhyve
   fields:
     slot:
       name: Program slot

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -27,6 +27,128 @@ refresh_devices:
   name: Refresh devices from cloud
   description: Re-query the Orbit cloud for new/changed devices and updated network keys. Manual; no background polling.
 
+set_program:
+  name: Set watering program
+  description: Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2). Choose exactly one day-mode.
+  target:
+    device:
+      integration: orbit_bhyve
+  fields:
+    slot:
+      name: Program slot
+      description: Which program slot to write (A–D).
+      required: true
+      example: A
+      selector:
+        select:
+          options: [A, B, C, D]
+    day_mode:
+      name: Day mode
+      description: How often the program runs. Exactly one mode.
+      required: true
+      example: weekdays
+      selector:
+        select:
+          options: [weekdays, interval, odd, even, once]
+    weekdays:
+      name: Weekdays
+      description: For day mode "weekdays" — which days to run.
+      required: false
+      example: "[mon, wed, fri]"
+      selector:
+        select:
+          multiple: true
+          options: [sun, mon, tue, wed, thu, fri, sat]
+    interval_days:
+      name: Interval (days)
+      description: For day mode "interval" — run every N days.
+      required: false
+      example: 3
+      selector:
+        number:
+          min: 1
+          max: 31
+          mode: box
+    interval_anchor:
+      name: Interval anchor date
+      description: For day mode "interval" — ISO date the interval counts from (default today).
+      required: false
+      example: "2026-07-01T00:00:00-04:00"
+      selector:
+        text:
+    start_times:
+      name: Start times
+      description: One or more start times (HH:MM, device-local).
+      required: true
+      example: "[06:00, 18:00]"
+      selector:
+        object:
+    zones:
+      name: Zones
+      description: Per-zone run time — a list of {zone, minutes}.
+      required: true
+      example: "[{zone: 1, minutes: 5}, {zone: 2, minutes: 7}]"
+      selector:
+        object:
+    name:
+      name: Program name
+      description: Optional label stored on the device.
+      required: false
+      example: Front lawn
+      selector:
+        text:
+    budget:
+      name: Seasonal budget (%)
+      description: Seasonal adjust percentage (default 100).
+      required: false
+      default: 100
+      example: 100
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: "%"
+          mode: box
+    enabled:
+      name: Enable
+      description: Enable and arm the program (runs the store→enable→autoMode handshake) so it runs on schedule.
+      required: false
+      default: false
+      selector:
+        boolean:
+
+delete_program:
+  name: Delete watering program
+  description: Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).
+  target:
+    device:
+      integration: orbit_bhyve
+  fields:
+    slot:
+      name: Program slot
+      description: Which program slot to clear (A–D).
+      required: true
+      example: A
+      selector:
+        select:
+          options: [A, B, C, D]
+
+get_program:
+  name: Get watering program(s)
+  description: Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2). Returns a response.
+  target:
+    device:
+      integration: orbit_bhyve
+  fields:
+    slot:
+      name: Program slot
+      description: Optional — a single slot (A–D). Omit to return all slots.
+      required: false
+      example: A
+      selector:
+        select:
+          options: [A, B, C, D]
+
 probe_status:
   name: Probe device status (debug)
   description: Force a fresh BLE connect + 8-step init on a device. No actuation. Decoded plaintext lands in the HA log via connection._on_notify. Used for protocol decoding work (e.g., finding battery bytes).

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -30,11 +30,15 @@ refresh_devices:
 set_program:
   name: Set watering program
   description: Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2). Choose exactly one day-mode.
-  target:
-    device:
-      filter:
-        - integration: orbit_bhyve
   fields:
+    device_id:
+      name: Device
+      description: The B-Hyve valve (HT34A / HT25G2).
+      required: true
+      selector:
+        device:
+          filter:
+            - integration: orbit_bhyve
     slot:
       name: Program slot
       description: Which program slot to write (A–D).
@@ -121,11 +125,15 @@ set_program:
 delete_program:
   name: Delete watering program
   description: Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).
-  target:
-    device:
-      filter:
-        - integration: orbit_bhyve
   fields:
+    device_id:
+      name: Device
+      description: The B-Hyve valve (HT34A / HT25G2).
+      required: true
+      selector:
+        device:
+          filter:
+            - integration: orbit_bhyve
     slot:
       name: Program slot
       description: Which program slot to clear (A–D).
@@ -138,11 +146,15 @@ delete_program:
 get_program:
   name: Get watering program(s)
   description: Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2). Returns a response.
-  target:
-    device:
-      filter:
-        - integration: orbit_bhyve
   fields:
+    device_id:
+      name: Device
+      description: The B-Hyve valve (HT34A / HT25G2).
+      required: true
+      selector:
+        device:
+          filter:
+            - integration: orbit_bhyve
     slot:
       name: Program slot
       description: Optional — a single slot (A–D). Omit to return all slots.

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -67,6 +67,36 @@
     "refresh_devices": {
       "name": "Refresh devices from cloud",
       "description": "Re-query the Orbit cloud for new/changed devices and updated network keys."
+    },
+    "set_program": {
+      "name": "Set watering program",
+      "description": "Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Which program slot to write (A–D)."},
+        "day_mode": {"name": "Day mode", "description": "How often the program runs. Exactly one mode."},
+        "weekdays": {"name": "Weekdays", "description": "For day mode \"weekdays\" — which days to run."},
+        "interval_days": {"name": "Interval (days)", "description": "For day mode \"interval\" — run every N days."},
+        "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
+        "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
+        "zones": {"name": "Zones", "description": "Per-zone run time — a list of {zone, minutes}."},
+        "name": {"name": "Program name", "description": "Optional label stored on the device."},
+        "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
+        "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}
+      }
+    },
+    "delete_program": {
+      "name": "Delete watering program",
+      "description": "Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Which program slot to clear (A–D)."}
+      }
+    },
+    "get_program": {
+      "name": "Get watering program(s)",
+      "description": "Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Optional — a single slot (A–D). Omit to return all slots."}
+      }
     }
   }
 }

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -72,6 +72,7 @@
       "name": "Set watering program",
       "description": "Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Which program slot to write (A–D)."},
         "day_mode": {"name": "Day mode", "description": "How often the program runs. Exactly one mode."},
         "weekdays": {"name": "Weekdays", "description": "For day mode \"weekdays\" — which days to run."},
@@ -88,6 +89,7 @@
       "name": "Delete watering program",
       "description": "Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Which program slot to clear (A–D)."}
       }
     },
@@ -95,6 +97,7 @@
       "name": "Get watering program(s)",
       "description": "Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Optional — a single slot (A–D). Omit to return all slots."}
       }
     }

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -78,7 +78,7 @@
         "interval_days": {"name": "Interval (days)", "description": "For day mode \"interval\" — run every N days."},
         "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
         "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
-        "zones": {"name": "Zones", "description": "Per-zone run time — a list of {zone, minutes}."},
+        "zones": {"name": "Zones", "description": "Per-zone run time — a list of zone/minutes pairs."},
         "name": {"name": "Program name", "description": "Optional label stored on the device."},
         "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
         "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}

--- a/custom_components/orbit_bhyve/switch.py
+++ b/custom_components/orbit_bhyve/switch.py
@@ -23,13 +23,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
-from .devices.base import PROGRAM_SLOTS
+from .devices.base import PROGRAM_SLOTS, UI_SLOTS
 from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
-
-# The app exposes program slots A–D (E/F are extra internal slots).
-_UI_SLOTS = ["A", "B", "C", "D"]
 
 
 async def async_setup_entry(
@@ -43,7 +40,7 @@ async def async_setup_entry(
         if not isinstance(coord.device, BHyveProtobufDevice):
             continue
         entities.append(BHyveAutomaticWateringSwitch(coord))
-        for letter in _UI_SLOTS:
+        for letter in UI_SLOTS:
             entities.append(BHyveProgramEnableSwitch(coord, letter))
     async_add_entities(entities)
 

--- a/custom_components/orbit_bhyve/switch.py
+++ b/custom_components/orbit_bhyve/switch.py
@@ -1,0 +1,134 @@
+"""Switch platform — automatic watering + per-program enable (protobuf family).
+
+Two switch types, both protobuf-family (HT34A / HT25G2) capabilities:
+
+- **Automatic watering** — the device-global controller mode (#14 timerMode):
+  on = autoMode (scheduled programs run), off = offMode (all automatic watering
+  disabled). Reads the live #16.#2.#1 mode from the status poll.
+- **Program A–D enable** — each stored program's enable bit in the #20
+  activeProgramFlags bitmask. On/off drives set_program_enabled; the switch is
+  only available once a program is stored in that slot (an empty slot has nothing
+  to enable). Program state comes from the idle-poll #10 sync read.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BHyveDeviceCoordinator
+from .devices.base import PROGRAM_SLOTS
+from .devices.protobuf import BHyveProtobufDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+# The app exposes program slots A–D (E/F are extra internal slots).
+_UI_SLOTS = ["A", "B", "C", "D"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SwitchEntity] = []
+    for coord in runtime.coordinators.values():
+        if not isinstance(coord.device, BHyveProtobufDevice):
+            continue
+        entities.append(BHyveAutomaticWateringSwitch(coord))
+        for letter in _UI_SLOTS:
+            entities.append(BHyveProgramEnableSwitch(coord, letter))
+    async_add_entities(entities)
+
+
+class _BHyveSwitchBase(CoordinatorEntity[BHyveDeviceCoordinator], SwitchEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    @property
+    def _state(self):
+        return self.coordinator.data or self.coordinator.device.state
+
+
+class BHyveAutomaticWateringSwitch(_BHyveSwitchBase):
+    """Device-global automatic watering (autoMode vs offMode)."""
+
+    _attr_name = "Automatic watering"
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_automatic_watering"
+
+    @property
+    def is_on(self) -> bool | None:
+        mode = self._state.controller_mode
+        if mode is None:
+            return None
+        return mode != 0  # 1=auto (on), 2=manual also counts as "not off"
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self.coordinator.device.set_controller_mode(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.device.set_controller_mode(False)
+        await self.coordinator.async_request_refresh()
+
+
+class BHyveProgramEnableSwitch(_BHyveSwitchBase):
+    """Enable/disable a single stored program (A–D) via the #20 bitmask."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator, letter: str):
+        super().__init__(coordinator)
+        self._letter = letter
+        self._slot = PROGRAM_SLOTS[letter]
+        self._attr_unique_id = f"{coordinator.device.unique_id}_program_{letter.lower()}_enable"
+        self._attr_name = f"Program {letter}"
+
+    @property
+    def _summary(self):
+        return self._state.programs.get(self._slot)
+
+    @property
+    def available(self) -> bool:
+        # Only meaningful once a program is stored in this slot; an empty slot has
+        # nothing to enable. Programs populate from the idle-poll #10 sync read.
+        summary = self._summary
+        return super().available and summary is not None and not summary.empty
+
+    @property
+    def is_on(self) -> bool | None:
+        summary = self._summary
+        if summary is None or summary.empty:
+            return None
+        return bool(summary.enabled)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self.coordinator.device.set_program_enabled(self._slot, True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.device.set_program_enabled(self._slot, False)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -67,6 +67,36 @@
     "refresh_devices": {
       "name": "Refresh devices from cloud",
       "description": "Re-query the Orbit cloud for new/changed devices and updated network keys."
+    },
+    "set_program": {
+      "name": "Set watering program",
+      "description": "Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Which program slot to write (A–D)."},
+        "day_mode": {"name": "Day mode", "description": "How often the program runs. Exactly one mode."},
+        "weekdays": {"name": "Weekdays", "description": "For day mode \"weekdays\" — which days to run."},
+        "interval_days": {"name": "Interval (days)", "description": "For day mode \"interval\" — run every N days."},
+        "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
+        "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
+        "zones": {"name": "Zones", "description": "Per-zone run time — a list of {zone, minutes}."},
+        "name": {"name": "Program name", "description": "Optional label stored on the device."},
+        "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
+        "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}
+      }
+    },
+    "delete_program": {
+      "name": "Delete watering program",
+      "description": "Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Which program slot to clear (A–D)."}
+      }
+    },
+    "get_program": {
+      "name": "Get watering program(s)",
+      "description": "Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2).",
+      "fields": {
+        "slot": {"name": "Program slot", "description": "Optional — a single slot (A–D). Omit to return all slots."}
+      }
     }
   }
 }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -72,6 +72,7 @@
       "name": "Set watering program",
       "description": "Create or replace a watering program (slots A–D) on a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Which program slot to write (A–D)."},
         "day_mode": {"name": "Day mode", "description": "How often the program runs. Exactly one mode."},
         "weekdays": {"name": "Weekdays", "description": "For day mode \"weekdays\" — which days to run."},
@@ -88,6 +89,7 @@
       "name": "Delete watering program",
       "description": "Clear a watering program slot (A–D) on a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Which program slot to clear (A–D)."}
       }
     },
@@ -95,6 +97,7 @@
       "name": "Get watering program(s)",
       "description": "Read back the stored watering programs (A–D) from a B-Hyve valve (HT34A / HT25G2).",
       "fields": {
+        "device_id": {"name": "Device", "description": "The B-Hyve valve (HT34A / HT25G2)."},
         "slot": {"name": "Program slot", "description": "Optional — a single slot (A–D). Omit to return all slots."}
       }
     }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -78,7 +78,7 @@
         "interval_days": {"name": "Interval (days)", "description": "For day mode \"interval\" — run every N days."},
         "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
         "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
-        "zones": {"name": "Zones", "description": "Per-zone run time — a list of {zone, minutes}."},
+        "zones": {"name": "Zones", "description": "Per-zone run time — a list of zone/minutes pairs."},
         "name": {"name": "Program name", "description": "Optional label stored on the device."},
         "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
         "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -115,6 +115,18 @@ def _flow_frame(active: int, total: int) -> bytes:
 _STATUS_REQ_FRAME = None  # set lazily to the #15{} frame the device emits
 
 
+def _is_status_elicitor(frame: bytes) -> bool:
+    """True if `frame` is a status-eliciting request: either #15{} getDeviceStatus
+    (post-command confirm reads) or #75 setEpochTime (the coordinator poll, which
+    sets the clock AND returns the same #16 status). Both should yield on_status."""
+    top = rx.pb_parse(rx.decode_inner(frame) or b"")
+    return rx._pb_field(top, 15) is not None or rx._pb_field(top, 75) is not None
+
+
+def _sent_status_request(conn) -> bool:
+    return any(_is_status_elicitor(f) for f in conn.sent)
+
+
 class _FakeConn:
     """Stand-in for BHyveBleConnection: records sent frames and feeds a canned
     plaintext back through the device's own observer, exactly as _on_notify
@@ -122,17 +134,23 @@ class _FakeConn:
 
     def __init__(self, device, *, on_status=None, on_command=None):
         self.device = device
-        self.on_status = on_status      # fed when the #15{} status request is sent
+        self.on_status = on_status      # fed on a status elicitor (#15{} or #75)
         self.on_command = on_command    # fed on any other frame (start/stop/rain)
         self.sent: list[bytes] = []
         self.disconnects = 0
 
     async def send(self, frame: bytes, drain_ms: int = 1500):
         self.sent.append(frame)
-        pt = self.on_status if frame == pb._build_message(pb._REQUEST_STATUS_PB) else self.on_command
+        pt = self.on_status if _is_status_elicitor(frame) else self.on_command
         if pt is not None:
             self.device._observe_plaintext(pt)
         return [b"\x01"]  # one notification (the bare #30 ack for a stop)
+
+    async def send_stream(self, frame: bytes, drain_ms: int = 4000):
+        # The idle coordinator poll reads programs via #10 syncRequest; these
+        # fakes carry no program dump, so return an empty stream (no programs).
+        self.sent.append(frame)
+        return b""
 
     async def disconnect(self):
         self.disconnects += 1
@@ -205,7 +223,21 @@ def test_refresh_state_polls_status_and_sees_out_of_band_run():
     state = asyncio.run(dev.refresh_state())
 
     assert state.is_watering is True
-    assert pb._build_message(pb._REQUEST_STATUS_PB) in dev.connection.sent
+    # The poll elicitor is #75 setEpochTime (reads status AND syncs the clock).
+    assert _sent_status_request(dev.connection)
+
+
+def test_refresh_state_poll_uses_epoch_time_elicitor():
+    # The coordinator poll must use #75 setEpochTime (not the bare #15{}) so it
+    # keeps the device clock honest while reading status — HW-validated content-
+    # identical reply (session 2026-07-06).
+    dev = _make_device(is_watering=False)
+    dev.connection = _FakeConn(dev, on_status=_status_frame(1), on_command=None)
+    asyncio.run(dev.refresh_state())
+    sent_fields = [rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 75) for f in dev.connection.sent]
+    assert any(v is not None for v in sent_fields)  # a #75 frame was sent
+    # and NOT the bare #15{} on the poll path
+    assert pb._build_message(pb._REQUEST_STATUS_PB) not in dev.connection.sent
 
 
 def test_start_arms_wall_clock_autoclose():

--- a/tests/test_ha_programs.py
+++ b/tests/test_ha_programs.py
@@ -16,7 +16,12 @@ from bleak.exc import BleakError
 from orbit_bhyve.connection import BHyveBleConnection
 from orbit_bhyve.devices import protobuf as tx
 from orbit_bhyve.devices import status as rx
-from orbit_bhyve.devices.base import DeviceState, ProgramSpec, ProgramSummary
+from orbit_bhyve.devices.base import (
+    DeviceState,
+    ProgramSpec,
+    ProgramSummary,
+    parse_start_minutes,
+)
 from orbit_bhyve.devices.ht25g2 import BHyveHT25G2Device
 
 
@@ -553,3 +558,66 @@ def test_refresh_state_reads_programs_on_idle_poll():
     # the #10 syncRequest went out on the idle poll (via send_stream)
     assert any(rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 10) is not None
                for f in dev.connection.streamed)
+
+
+# --- PR#31 round-2 review regressions ---------------------------------------
+
+def test_next_start_clears_when_16_9_absent():
+    # Finding 1 / class "protobuf zero-omission -> clear-on-absence": the device
+    # omits zero-valued #16.#9, so disabling/deleting the last program stops it
+    # emitting #9. A later #16 status with NO #9 must CLEAR the Next-run state, not
+    # freeze it at the old timestamp (which also blocked a stale false-confirm).
+    dev = _make_gen2()
+    dev._observe_plaintext(_status_with_next_start(0b0010, epoch=1_700_000_000))
+    assert dev.state.next_start_flags == 0b0010
+    assert dev.state.next_start_at is not None
+    dev._observe_plaintext(_status_idle())          # #16 present, #9 absent
+    assert dev.state.next_start_flags is None
+    assert dev.state.next_start_at is None
+
+
+def test_set_program_disable_confirm_fails_safe_on_dropped_mask():
+    # Finding 3 / class "frame-drop None handling is symmetric": a DISABLE whose
+    # confirm read drops the #20 mask (mask=None) must not confirm True unverified.
+    # Routing through _enable_mask reports it unconfirmed (the safe direction) — the
+    # old `(mask2 or 0) & bit == on` returned True for a disable without verifying.
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    dev = _make_gen2()
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, enabled=True, name="A")}
+    dev.connection = _FakeProgramConn(
+        dev,
+        # pre-write read has the mask; the confirm read DROPS the trailing #20 frame
+        dumps=[_dump_stream([a], mask=1), _dump_stream([a], mask=None)],
+    )
+    assert asyncio.run(dev.set_program_enabled(1, False)) is False
+
+
+def test_read_programs_clears_stale_on_empty_but_coherent_dump():
+    # Finding 5 / class "clear-on-absence": all programs deleted via the app on
+    # hardware that OMITS deleted slots -> a coherent dump (a #20 mask and/or #16
+    # status decoded, zero #19 bodies) must CLEAR last-known, not retain a stale
+    # schedule forever. Contrast with the truncated-read test above (mask+status
+    # both None) which must PRESERVE state.
+    dev = _make_gen2()
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, enabled=True, name="Stale")}
+    dev.connection = _ScriptedStreamConn(dev, streams=[_dump_stream([], mask=0)])
+    programs = asyncio.run(dev.get_programs())
+    assert programs == {}
+    assert dev.state.programs == {}   # stale schedule cleared
+
+
+def test_parse_start_minutes_accepts_hhmm_and_hhmmss():
+    # Finding 2 / class "service-input coercion footguns".
+    assert parse_start_minutes("06:00") == 360
+    assert parse_start_minutes("18:00") == 1080
+    assert parse_start_minutes("06:00:30") == 360   # HA time-selector HH:MM:SS, secs dropped
+    assert parse_start_minutes("23:59") == 1439
+
+
+@pytest.mark.parametrize("bad", ["1080", 1080, "24:00", "12:60", "18:00:00:00", "abc", ""])
+def test_parse_start_minutes_rejects_footguns(bad):
+    # "1080"/1080 is the YAML sexagesimal footgun (unquoted 18:00 -> int 1080 ->
+    # cv.string "1080"); the old `% 1440` math silently scheduled MIDNIGHT. Reject
+    # rather than wrap, and reject out-of-range / non-time tokens.
+    with pytest.raises(ValueError):
+        parse_start_minutes(bad)

--- a/tests/test_ha_programs.py
+++ b/tests/test_ha_programs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from bleak.exc import BleakError
 
 from orbit_bhyve.connection import BHyveBleConnection
 from orbit_bhyve.devices import protobuf as tx
@@ -340,6 +341,37 @@ def test_delete_program_clears_slot():
     assert ok is True
     ops = _program_ops(dev.connection.sent)
     assert ops == [20, 19, 14]  # clear-bit, delete body, keep autoMode
+
+
+class _WriteDesyncConn(_FakeProgramConn):
+    """Reads (send_stream) succeed, but the first write send() raises BleakError —
+    as a CTR-desync self-heal tears the pooled session down mid-sequence over an
+    ESPHome proxy (hardware-observed on a marginal-link Gen2 valve)."""
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        raise BleakError("Not connected")
+
+
+def test_set_program_returns_false_on_marginal_link_desync():
+    # A write that desyncs mid-sequence must fail gracefully as False (the caller
+    # /coordinator re-reads real state), NOT surface a raw BleakError as a 500.
+    spec = _ha_spec(4, "weekdays", weekday_mask=0x7F, start_mins=(360,),
+                    zones=((0, 180),), name="D", enabled=False)
+    dev = _make_gen2()
+    dev.connection = _WriteDesyncConn(dev, dumps=[_dump_stream([], mask=0)])
+    ok = asyncio.run(dev.set_program(spec))
+    assert ok is False                      # graceful, not a raised exception
+    assert dev.connection.disconnects == 1  # session still torn down (finally ran)
+
+
+def test_program_and_controller_writes_return_false_on_desync():
+    # The Program A-D enable switches and the Automatic-watering switch drive
+    # these; a marginal-link write must return False, never raise to the switch.
+    dev = _make_gen2()
+    dev.connection = _WriteDesyncConn(dev, dumps=[_dump_stream([], mask=0)])
+    assert asyncio.run(dev.set_program_enabled(1, True)) is False
+    assert asyncio.run(dev.delete_program(1)) is False
+    assert asyncio.run(dev.set_controller_mode(True)) is False
 
 
 def test_set_controller_mode_confirms_via_status():

--- a/tests/test_ha_programs.py
+++ b/tests/test_ha_programs.py
@@ -121,9 +121,11 @@ def test_ha_parse_decodes_packed_single_start_hw_shape():
 
 def _dump_stream(program_pbs, mask, status_pb=None) -> bytes:
     """A #10 sync-dump plaintext stream: concatenated inner messages (each
-    aa775a0f-framed), exactly what connection.send_stream returns."""
+    aa775a0f-framed), exactly what connection.send_stream returns. mask=None
+    models a burst whose trailing #20 enable frame dropped (parse -> mask None)."""
     parts = [tx._build_message(p) for p in program_pbs]
-    parts.append(tx._build_message(tx._build_set_active_programs_pb(mask)))
+    if mask is not None:
+        parts.append(tx._build_message(tx._build_set_active_programs_pb(mask)))
     if status_pb is not None:
         parts.append(tx._build_message(status_pb))
     return b"".join(parts)
@@ -341,6 +343,57 @@ def test_delete_program_clears_slot():
     assert ok is True
     ops = _program_ops(dev.connection.sent)
     assert ops == [20, 19, 14]  # clear-bit, delete body, keep autoMode
+
+
+def test_enable_mask_reconstructs_from_state_when_frame_dropped():
+    # C1: if the #20 mask frame drops on the pre-write read (mask=None), rebuild
+    # it from the last-known per-slot enabled flags rather than collapsing to 0
+    # (which would clear every other slot's enable bit on the next write).
+    dev = _make_gen2()
+    dev.state.programs = {
+        1: ProgramSummary(slot=1, empty=False, enabled=True),
+        2: ProgramSummary(slot=2, empty=False, enabled=False),
+        3: ProgramSummary(slot=3, empty=False, enabled=True),
+    }
+    assert dev._enable_mask(None) == 0b101   # bits for slots 1 and 3
+    assert dev._enable_mask(0b010) == 0b010  # a present mask passes through
+
+
+def test_enable_preserves_other_slots_when_mask_frame_drops():
+    # C1 end-to-end: enabling slot D on a read that dropped its #20 frame must
+    # not clear slot A's enable bit — the #20 write carries A's bit too.
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    d = tx._build_program_pb(_ha_spec(4, "weekdays", weekday_mask=0x7F,
+                                      start_mins=(360,), zones=((0, 180),), name="D"))
+    dev = _make_gen2()
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, enabled=True)}  # A known-enabled
+    dev.connection = _FakeProgramConn(
+        dev,
+        dumps=[_dump_stream([a, d], mask=None), _dump_stream([a, d], mask=0b1001)],
+    )
+    asyncio.run(dev.set_program_enabled(4, True))
+    enable_masks = [
+        rx._pb_field(rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(f)), 20)), 1)
+        for f in dev.connection.sent
+        if rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 20) is not None
+    ]
+    assert enable_masks and all(m & 0b0001 for m in enable_masks)  # slot A never cleared
+    assert all(m & 0b1000 for m in enable_masks)                   # slot D set
+
+
+def test_set_program_enable_confirm_requires_this_slots_next_start():
+    # C2: next_start_flags is a bitmask of whichever slot(s) start next. Enabling
+    # slot D must NOT confirm just because another program (slot A) is next.
+    spec = _ha_spec(4, "weekdays", weekday_mask=0x7F, start_mins=(360,),
+                    zones=((0, 180),), name="D", enabled=True)
+    stored = tx._build_program_pb(spec)
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(
+        dev,
+        dumps=[_dump_stream([], mask=0), _dump_stream([stored], mask=0)],
+        status_pt=_status_with_next_start(0b0001),  # slot A is next, not D
+    )
+    assert asyncio.run(dev.set_program(spec)) is False
 
 
 class _WriteDesyncConn(_FakeProgramConn):

--- a/tests/test_ha_programs.py
+++ b/tests/test_ha_programs.py
@@ -1,0 +1,470 @@
+"""Watering-program protocol tests for the HA integration.
+
+Covers the program builders (`devices/protobuf.py`) against hardware-verified
+byte references, the multi-frame RX reassembly (`connection.send_stream` +
+`status.split_inner_messages`/`parse_sync_dump`), and the program device
+methods that drive the verified 3-write enable handshake. No hardware or Home
+Assistant required.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from orbit_bhyve.connection import BHyveBleConnection
+from orbit_bhyve.devices import protobuf as tx
+from orbit_bhyve.devices import status as rx
+from orbit_bhyve.devices.base import DeviceState, ProgramSpec, ProgramSummary
+from orbit_bhyve.devices.ht25g2 import BHyveHT25G2Device
+
+
+# --- builder byte references (W0 hardware-verified; same as the CLI) --------
+
+@pytest.mark.parametrize(
+    "pb,expected",
+    [
+        (tx._build_set_timer_mode_pb(1), "720408011200"),   # autoMode
+        (tx._build_set_timer_mode_pb(0), "720408001200"),   # offMode
+        (tx._build_set_timer_mode_pb(2), "720408021200"),   # manualMode (== stop)
+        (tx._STOP_PB, "720408021200"),
+        (tx._build_set_active_programs_pb(0), "a201020800"),
+        (tx._build_set_active_programs_pb(8), "a201020808"),  # slot D bit
+        (tx._build_sync_request_pb(), "5200"),                # #10 empty
+        (tx._build_program_delete_pb(4), "9a010408041200"),   # #19{#1=4,#2 NotSet}
+    ],
+)
+def test_ha_program_builder_byte_refs(pb, expected):
+    assert pb.hex() == expected
+
+
+def test_ha_timer_mode_requires_empty_manual_params_marker():
+    # a #14 that omits the #2 `12 00` marker is silently ignored by the device
+    assert tx._build_set_timer_mode_pb(1).endswith(bytes.fromhex("1200"))
+
+
+def test_ha_active_programs_bitmask_is_one_shifted():
+    for slot, bit in [(1, 1), (2, 2), (3, 4), (4, 8), (5, 16)]:
+        assert bit == 1 << (slot - 1)
+        pb = tx._build_set_active_programs_pb(bit)
+        body = rx.pb_parse(pb)[0][2]
+        assert rx._pb_field(rx.pb_parse(body), 1) == bit
+
+
+# --- signed-tz epoch time (#75), hardware-verified byte reference -----------
+
+def _ha_spec(*a, **kw):
+    return ProgramSpec(*a, **kw)
+
+
+def test_set_epoch_time_signed_tz_byte_ref():
+    # #75 setEpochTime { #1 epoch, #2 tzOffsetSec } — the coordinator poll's
+    # elicitor. A negative tz offset must encode as a signed varint (EDT = -4h).
+    assert (
+        tx._build_set_epoch_time_pb(epoch_utc=1783317742, tz_offset_sec=-14400).hex()
+        == "da041108ee89add20610c08fffffffffffffff01"
+    )
+
+
+# --- #19 build -> parse round-trips (HA decoder) ----------------------------
+
+def _body(pb19):
+    return rx.pb_parse(pb19)[0][2]
+
+
+def test_ha_weekdays_multizone_multistart_round_trip():
+    spec = _ha_spec(slot=4, day_mode="weekdays", weekday_mask=0x7F,
+                    start_mins=(360, 1080), zones=((0, 300), (1, 420)), name="W0TestD")
+    sch = rx.parse_program_body(_body(tx._build_program_pb(spec)))
+    assert sch.slot == 4 and not sch.empty
+    assert sch.day_mode == "weekdays" and sch.weekday_mask == 0x7F
+    assert sch.start_mins == (360, 1080)
+    assert sch.zones == ((0, 300), (1, 420))
+    assert sch.name == "W0TestD" and sch.budget == 100
+
+
+def test_ha_interval_round_trip_emits_anchor_iso():
+    spec = _ha_spec(slot=2, day_mode="interval", interval_days=3,
+                    interval_anchor="2026-06-28T00:00:00-04:00",
+                    start_mins=(360,), zones=((0, 600),), name="Drip")
+    sch = rx.parse_program_body(_body(tx._build_program_pb(spec)))
+    assert sch.day_mode == "interval" and sch.interval_days == 3
+    assert sch.interval_anchor.startswith("2026-06-28")
+    assert sch.start_mins == (360,) and sch.zones == ((0, 600),)
+
+
+@pytest.mark.parametrize("mode,field", [("odd", 5), ("even", 6)])
+def test_ha_odd_even_empty_markers(mode, field):
+    spec = _ha_spec(slot=1, day_mode=mode, start_mins=(360,), zones=((0, 60),), name="x")
+    body = _body(tx._build_program_pb(spec))
+    assert rx._pb_field(rx.pb_parse(body), field) == b""
+    assert rx.parse_program_body(body).day_mode == mode
+
+
+def test_ha_delete_produces_notset_and_parses_empty():
+    sch = rx.parse_program_body(_body(tx._build_program_delete_pb(1)))
+    assert sch.slot == 1 and sch.empty
+
+
+def test_ha_parse_decodes_packed_single_start_hw_shape():
+    # the exact bytes BTValve03 echoed for `--start 00:55` (start_min 55 = 0x37).
+    body = bytes.fromhex("08061a02087f4201374a040800103c50648a0107434c4954455354")
+    sch = rx.parse_program_body(body)
+    assert sch.slot == 6 and sch.name == "CLITEST"
+    assert sch.start_mins == (55,)
+    assert sch.zones == ((0, 60),)
+    assert sch.weekday_mask == 0x7F
+
+
+# --- multi-frame reassembly (split_inner_messages / parse_sync_dump) --------
+
+def _dump_stream(program_pbs, mask, status_pb=None) -> bytes:
+    """A #10 sync-dump plaintext stream: concatenated inner messages (each
+    aa775a0f-framed), exactly what connection.send_stream returns."""
+    parts = [tx._build_message(p) for p in program_pbs]
+    parts.append(tx._build_message(tx._build_set_active_programs_pb(mask)))
+    if status_pb is not None:
+        parts.append(tx._build_message(status_pb))
+    return b"".join(parts)
+
+
+def test_split_inner_messages_finds_contiguous_msgs():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    stream = _dump_stream([a], mask=1)
+    msgs = rx.split_inner_messages(stream)
+    assert len(msgs) == 2  # the #19 body + the #20 bitmask
+    assert any(rx._pb_field(rx.pb_parse(m), rx.RX_F_PROGRAM) is not None for m in msgs)
+
+
+def test_parse_sync_dump_fills_enabled_from_bitmask():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    c = tx._build_program_pb(_ha_spec(3, "even", start_mins=(420,), zones=((0, 60),), name="C"))
+    stream = _dump_stream([a, c], mask=0b001)  # only A enabled (bit 0)
+    programs, mask, _status = rx.parse_sync_dump(stream)
+    assert mask == 0b001
+    assert programs[1].enabled is True    # A (bit 0 set)
+    assert programs[3].enabled is False   # C (bit 2 clear)
+
+
+def test_parse_sync_dump_reads_status_next_start():
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_NEXTSTART_FLAGS, 0b001)
+    sub += tx._pb_field_varint(rx.RX_F_STATUS_NEXTSTART, 1_700_000_000)
+    status_pb = tx._pb_field_bytes(rx.RX_F_STATUS, sub)
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    programs, mask, status = rx.parse_sync_dump(_dump_stream([a], mask=1, status_pb=status_pb))
+    assert status is not None and status.next_start_flags == 0b001
+    assert status.next_start_epoch == 1_700_000_000
+
+
+# --- connection.send_stream reassembles a real multi-frame CTR burst --------
+
+def _handshaken_stream_conn() -> BHyveBleConnection:
+    conn = BHyveBleConnection(None, "AA:BB:CC:DD:EE:FF", "00" * 16)
+    conn._reply_header = rx.MSG_HEADER
+    conn._handshaken = True
+    conn._iv = b"\x01" * 12
+    conn._rx_ctr = 1000
+    return conn
+
+
+def test_send_stream_reassembles_message_split_across_frames():
+    # A long #19 program body deliberately spans multiple CTR-block frames. The
+    # per-frame decrypt in _on_notify + send_stream's concat must rejoin it.
+    conn = _handshaken_stream_conn()
+    long_prog = tx._build_program_pb(_ha_spec(
+        4, "weekdays", weekday_mask=42, start_mins=(360,), zones=((0, 300),),
+        name="A long enough name to force this message across a frame boundary!"))
+    stream_pt = _dump_stream([long_prog], mask=9)
+
+    # Encrypt the whole plaintext stream as one CTR run at the conn's rx_ctr, then
+    # chop the ciphertext into outer frames on 16-byte block boundaries.
+    ks, _ = conn._aes_keystream(conn._rx_ctr, (len(stream_pt) + 15) // 16)
+    ct = bytes(b ^ k for b, k in zip(stream_pt, ks[:len(stream_pt)]))
+    frames = []
+    for off, nblk in ((0, 1), (16, 3), (64, 99)):  # 1 block, 3 blocks, rest
+        chunk = ct[off:off + nblk * 16]
+        if chunk:
+            frames.append(bytes([conn._frame_magic, len(chunk)]) + chunk + b"\x00\x00")
+
+    for f in frames:
+        conn._on_notify(None, f)
+    got = b"".join(conn._notif_pt)
+    assert got == stream_pt
+    programs, mask, _ = rx.parse_sync_dump(got)
+    assert mask == 9 and 4 in programs and programs[4].name.startswith("A long enough")
+
+
+# --- program device methods (mirror the CLI handshake) ----------------------
+
+def _make_gen2(**state_kwargs):
+    dev = object.__new__(BHyveHT25G2Device)  # bypass HA-heavy __init__
+    dev.mac = "AA:BB:CC:DD:EE:FF"
+    dev.state = DeviceState(**state_kwargs)
+    dev.flow_counts_per_gallon = 433
+    return dev
+
+
+def _is_status_elicitor(frame: bytes) -> bool:
+    top = rx.pb_parse(rx.decode_inner(frame) or b"")
+    return rx._pb_field(top, 15) is not None or rx._pb_field(top, 75) is not None
+
+
+def _status_with_next_start(flags, epoch=1_700_000_000, run_state=1) -> bytes:
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, run_state)
+    sub += tx._pb_field_varint(rx.RX_F_STATUS_NEXTSTART_FLAGS, flags)
+    sub += tx._pb_field_varint(rx.RX_F_STATUS_NEXTSTART, epoch)
+    return tx._build_message(tx._pb_field_bytes(rx.RX_F_STATUS, sub))
+
+
+def _status_with_mode(mode) -> bytes:
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, 1)
+    sub += tx._pb_field_bytes(rx.RX_F_STATUS_RUNECHO, tx._pb_field_varint(rx.RX_F_RUNECHO_MODE, mode))
+    return tx._build_message(tx._pb_field_bytes(rx.RX_F_STATUS, sub))
+
+
+class _FakeProgramConn:
+    """Records send()/send_stream() frames, returns a queue of canned sync-dump
+    streams for send_stream, and feeds a canned status via the observer on a
+    status elicitor (#15/#75). is_connected stays True (pooled session)."""
+
+    def __init__(self, device, *, dumps=None, status_pt=None):
+        self.device = device
+        self._dumps = list(dumps or [])
+        self.status_pt = status_pt
+        self.sent: list[bytes] = []
+        self.streamed: list[bytes] = []
+        self.disconnects = 0
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        if _is_status_elicitor(frame) and self.status_pt is not None:
+            self.device._observe_plaintext(self.status_pt)
+        return [b"\x01"]
+
+    async def send_stream(self, frame: bytes, drain_ms: int = 4000):
+        self.streamed.append(frame)
+        if len(self._dumps) > 1:
+            return self._dumps.pop(0)
+        return self._dumps[0] if self._dumps else b""
+
+    async def disconnect(self):
+        self.disconnects += 1
+
+    @property
+    def is_connected(self):
+        return True
+
+
+def _program_ops(sent: list[bytes]) -> list[int]:
+    """Top-level field number of each non-status, non-flow sent frame — the
+    program/mode op sequence (19=store, 20=enable, 14=mode)."""
+    ops = []
+    for f in sent:
+        top = rx.pb_parse(rx.decode_inner(f) or b"")
+        num = top[0][0] if top else None
+        if num in (14, 19, 20):
+            ops.append(num)
+    return ops
+
+
+def test_get_programs_reads_and_stores():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(dev, dumps=[_dump_stream([a], mask=1)])
+    programs = asyncio.run(dev.get_programs())
+    assert 1 in programs and programs[1].name == "A" and programs[1].enabled is True
+    assert dev.state.programs[1].enabled is True
+    assert dev.connection.disconnects == 1  # ephemeral teardown
+
+
+def test_set_program_enabled_drives_three_write_handshake_in_order():
+    spec = _ha_spec(4, "weekdays", weekday_mask=0x7F, start_mins=(360,),
+                    zones=((0, 180),), name="D", enabled=True)
+    stored = tx._build_program_pb(spec)
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(
+        dev,
+        dumps=[_dump_stream([], mask=0), _dump_stream([stored], mask=0)],
+        status_pt=_status_with_next_start(0b1000),  # slot D next-start reported
+    )
+    ok = asyncio.run(dev.set_program(spec))
+    assert ok is True
+    # store -> enable -> autoMode -> re-send store -> re-send enable
+    assert _program_ops(dev.connection.sent) == [19, 20, 14, 19, 20]
+    assert dev.state.next_start_flags == 0b1000
+
+
+def test_set_program_store_only_keeps_automode_no_run_dance():
+    spec = _ha_spec(4, "weekdays", weekday_mask=0x7F, start_mins=(360,),
+                    zones=((0, 180),), name="D", enabled=False)
+    stored = tx._build_program_pb(spec)
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(
+        dev, dumps=[_dump_stream([], mask=0), _dump_stream([stored], mask=0)]
+    )
+    ok = asyncio.run(dev.set_program(spec))
+    assert ok is True
+    # store -> clear-bit enable -> autoMode; NO re-send store/enable run dance
+    assert _program_ops(dev.connection.sent) == [19, 20, 14]
+    # the controller is returned to autoMode(1), never dropped to offMode(0)
+    modes = [rx._pb_field(rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(f)), 14)), 1)
+             for f in dev.connection.sent
+             if rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 14) is not None]
+    assert modes == [1]
+
+
+def test_set_program_enabled_toggle_flips_bitmask():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(
+        dev,
+        dumps=[_dump_stream([a], mask=0), _dump_stream([a], mask=1)],  # off -> on
+        status_pt=_status_with_next_start(0b001),
+    )
+    ok = asyncio.run(dev.set_program_enabled(1, True))
+    assert ok is True
+    ops = _program_ops(dev.connection.sent)
+    assert ops[0] == 20 and 14 in ops           # enable then autoMode
+    # the enable bitmask carries bit0 (slot A)
+    first = rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(dev.connection.sent[0])), 20))
+    assert rx._pb_field(first, 1) == 1
+
+
+def test_delete_program_clears_slot():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(
+        dev, dumps=[_dump_stream([a], mask=1), _dump_stream([tx._build_program_delete_pb(1)], mask=0)]
+    )
+    ok = asyncio.run(dev.delete_program(1))
+    assert ok is True
+    ops = _program_ops(dev.connection.sent)
+    assert ops == [20, 19, 14]  # clear-bit, delete body, keep autoMode
+
+
+def test_set_controller_mode_confirms_via_status():
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(dev, status_pt=_status_with_mode(1))
+    ok = asyncio.run(dev.set_controller_mode(True))
+    assert ok is True
+    assert dev.state.controller_mode == 1
+    # a #14 timerMode was sent with mode=1
+    mode14 = [f for f in dev.connection.sent
+              if rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 14) is not None]
+    assert mode14 and rx._pb_field(rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(mode14[0])), 14)), 1) == 1
+
+
+# --- identify (#47 LED locate) ---------------------------------------------
+
+def test_identify_builder_byte_refs():
+    assert tx._build_identify_pb(5).hex() == "fa02020805"   # start (5s)
+    assert tx._build_identify_pb(0).hex() == "fa02020800"   # stop
+
+
+def test_identify_flashes_then_stops(monkeypatch):
+    import orbit_bhyve.devices.protobuf as P
+
+    async def _no_sleep(*_a):
+        return None
+    monkeypatch.setattr(P.asyncio, "sleep", _no_sleep)
+
+    dev = _make_gen2()
+    dev.connection = _FakeProgramConn(dev)
+    ok = asyncio.run(dev.identify(seconds=6))
+    assert ok is True
+    id_frames = [f for f in dev.connection.sent
+                 if rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 47) is not None]
+    assert len(id_frames) == 2   # start then explicit stop (the flash latches)
+    vals = [rx._pb_field(rx.pb_parse(rx._pb_field(rx.pb_parse(rx.decode_inner(f)), 47)), 1)
+            for f in id_frames]
+    assert vals == [6, 0]
+    assert dev.connection.disconnects == 1
+
+
+# --- idle coordinator poll refreshes the A–D schedules ----------------------
+
+def _status_idle() -> bytes:
+    return tx._build_message(
+        tx._pb_field_bytes(rx.RX_F_STATUS, tx._pb_field_varint(rx.RX_F_STATUS_MODE, 1))
+    )
+
+
+class _ScriptedStreamConn:
+    """Returns a scripted list of sync-dump streams, one per send_stream call. Feeds
+    a canned status on a #15/#75 elicitor. Records send_stream calls in `streamed`."""
+
+    def __init__(self, device, streams, status_pt=None):
+        self.device = device
+        self._streams = list(streams)
+        self.status_pt = status_pt
+        self.sent: list[bytes] = []
+        self.streamed: list[bytes] = []
+        self.disconnects = 0
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        self.sent.append(frame)
+        if _is_status_elicitor(frame) and self.status_pt is not None:
+            self.device._observe_plaintext(self.status_pt)
+        return [b"\x01"]
+
+    async def send_stream(self, frame: bytes, drain_ms: int = 4000):
+        self.streamed.append(frame)
+        return self._streams.pop(0) if self._streams else b""
+
+    async def disconnect(self):
+        self.disconnects += 1
+
+    @property
+    def is_connected(self):
+        return True
+
+
+def test_read_programs_keeps_last_known_on_empty_read_no_retry():
+    # A desynced/truncated read yields an empty stream. It must NOT blank the known
+    # schedules, and must NOT retry with an immediate reconnect (that races the
+    # device's single-BLE-session release and wedges the link) — get_programs
+    # returns the last-known state.programs, one send_stream only.
+    dev = _make_gen2()
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, enabled=True, name="Keep")}
+    dev.connection = _ScriptedStreamConn(dev, streams=[b""])
+    programs = asyncio.run(dev.get_programs())
+    assert 1 in programs and programs[1].name == "Keep"
+    assert len(dev.connection.streamed) == 1   # no amplifying retry
+
+
+def test_read_programs_populates_bodies_and_carries_enabled_without_mask():
+    # A burst that decodes the #19 bodies but drops the small #20 mask (mask=None)
+    # must still populate the schedule, and carry each slot's KNOWN enabled state
+    # forward rather than reporting it as off/unknown.
+    dev = _make_gen2()
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, enabled=True, name="A")}
+    body_only = tx._build_message(
+        tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    )  # a #19 message with NO trailing #20 mask
+    dev.connection = _ScriptedStreamConn(dev, streams=[body_only])
+    programs = asyncio.run(dev.get_programs())
+    assert 1 in programs and not programs[1].empty
+    assert programs[1].enabled is True         # carried forward, not blanked to None
+    assert len(dev.connection.streamed) == 1
+
+
+def test_read_programs_empty_device_completes_without_retry():
+    # A genuinely empty device returns the #20 mask (0) with no #19 bodies — that is
+    # a COMPLETE read, not a partial one, so it must not retry.
+    dev = _make_gen2()
+    dev.connection = _ScriptedStreamConn(dev, streams=[_dump_stream([], mask=0)])
+    programs = asyncio.run(dev.get_programs())
+    assert programs == {}
+    assert len(dev.connection.streamed) == 1   # no retry
+
+
+def test_refresh_state_reads_programs_on_idle_poll():
+    a = tx._build_program_pb(_ha_spec(1, "odd", start_mins=(360,), zones=((0, 60),), name="A"))
+    dev = _make_gen2(is_watering=False)
+    dev.connection = _FakeProgramConn(dev, dumps=[_dump_stream([a], mask=1)], status_pt=_status_idle())
+    state = asyncio.run(dev.refresh_state())
+    assert state.is_watering is False
+    assert 1 in state.programs and state.programs[1].enabled is True
+    # the #10 syncRequest went out on the idle poll (via send_stream)
+    assert any(rx._pb_field(rx.pb_parse(rx.decode_inner(f) or b""), 10) is not None
+               for f in dev.connection.streamed)


### PR DESCRIPTION
# Watering programs + protobuf-family capability round-up

Builds on #24 (protobuf-family foundation, now merged) and targets `main` at
v2.2.0. Adds local BLE **watering-program** control for the protobuf family
(HT25G2 Gen2 + HT34A XD), plus the supporting protocol/transport work. All
additive and gated to the protobuf family via `resolve_device_class()`; the
mesh path and existing behavior are untouched.

Hardware-verified end-to-end on 4× Gen2 (HT25G2 fw0111) + the XD (HT34A fw0107)
over ESPHome BLE proxies. 136 tests, no HA/hardware required to run them.

## What's in it

**Watering programs (the headline)**
- Read/write non-Smart program slots (A–F) over BLE: watering days
  (weekdays / even / odd / every-N-days), start time(s), per-zone run
  durations. Store, replace, enable/disable, delete.
- Services: `set_program`, `delete_program`, `get_program`
  (`SupportsResponse.ONLY`, returns the stored slot as structured data).
- Entities: **Automatic-watering** switch (controller auto/off),
  **Program A–D** enable switches (a slot with no stored program reads
  `unavailable`), **Program A–D** summary sensors (schedule in attributes),
  and a **Next run** timestamp sensor (device-computed next start).
- Slots are read back from the device's `#10` sync dump (a multi-frame reply),
  so programs created in the B-Hyve app show up too. There is no schedule
  *read* opcode in the protocol; `#10` is the only path and it returns all
  slots.
- Enabling a program uses the hardware-verified **3-write sequence** (store
  `#19` → enable `#20` bitmask → `#14 timerMode autoMode` with the required
  empty `manualModeParams` marker, re-sent), which is what the app does and
  the only sequence that makes a stored program actually compute a next start.

**Identify button** — `#47` LED-locate across the protobuf family (flashes the
Gen2 LED; no-op on the XD, which ignores it).

**Supporting protocol/transport work** (needed by programs, but general):
- `connection.send_stream()` — multi-frame RX reassembly: concatenates a
  reply's per-frame plaintext so a long `#10` dump that CTR-streams across
  frames can be reassembled. Single-frame paths (`#16`/`#30`/`#59`) unchanged.
- Program/mode writes fail gracefully on a marginal link. A CTR-desync
  self-heal can tear the pooled session down mid-write-sequence (the next write
  then raises `BleakError("Not connected")` over an ESPHome proxy); the write
  methods now catch that and return `False` (→ "not confirmed" + a coordinator
  refresh that re-reads real state) instead of surfacing a raw exception to the
  service/switch call. Mirrors the read path's best-effort behavior.

## Design choices & rationale

Two threads run through these changes: **keep leaning away from the cloud and
the native app**, and **add capability without over-committing HA surface**
before the shape is proven on hardware.

- **Time sync on the device, from HA.** Schedules, rain-delay expiry, and
  on-device auto-close all key off the device's own clock. Rather than depend
  on the app to keep that clock honest, the coordinator poll now syncs it to
  HA-now via `#75 setEpochTime` — which returns the same `#16` status block, so
  it costs nothing extra and folds another job the app used to own into the
  integration.

- **Programs: make them visible and workable, but keep the HA surface small
  for now.** This deliberately does *not* build out a full HA entity model for
  every program attribute (per-start-time entities, per-zone duration numbers,
  day-mode selectors, etc.). Instead it exposes programs through a compact set
  — enable switches, a read-only schedule summary sensor, a next-run sensor,
  and get/set/delete services — so a user can see what's stored (including
  app-created programs), toggle slots, and script changes today, without
  locking in a large entity schema before the ergonomics are proven. The full
  encode/decode is already in place under the hood; the entity surface can grow
  later without protocol rework.

## Behavioral change to call out (not purely additive)

One existing behavior changes here — flagging it explicitly for review
(rationale in *Design choices* above):

- **Coordinator poll elicitor: `#75 setEpochTime` instead of a bare `#15{}`.**
  Returns the same `#16` status block, and additionally syncs the device
  clock to HA-now. Content-identical status reply verified on hardware.

## Compatibility / safety

- Programs, switches, program sensors, Next-run, and Identify are created only
  for protobuf-family devices; mesh HT25 and the hub are unaffected.
- No new cloud dependency — everything is BLE after setup.
- Firmware caveat unchanged: RE'd against fw0111 / fw0107.

## Not included (stays in our fork)

The CLI (`scripts/bhyve.py`) and RE/exploration tooling that we develop and
hardware-verify against are intentionally left out of the integration, per the
repo's "diagnostic code stays out of the component" guidance. The shipping
program encoders/decoders live in `devices/protobuf.py` + `devices/status.py`.
