### PR TITLE
fix: don't await the first-poll kick in async_setup_entry (blocks bootstrap when no BT backend)

### DIFF
--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -99,13 +99,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     _register_services(hass)
 
-    # Kick a prompt (non-blocking) first poll so an in-progress run / live state
-    # is read within one cycle instead of waiting a full idle interval. Matters
-    # after an HA restart mid-run: without this the valve shows idle until the
-    # next idle-cadence tick. async_request_refresh only *schedules* the poll, so
-    # this doesn't block setup on a slow/deep-sleeping device.
+    # Kick a prompt first poll so an in-progress run / live state is read
+    # within one cycle instead of waiting a full idle interval. Matters after
+    # an HA restart mid-run: without this the valve shows idle until the next
+    # idle-cadence tick.
+    #
+    # NOTE: async_request_refresh() must NOT be awaited here. Its debouncer
+    # fires IMMEDIATELY on the first call, so awaiting it runs a real BLE poll
+    # inline during setup. If no Bluetooth backend is up yet (e.g. the adapter
+    # hasn't enumerated at boot), that await can outlive bootstrap's timeout:
+    # HA cancels the entry mid-setup, the forwarded platforms leak ('has
+    # already been setup!' on every retry/reload), and the coordinators are
+    # left shut down ('Debouncer call ignored as shutdown has been
+    # requested.'). Fire the first polls as entry-scoped background tasks.
     for coord in runtime.coordinators.values():
-        await coord.async_request_refresh()
+        entry.async_create_background_task(
+            hass,
+            coord.async_request_refresh(),
+            f"orbit_bhyve first poll {coord.name}",
+        )
     return True
 
 


### PR DESCRIPTION
## Symptom

If Home Assistant boots while no Bluetooth backend is available (e.g. a USB adapter that hasn't re-enumerated yet — common with VM passthrough), the integration's setup hangs until bootstrap gives up:

```
WARNING [homeassistant.bootstrap] Waiting for integrations to complete setup: {('orbit_bhyve', '01KXC…')}
ERROR   [homeassistant.config_entries] Setup of config entry '…' for orbit_bhyve integration cancelled
```

The cancellation lands **after** the platforms were forwarded, so they leak — every later retry/reload then fails with:

```
ValueError: Config entry … for orbit_bhyve.valve has already been setup!
```

…and the per-device coordinators are left shut down: Sync/refresh silently no-op (`Debouncer call ignored as shutdown has been requested.`). Only a full core restart recovers, which then hits the same hang if the adapter still isn't up.

## Root cause

The first-poll kick at the end of `async_setup_entry`:

```python
for coord in runtime.coordinators.values():
    await coord.async_request_refresh()
```

The comment assumes `async_request_refresh` "only schedules the poll", but the coordinator's request-refresh `Debouncer` is created with `immediate=True` — the **first** call runs `_async_refresh` inline. So setup awaits N real BLE polls, and with no scanner available `bleak-retry-connector` waits far longer than bootstrap's per-entry budget.

## Fix

Fire the first polls as entry-scoped background tasks (`entry.async_create_background_task`). Setup returns immediately; the prompt-first-poll behavior is preserved.

Verified live on HA core 2026.7.2: with the adapter absent the entry now sets up instantly (no bootstrap warnings, no cancellation), and the first polls complete on their own once Bluetooth appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)