### PR TITLE
feat(devices): route HT31-0001 to the HT34A XD class (hardware-verified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ when the WAN goes down.
 | 4-port XD         | `HT34A-0001`   | `0107`           | ✅ Battery/status decode verified on hardware; XD actuation proven via HT32A sibling |
 | 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
 | 2-port XD         | `HT32A-0001`   | `0107`           | ✅ Actuated end-to-end (shares the HT34A XD protobuf protocol) |
+| Hose-tap timer    | `HT31-0001`    | `0058`           | ✅ Actuated end-to-end (shares the HT34A XD protobuf protocol) |
 
 > ⚠️ **Do NOT update your B-Hyve device firmware.** This integration was
 > reverse-engineered against the firmware versions above. A firmware update

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -57,6 +57,14 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         # class handles a 2-port unit unchanged. Untested on hardware here
         # (issue #13) — same caveat as HT34A.
         return BHyveHT34ADevice
+    if (hardware or "").startswith("HT31"):
+        # HT31-0001 "Smart Hose Tap Timer" (fw0058): single-port sibling of
+        # the XD family — same fw0058 protobuf-over-CRC16 protocol (magic
+        # 0x11) as HT34-0001. Hardware-verified end-to-end (status/battery
+        # polling + valve actuation with water observed) on five fw0058
+        # units, 2026-07-12. Station count flows from the cloud record, so
+        # the 4-port class handles the 1-port unit unchanged.
+        return BHyveHT34ADevice
     raise UnsupportedModel(hardware or "?", firmware or "?")
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -34,6 +34,7 @@ from orbit_bhyve.devices.protobuf import BHyveProtobufDevice
     [
         ("", "", "bridge", BHyveHubDevice),               # hub wins on type
         ("HT34A-0001", "0107", "", BHyveHT34ADevice),     # XD 4-port
+        ("HT31-0001", "0058", "", BHyveHT34ADevice),      # 1-port Smart Hose Tap (XD protobuf)
         ("HT25G2-0001", "0111", "", BHyveHT25G2Device),   # Gen2 by suffix
         ("HT25-0001", "0111", "", BHyveHT25G2Device),       # Gen2 by fw0111
         ("HT25-0001", "0085", "", BHyveHT25Fw0085Device),   # mesh fw0085 (upstream subclass)


### PR DESCRIPTION
## What

Adds a routing clause so `HT31-0001` ("Smart Hose Tap Timer", fw `0058`) resolves to `BHyveHT34ADevice` instead of raising `UnsupportedModel`. Also adds the README hardware-table row and a resolver test case. Same approach as the HT32A routing in #14.

## Why

Five HT31-0001 units on my account were skipped at setup:

```
Smart Hose Tap Timer 1: no device class for hardware='HT31-0001' firmware='0058' — skipping
```

The HT31 is the single-port sibling of the XD family and runs the same fw `0058` as HT34-0001, so it speaks the XD protobuf-over-CRC16 protocol (frame magic `0x11`). Station count flows from the cloud record, so the 4-port class handles the 1-port unit unchanged.

## Hardware verification

Tested on **five HT31-0001 / fw0058** units (HA OS 18.1, core 2026.7.2, Intel USB adapter):

- ✅ Encrypted session + 8-step init (Connected sensor on, RSSI/battery/state populated)
- ✅ Status + battery polling over repeated cycles (battery 100%, 0 consecutive timeouts)
- ✅ Valve actuation: `valve.open_valve` with a 1-minute duration — water observed at the tap, `watering` sensor on with correct `watering_ends`, device auto-closed at 1:00 and HA mirrored it
- ✅ Repeated with both b-hyve WiFi hubs unplugged — fully hub/cloud-independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)