### PR TITLE
fix(rain-delay): don't self-overwrite on units that ignore #15; add a rain-delay preset select

### DIFF
--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -46,6 +46,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.BUTTON,
+    Platform.SELECT,
 ]
 
 

--- a/custom_components/orbit_bhyve/devices/protobuf.py
+++ b/custom_components/orbit_bhyve/devices/protobuf.py
@@ -438,10 +438,21 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
                 plaintext = _build_message(_build_rain_delay_pb(minutes, expiry))
                 notifs = await self.connection.send(plaintext, drain_ms=2000)
                 self._stamp_command(f"rain_delay set {minutes}m", len(notifs))
+                # Seed the INTENDED delay onto state before the confirm read. If that
+                # read falls into _recover_status (a unit that ignores the passive
+                # #15), its status elicitor is a setRainDelay re-assert of self.state
+                # (_noop_rain_delay_pb). Left at the pre-set value it would re-send
+                # #17{#1=0} and CLEAR the delay we just set (the reported bug). Seeding
+                # the new value makes that re-assert idempotent with the set, so the
+                # device echoes the real #16.#13 back and confirmation stays honest.
+                self.state.rain_delay_minutes = minutes
+                self.state.rain_delay_ends = datetime.fromtimestamp(expiry, tz=timezone.utc)
                 # Read back the authoritative #16.#13 echo via #15{} rather than trusting
-                # the set reply's push (which the device suppresses while active).
+                # the set reply's push (which the device suppresses while active). Gate
+                # "confirmed" on a real #16 decoding this cycle (_status_parsed) so the
+                # seeded value alone can't report a false confirm when no status came back.
                 await self.refresh_status()
-                ok = bool(self.state.rain_delay_minutes)
+                ok = self._status_parsed and bool(self.state.rain_delay_minutes)
                 _LOGGER.log(
                     logging.DEBUG if ok else logging.WARNING,
                     "%s: %s rain-delay set %dm %s",
@@ -463,9 +474,16 @@ class BHyveProtobufDevice(BHyveBleDeviceBase):
             plaintext = _build_message(_build_rain_delay_pb(0, None))
             notifs = await self.connection.send(plaintext, drain_ms=2000)
             self._stamp_command("rain_delay clear", len(notifs))
+            # Seed the cleared state before the confirm read for the same reason as
+            # set_rain_delay: if _recover_status runs, its _noop_rain_delay_pb elicitor
+            # re-asserts self.state — left at the stale pre-clear minutes it would
+            # re-send the delay and UNDO the clear. Seeding 0 makes it re-send #17{#1=0}
+            # (idempotent with the clear) and the device echoes the real cleared #16.#13.
+            self.state.rain_delay_minutes = 0
+            self.state.rain_delay_ends = None
             # Confirm the cleared #16.#13 echo via a #15{} read-back.
             await self.refresh_status()
-            return not self.state.rain_delay_minutes
+            return self._status_parsed and not self.state.rain_delay_minutes
         finally:
             if self.connection is not None:
                 await self.connection.disconnect()

--- a/custom_components/orbit_bhyve/select.py
+++ b/custom_components/orbit_bhyve/select.py
@@ -1,0 +1,108 @@
+"""Select platform — rain-delay presets.
+
+A single SelectEntity per protobuf-family device (HT34A/HT25G2) that exposes
+the rain delay as a coarse dropdown of hour/day presets. Each pick is exactly
+ONE BLE write, which is the point: unlike a number stepper/slider (one write per
+click/drag) there is no ambiguity about when the value is sent, and no queue of
+unintended intermediate writes fighting the coordinator poll for the device's
+single BLE session.
+
+The finer-grained "Rain delay" NumberEntity (hours, arbitrary values) stays
+alongside this for the rare odd value and for backwards compatibility with
+existing dashboards/automations. Both drive the same device.set_rain_delay.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BHyveDeviceCoordinator
+from .devices.protobuf import BHyveProtobufDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+_OFF = "Off"
+
+# Ordered preset label -> rain-delay minutes. Mirrors the B-Hyve app's coarse
+# choices: short hour holds plus multi-day delays, capped at the app's 7-day
+# ceiling. "Off" clears the delay.
+RAIN_DELAY_PRESETS: dict[str, int] = {
+    _OFF: 0,
+    "1 hour": 60,
+    "2 hours": 120,
+    "4 hours": 240,
+    "8 hours": 480,
+    "12 hours": 720,
+    "16 hours": 960,
+    "1 day": 1440,
+    "2 days": 2880,
+    "3 days": 4320,
+    "5 days": 7200,
+    "7 days": 10080,
+}
+# Reverse map for reflecting the device's live state back to a preset label.
+_MINUTES_TO_LABEL: dict[int, str] = {v: k for k, v in RAIN_DELAY_PRESETS.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SelectEntity] = []
+    for coord in runtime.coordinators.values():
+        # Rain delay is a protobuf-family (HT34A/HT25G2) capability.
+        if isinstance(coord.device, BHyveProtobufDevice):
+            entities.append(BHyveRainDelaySelect(coord))
+    async_add_entities(entities)
+
+
+class BHyveRainDelaySelect(CoordinatorEntity[BHyveDeviceCoordinator], SelectEntity):
+    """Rain delay as a preset dropdown. Reflects the device's live #16.#13 state,
+    so it is not restored — the device is truth. One pick = one BLE write."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Rain delay preset"
+    _attr_icon = "mdi:weather-rainy"
+    _attr_options = list(RAIN_DELAY_PRESETS)
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_rain_delay_preset"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    @property
+    def current_option(self) -> str | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        minutes = state.rain_delay_minutes or 0
+        if not minutes:
+            return _OFF
+        # An active delay set to a non-preset value (e.g. via the app or the
+        # exact-hours number) has no matching option — show nothing selected
+        # rather than mislabel it; the "Rain delay" number/"ends" sensor carry
+        # the exact value.
+        return _MINUTES_TO_LABEL.get(minutes)
+
+    async def async_select_option(self, option: str) -> None:
+        minutes = RAIN_DELAY_PRESETS[option]
+        device = self.coordinator.device
+        if minutes <= 0:
+            await device.clear_rain_delay()
+        else:
+            await device.set_rain_delay(minutes)
+        await self.coordinator.async_request_refresh()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -270,6 +270,59 @@ def test_set_rain_delay_anchors_expiry_to_device_clock():
     assert rx._pb_field(rd_pb, rx.RX_F_RD_EXPIRY) == clock + minutes * 60
 
 
+def _written_rain_delay_minutes(frame: bytes) -> int | None:
+    """If `frame` is a setRainDelay (#17) write, return its #1 minutes; else None."""
+    inner = rx.decode_inner(frame)
+    if inner is None:
+        return None
+    body = rx._pb_field(rx.pb_parse(inner), 17)
+    if body is None:
+        return None
+    return rx._pb_field(rx.pb_parse(body), rx.RX_F_RD_MINUTES) or 0
+
+
+class _IgnoresStatusEchoesRainDelayConn(_FakeConn):
+    """A unit (like BTValve01 while active) that ignores the passive #15 query and
+    does NOT echo the set write's own reply ("suppressed while active"), but DOES
+    answer the status-recovery no-op — a #17 write issued right after a failed #15
+    — with the resulting #16 status. Tells the two #17 writes apart by whether a
+    #15 immediately preceded them: only the recovery no-op does."""
+
+    def __init__(self, device, *, clock: int):
+        super().__init__(device, on_status=None, on_command=None)
+        self._clock = clock
+
+    async def send(self, frame: bytes, drain_ms: int = 1500):
+        prev = self.sent[-1] if self.sent else None
+        self.sent.append(frame)
+        minutes = _written_rain_delay_minutes(frame)
+        if minutes is not None and prev == pb._build_message(pb._REQUEST_STATUS_PB):
+            self.device._observe_plaintext(_status_clock_and_rain_delay(self._clock, minutes))
+        return [b"\x01"]
+
+
+def test_set_rain_delay_survives_recovery_on_unit_that_ignores_15():
+    # Regression: on a unit that ignores #15 and whose set reply is suppressed, the
+    # confirm read-back falls into _recover_status, whose #16-eliciting no-op re-
+    # asserts self.state. set_rain_delay must SEED the intended minutes BEFORE that
+    # read, so the no-op re-sends the delay just set — not a stale bare #17{#1=0}
+    # clear that silently cancels it (the "rain-delay set … unconfirmed" bug, where
+    # the entity snapped back to 0). has_flow=False isolates the rain-delay recovery
+    # path from the orthogonal flow (#57) dance.
+    clock = 1_700_000_000
+    dev = _make_device(is_watering=False)
+    dev.has_flow = False
+    dev.connection = _IgnoresStatusEchoesRainDelayConn(dev, clock=clock)
+
+    ok = asyncio.run(dev.set_rain_delay(120))
+
+    # Pre-fix: the recovery no-op read stale state (0) and sent #17{#1=0}, so the
+    # device echoed 0 -> ok False, minutes 0. Post-fix: the seed makes the no-op
+    # re-assert 120, the device echoes 120 back -> confirmed.
+    assert ok is True
+    assert dev.state.rain_delay_minutes == 120
+
+
 # --- flow (#57/#59, Gen2-only) --------------------------------------------
 
 def test_has_flow_only_on_gen2():


### PR DESCRIPTION
## Summary

Two rain-delay changes for the protobuf family (HT34A XD + HT25G2 Gen2):

1. **Bug fix — `set_rain_delay` / `clear_rain_delay` could silently cancel the change
   they just made.** On a unit that ignores the passive `#15` `getDeviceStatus` query,
   the confirm read-back falls into `_recover_status`, whose status elicitor is a
   `setRainDelay` (`#17`) re-assert of `self.state` (`_noop_rain_delay_pb`). Because the
   device suppresses the set reply while it is active, `self.state.rain_delay_minutes`
   still held the **pre-write** value at that point, so the no-op sent `#17{#1=0}` and
   **cleared the delay just set** (and, symmetrically, re-asserted a stale delay to
   **undo a clear**). The device then echoed `0`, the entity snapped back to `0`, and the
   log showed `rain-delay set … unconfirmed`. Hardware-observed on a live valve.

2. **Feature — a rain-delay preset `select` entity.** Exposes the delay as coarse
   hour/day presets so one pick is exactly **one BLE write**, with no ambiguity about
   when the value is sent (unlike a number stepper/slider, which writes on every
   click/drag and can queue intermediate writes that contend with the coordinator poll
   for the device's single BLE session).

## Changes

### `0232197` — fix + regression test
- In `set_rain_delay` and `_clear_rain_delay_unlocked`, **seed the intended rain-delay
  state onto `self.state` before the confirming read-back**, so a `_recover_status`
  no-op re-asserts the *new* value (idempotent with the write) and the device echoes the
  real `#16.#13` back — instead of reverting to stale pre-write state.
- **Gate "confirmed" on `_status_parsed`** so the seed alone can't report a false confirm
  when no `#16` was decoded.
- New regression test (`tests/test_devices.py`) models a unit that ignores `#15` and
  whose set reply is suppressed; it **reproduces the exact `unconfirmed` symptom without
  the fix** and passes with it.

### `7b92cc1` — preset select
- New `select.py` → one `BHyveRainDelaySelect` per protobuf-family device. Options:
  `Off, 1/2/4/8/12/16 hours, 1/2/3/5/7 days`. `current_option` reflects the live
  `#16.#13` state (a non-preset active value shows nothing selected rather than
  mislabeling); selecting maps to `set_rain_delay` / `clear_rain_delay`, one write.
- `__init__.py`: add `Platform.SELECT` to `PLATFORMS`.

## Backwards compatibility

Strictly additive.
- The fix only changes the ordering/gating inside the existing rain-delay methods; the
  wire protocol and the happy path (a unit that answers `#15`) are unchanged.
- The existing **"Rain delay" number** entity (arbitrary hours) is untouched and stays
  alongside the new dropdown, so existing dashboards / automations keep working.
- The `select` platform is gated to `BHyveProtobufDevice`; mesh/hub devices are unaffected.

## Testing

- **Unit:** 103 tests green. The new regression test fails without the fix
  (`rain-delay set 120m unconfirmed`, minutes wiped to 0) and passes with it.
- **CI:** Hassfest + HACS both pass on the fork's `validate.yaml`.
- **Hardware (fleet, deployed to HA):** set/cleared rain delay across BTValve01–04 (Gen2)
  and the BT4ValveXD01 (HT34A) from the new dropdown — each pick is a single
  `rain-delay set …m confirmed`, no `unconfirmed` warnings, and the dropdown reflects the
  device's live state (e.g. a 1440 m delay reads back as "1 day"). The pre-fix symptom
  (entity snapping back to 0) is gone.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
