### PR TITLE
feat(battery): per-device battery chemistry select so the % gauge matches non-alkaline AA cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,22 @@ Per discovered sprinkler device:
   **optimistic** (derived from the last command, not from a decoded
   device status).
 - **Battery (%)** sensor — live, BLE-sourced. Decoded from the device's
-  info-ack frame on every poll, no cloud round-trip after setup.
+  info-ack frame on every poll, no cloud round-trip after setup. The percent
+  is a linear voltage gauge whose discharge curve is chosen by the **Battery
+  chemistry** selector below.
 - **Battery voltage (mV)** sensor — same source as the percent sensor;
   disabled by default, enable it from the entity's settings if you want
   the raw reading.
+- **Battery chemistry** (`select`, config category) — the AA cell chemistry
+  you installed (**Alkaline** / **Ni-MH rechargeable** / **Lithium primary**
+  / **Lithium regulated 1.5 V**), which selects the voltage→percent curve.
+  Chemistry can't be auto-detected from a single voltage reading (2550 mV
+  could be alkaline at 25% or Ni-MH at 80%), so it defaults to Alkaline
+  (Orbit's stock assumption) and you set it per device; changing it re-gauges
+  the percent immediately, no device round-trip. **Note:** regulated 1.5 V
+  Li-Ion cells output a constant voltage until they abruptly cut off, so no
+  percentage gauge can track them — the percent reads full right up until the
+  valve dies. Watch the voltage sensor instead.
 - **Signal strength (RSSI)** sensor — the BLE advertisement RSSI from
   Home Assistant's bluetooth manager (works even while disconnected);
   disabled by default.

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -15,11 +15,41 @@ from ..const import DEFAULT_FLOW_COUNTS_PER_GALLON
 _LOGGER = logging.getLogger(__name__)
 
 
-def _mv_to_pct(mv: int) -> int:
-    """Linear approximation matching the cloud's discharge curve to within
-    a few percent: 0% at 2400 mV, 100% at 3000 mV. Tuned against three
-    live devices (Hill 33%/2602 mV, Corner 34%/2606 mV, Deck 65%/2771 mV)."""
-    pct = round((mv - 2400) * 100 / 600)
+# Per-chemistry linear fuel-gauge endpoints: (mV at 0%, mV at 100%). AA cells
+# in a 2x series (3 V nominal). See the "Battery Chemistry Options" plan for the
+# electrochemical rationale; the conservative Ni-MH 0% floor (2350 mV, well above
+# true-empty) exists to warn before solenoid-latch failure under water pressure.
+# Regulated 1.5 V Li-Ion outputs a constant ~3000 mV until it dies, so no linear
+# gauge can track it — it shares the alkaline endpoints and is documented as
+# unmeasurable by percent.
+BATTERY_CHEMISTRIES: dict[str, tuple[int, int]] = {
+    "alkaline": (2400, 3000),
+    "nimh": (2350, 2750),
+    "lithium_primary": (2600, 3400),
+    "lithium_regulated": (2400, 3000),
+}
+DEFAULT_BATTERY_CHEMISTRY = "alkaline"
+
+
+def _mv_to_pct(mv: int, chemistry: str = DEFAULT_BATTERY_CHEMISTRY) -> int:
+    """Linear voltage->percent fuel gauge for the selected battery chemistry.
+    Endpoints live in BATTERY_CHEMISTRIES.
+
+    Provenance / accuracy caveat: none of these curves are calibrated against a
+    known state of charge (that needs a controlled discharge). The alkaline
+    endpoints (2400/3000) are Orbit's stock assumption; they reproduce Orbit's
+    OWN displayed gauge — HW cross-checked 2026-07-17 on our XD (BT4ValveXD01):
+    2828 mV -> 71%, matching the 71% the B-Hyve app showed for the same device.
+    (The inherited upstream/wxfield anchor points — Hill 33%/2602 mV,
+    Corner 34%/2606 mV, Deck 65%/2771 mV — were CLOUD-reported percentages on
+    devices that are not ours, so they are a weaker cross-reference to the same
+    alkaline gauge, not measurements.) The Ni-MH / lithium endpoints are
+    engineering estimates from the discharge-profile analysis (see the
+    Battery-Chemistry-Options plan), with a deliberately conservative Ni-MH 0%
+    floor for solenoid-latch safety; there is no cheap ground truth for them
+    (Orbit's gauge assumes alkaline and mis-reports them too)."""
+    lo, hi = BATTERY_CHEMISTRIES.get(chemistry, BATTERY_CHEMISTRIES[DEFAULT_BATTERY_CHEMISTRY])
+    pct = round((mv - lo) * 100 / (hi - lo))
     return max(0, min(100, pct))
 
 
@@ -163,10 +193,13 @@ class BHyveBleDeviceBase(abc.ABC):
         # disagrees with our linear _mv_to_pct (esp. for NiMH), so seeding it
         # painted a wrong value — inconsistent with the voltage sensor — into the
         # battery sensor's long-term statistics at every startup, until the first
-        # poll replaced it. Start unknown; apply_status_plaintext fills these in
-        # from the device on the first successful poll.
-        self.battery_pct: int | None = None
+        # poll replaced it. Start unknown; apply_status_plaintext fills battery_mv
+        # in from the device on the first successful poll.
         self.battery_mv: int | None = None
+        # User-selected AA cell chemistry driving the voltage->percent gauge
+        # (battery_pct). Restored/updated by the Battery-chemistry select entity;
+        # defaults to alkaline (Orbit's stock assumption).
+        self.battery_chemistry: str = DEFAULT_BATTERY_CHEMISTRY
         self.network_key: str = record["network_key"]
         self.state = DeviceState()
         # Optional callback a coordinator registers so an out-of-band state
@@ -197,6 +230,15 @@ class BHyveBleDeviceBase(abc.ABC):
             return int(self.firmware)
         except (TypeError, ValueError):
             return 0
+
+    @property
+    def battery_pct(self) -> int | None:
+        """Voltage-derived battery percent for the selected chemistry. Computed
+        (not stored) so changing the chemistry select recalculates it immediately,
+        without waiting for the next BLE poll to re-stamp it."""
+        if self.battery_mv is None:
+            return None
+        return _mv_to_pct(self.battery_mv, self.battery_chemistry)
 
     @property
     def unique_id(self) -> str:
@@ -264,8 +306,7 @@ class BHyveBleDeviceBase(abc.ABC):
             # Info-ack: payload bytes 4-5 (pt[9:11]) are battery mV, LE.
             mv = int.from_bytes(pt[9:11], "little")
             if 1500 <= mv <= 4000:  # out-of-band => malformed; don't poison state
-                self.battery_mv = mv
-                self.battery_pct = _mv_to_pct(mv)
+                self.battery_mv = mv  # battery_pct is a chemistry-aware property
         elif seq == 0x02 and len(pt) >= 6:
             # Status reply/push: payload[0] (pt[5]) is the watering mode —
             # 0x04 = watering, 0x01 = idle. Authoritative device state, used to

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -17,7 +17,7 @@ import struct
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
-from .base import ProgramSummary, _mv_to_pct
+from .base import ProgramSummary
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -427,8 +427,7 @@ def apply_status_plaintext(device, pt: bytes) -> None:
         device.state.device_clock = st.device_clock
 
     if st.battery_mv is not None and 1500 <= st.battery_mv <= 4000:
-        device.battery_mv = st.battery_mv
-        device.battery_pct = _mv_to_pct(st.battery_mv)
+        device.battery_mv = st.battery_mv  # battery_pct is a chemistry-aware property
 
     # Raw cumulative flow counter (#59.#3) — record whenever a #59 carries it,
     # regardless of the flow-active flag, so read_flow can sample its slope even

--- a/custom_components/orbit_bhyve/select.py
+++ b/custom_components/orbit_bhyve/select.py
@@ -1,15 +1,21 @@
-"""Select platform — rain-delay presets.
+"""Select platform — rain-delay presets and battery chemistry.
 
-A single SelectEntity per protobuf-family device (HT34A/HT25G2) that exposes
-the rain delay as a coarse dropdown of hour/day presets. Each pick is exactly
-ONE BLE write, which is the point: unlike a number stepper/slider (one write per
-click/drag) there is no ambiguity about when the value is sent, and no queue of
-unintended intermediate writes fighting the coordinator poll for the device's
-single BLE session.
+The rain-delay select is a single SelectEntity per protobuf-family device
+(HT34A/HT25G2) that exposes the rain delay as a coarse dropdown of hour/day
+presets. Each pick is exactly ONE BLE write, which is the point: unlike a number
+stepper/slider (one write per click/drag) there is no ambiguity about when the
+value is sent, and no queue of unintended intermediate writes fighting the
+coordinator poll for the device's single BLE session.
 
 The finer-grained "Rain delay" NumberEntity (hours, arbitrary values) stays
 alongside this for the rare odd value and for backwards compatibility with
 existing dashboards/automations. Both drive the same device.set_rain_delay.
+
+The battery-chemistry select is a CONFIG entity on every BLE device: the AA cell
+chemistry the user installed determines the voltage->percent discharge curve, and
+it can't be auto-detected from a stateless voltage reading (a 2550 mV cell could
+be alkaline at 25% or Ni-MH at 80%). It persists via restore-state (no device
+traffic) and re-derives the battery-percent sensor on change.
 """
 from __future__ import annotations
 
@@ -17,15 +23,31 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
+from .devices.base import BATTERY_CHEMISTRIES
 from .devices.protobuf import BHyveProtobufDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+# Internal chemistry key -> user-facing dropdown label. Keys match
+# devices.base.BATTERY_CHEMISTRIES; labels are what the user picks.
+BATTERY_CHEMISTRY_LABELS: dict[str, str] = {
+    "alkaline": "Alkaline",
+    "nimh": "Ni-MH rechargeable",
+    "lithium_primary": "Lithium (primary)",
+    "lithium_regulated": "Lithium (regulated 1.5V)",
+}
+_LABEL_TO_CHEMISTRY: dict[str, str] = {v: k for k, v in BATTERY_CHEMISTRY_LABELS.items()}
+# Every gauge chemistry must have a user-facing label (and vice versa) or a valid
+# selection would have no curve / a curve would be unreachable.
+assert set(BATTERY_CHEMISTRY_LABELS) == set(BATTERY_CHEMISTRIES)
 
 _OFF = "Off"
 
@@ -58,6 +80,10 @@ async def async_setup_entry(
     runtime = hass.data[DOMAIN][entry.entry_id]
     entities: list[SelectEntity] = []
     for coord in runtime.coordinators.values():
+        # Battery chemistry applies to every BLE device (mesh + protobuf); hubs /
+        # key-less records have no battery to gauge.
+        if coord.device.connection is not None:
+            entities.append(BHyveBatteryChemistrySelect(coord))
         # Rain delay is a protobuf-family (HT34A/HT25G2) capability.
         if isinstance(coord.device, BHyveProtobufDevice):
             entities.append(BHyveRainDelaySelect(coord))
@@ -106,3 +132,50 @@ class BHyveRainDelaySelect(CoordinatorEntity[BHyveDeviceCoordinator], SelectEnti
         else:
             await device.set_rain_delay(minutes)
         await self.coordinator.async_request_refresh()
+
+
+class BHyveBatteryChemistrySelect(
+    CoordinatorEntity[BHyveDeviceCoordinator], SelectEntity, RestoreEntity
+):
+    """Which AA cell chemistry the user installed, driving the battery-percent
+    fuel gauge. Pure HA-side config: no BLE traffic — it just selects the
+    voltage->percent curve applied to the live battery_mv. Persisted across
+    restarts via restore-state (the device can't report its own chemistry)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Battery chemistry"
+    _attr_icon = "mdi:battery-sync"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = list(BATTERY_CHEMISTRY_LABELS.values())
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_battery_chemistry"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.cloud_id)},
+            "name": device.name,
+            "manufacturer": "Orbit Irrigation",
+            "model": device.hardware,
+            "sw_version": device.firmware,
+            "connections": {("mac", device.mac)} if device.mac else set(),
+        }
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        # Restore the user's last pick onto the device so the battery gauge uses
+        # it from the first reading, before any user interaction. A stored label
+        # that no longer maps (renamed option) falls through to the default.
+        last = await self.async_get_last_state()
+        if last is not None and last.state in _LABEL_TO_CHEMISTRY:
+            self.coordinator.device.battery_chemistry = _LABEL_TO_CHEMISTRY[last.state]
+
+    @property
+    def current_option(self) -> str | None:
+        return BATTERY_CHEMISTRY_LABELS.get(self.coordinator.device.battery_chemistry)
+
+    async def async_select_option(self, option: str) -> None:
+        self.coordinator.device.battery_chemistry = _LABEL_TO_CHEMISTRY[option]
+        # No device round-trip; recompute the battery-percent sensor (and this
+        # entity) from the already-known voltage right away.
+        self.coordinator.async_update_listeners()

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
-from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, UI_SLOTS, ProgramSummary, _mv_to_pct
+from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, UI_SLOTS, ProgramSummary
 from .devices.protobuf import BHyveProtobufDevice
 
 _WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
@@ -134,12 +134,11 @@ class BHyveBatterySensor(_RestoreLastValueSensor):
 
     @property
     def native_value(self) -> float | None:
-        device = self.coordinator.device
-        if device.battery_pct is not None:
-            return device.battery_pct
-        if device.battery_mv is not None:
-            return _mv_to_pct(device.battery_mv)
-        return self._restored_value
+        # battery_pct is a chemistry-aware property derived from battery_mv, so
+        # it already covers the mv-only case; fall back to the restored value only
+        # when no live voltage has been read yet.
+        pct = self.coordinator.device.battery_pct
+        return pct if pct is not None else self._restored_value
 
 
 class BHyveBatteryVoltageSensor(_RestoreLastValueSensor):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -79,6 +79,47 @@ def test_mv_to_pct(mv, pct):
     assert _mv_to_pct(mv) == pct
 
 
+@pytest.mark.parametrize(
+    "chemistry,mv,pct",
+    [
+        # NiMH plateau (2450 mV) reads a healthy 25% on its curve vs a false ~8% on
+        # alkaline; endpoints 2350..2750.
+        ("nimh", 2450, 25),
+        ("nimh", 2350, 0),
+        ("nimh", 2750, 100),
+        # Primary lithium: 2600..3400; its 3000 mV plateau reads 50%.
+        ("lithium_primary", 3000, 50),
+        ("lithium_primary", 2600, 0),
+        # Regulated li-ion shares alkaline endpoints (unmeasurable-by-percent, so
+        # it just tracks the alkaline curve).
+        ("lithium_regulated", 2700, 50),
+        # Unknown chemistry falls back to the alkaline curve rather than dividing by
+        # a bogus span.
+        ("bogus", 2700, 50),
+    ],
+)
+def test_mv_to_pct_chemistry(chemistry, mv, pct):
+    assert _mv_to_pct(mv, chemistry) == pct
+
+
+def test_battery_pct_property_follows_chemistry():
+    # battery_pct is derived live from battery_mv + battery_chemistry, so flipping
+    # the chemistry re-gauges the same voltage with no new BLE read.
+    record = {
+        "cloud_id": "abc", "name": "T", "mac": "AA:BB:CC:DD:EE:FF",
+        "hardware": "HT25G2-0001", "firmware": "0111", "stations": 1,
+        "network_key": "",  # no key -> no BLE connection (no hass needed)
+    }
+    dev = BHyveHT25G2Device(None, record)
+    assert dev.battery_pct is None            # no voltage yet
+    dev.battery_mv = 2450
+    assert dev.battery_chemistry == "alkaline"  # default
+    assert dev.battery_pct == _mv_to_pct(2450, "alkaline")
+    dev.battery_chemistry = "nimh"
+    assert dev.battery_pct == _mv_to_pct(2450, "nimh")
+    assert dev.battery_pct == 25
+
+
 def test_cloud_battery_snapshot_is_not_seeded():
     # The cloud battery snapshot must NEVER seed the sensor: it's on a different
     # discharge curve than _mv_to_pct, so it painted a wrong (voltage-inconsistent)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -12,7 +12,7 @@ import pytest
 
 from orbit_bhyve.devices import protobuf as tx
 from orbit_bhyve.devices import status as rx
-from orbit_bhyve.devices.base import DeviceState, _mv_to_pct
+from orbit_bhyve.devices.base import DeviceState
 
 
 # --- protobuf low-level helpers -------------------------------------------
@@ -327,7 +327,6 @@ def _fake_device():
     return SimpleNamespace(
         mac="AA:BB:CC:DD:EE:FF",
         battery_mv=None,
-        battery_pct=None,
         state=DeviceState(is_watering=True, active_zone=1, seconds_remaining=300),
     )
 
@@ -335,8 +334,9 @@ def _fake_device():
 def test_apply_updates_battery_and_clears_zone_on_idle():
     dev = _fake_device()
     rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1, battery_mv=2700)))
+    # apply_status_plaintext stores raw mV only; percent is a chemistry-aware
+    # property on the real device (see test_devices.py::test_battery_pct_*).
     assert dev.battery_mv == 2700
-    assert dev.battery_pct == _mv_to_pct(2700)
     assert dev.state.is_watering is False
     assert dev.state.active_zone is None
     assert dev.state.seconds_remaining is None


### PR DESCRIPTION
## Summary

The battery percent is a linear voltage gauge with **alkaline** endpoints (0% @ 2400 mV,
100% @ 3000 mV). That's accurate for the alkaline cells Orbit assumes, but it reads other AA
chemistries badly — most importantly **Ni-MH rechargeables**, which spend ~80% of their life
on a flat ~2.4–2.5 V plateau. On that plateau the current formula reports a low percent
(and trips Home Assistant's low-battery alerts) while most of the charge remains. Live example
from my fleet: a Ni-MH valve reading **2628 mV** shows just **38% remaining** on the alkaline
curve, when the correct Ni-MH curve puts it at about **70% remaining** — i.e. it looks nearly
flat while it's actually well over half full.

Chemistry can't be inferred from a single stateless voltage reading (2550 mV could be alkaline
at ~25% or Ni-MH at ~80%, and AA cells are charged off-device so there's no charging signal), so
this adds a **per-device "Battery chemistry" select** (config category) that picks the
voltage→percent curve. It defaults to **Alkaline**, so out-of-the-box behavior is unchanged.

## Changes (`f639295`)

- **`devices/base.py`**
  - `BATTERY_CHEMISTRIES`: chemistry → `(mV@0%, mV@100%)` endpoint map, plus
    `DEFAULT_BATTERY_CHEMISTRY = "alkaline"`.
  - `_mv_to_pct(mv, chemistry="alkaline")` gains an optional chemistry arg (defaults to
    alkaline, so every existing caller is unchanged); unknown chemistry falls back to alkaline.
  - `battery_pct` becomes a **computed property** of `battery_mv` + `battery_chemistry` instead
    of a stored attribute, so changing the chemistry re-gauges immediately with no new BLE read.
    (`battery_pct` was already just `_mv_to_pct(battery_mv)` at every write site, so this removes
    redundant state rather than adding any.)
  - New `battery_chemistry` instance attribute (default alkaline), set by the select.
- **`select.py`** — `BHyveBatteryChemistrySelect` on every BLE device (`connection is not None`;
  mesh + protobuf). `RestoreEntity`, `EntityCategory.CONFIG`. Persists the pick across restarts
  via restore-state (the device can't report its own chemistry), and on change recomputes the
  percent sensor via `async_update_listeners()` — no device round-trip.
- **`sensor.py` / `devices/status.py`** — consume the property; drop the now-redundant stored
  percent write and the dead `_mv_to_pct` fallback branch + import.
- **`README.md`** — document the selector and the regulated-Li-Ion caveat (see below).
- **`tests/test_devices.py` / `tests/test_protocol.py`** — chemistry curve endpoints
  (Ni-MH / lithium / regulated / unknown-fallback) and a `battery_pct`-follows-chemistry
  regression that fails on the pre-change code; `apply_status_plaintext` now stores mV only, so
  the protocol test asserts `battery_mv` and the percent is covered as a property.

## Proposed voltage endpoints (2× AA series)

| Chemistry | 0% | 100% | Rationale |
| :--- | :---: | :---: | :--- |
| Alkaline (default) | 2400 | 3000 | Orbit's stock curve; unchanged |
| Ni-MH rechargeable | 2350 | 2750 | Flat ~2.4–2.5 V plateau; conservative 0% floor (see safety note) |
| Lithium primary (Li-FeS₂) | 2600 | 3400 | High, very flat ~3.0 V plateau, sudden end-cliff |
| Lithium regulated 1.5 V | 2400 | 3000 | Constant output → unmeasurable by percent (see caveat) |

**Regulated 1.5 V Li-Ion caveat (documented in the README):** these cells hold a constant output
voltage until their internal cell hits cutoff and the regulator shuts off instantly, so *no*
percentage gauge can track them — the percent reads full right up until the valve dies. The
selector still lets users label them; the README tells them to watch the voltage sensor instead.

**Ni-MH safety note:** the 2350 mV 0% floor is deliberately above the cell's true-empty
(~2.1–2.2 V) so the low-battery warning fires *before* the closing solenoid pulse can sag too low
to latch the valve shut under water pressure.

## Backwards compatibility

Strictly additive.
- Default chemistry is Alkaline, and `_mv_to_pct`'s new arg defaults to alkaline, so the percent
  sensor behaves exactly as before for anyone who doesn't touch the new selector.
- The select is added on every BLE device but sits in the **config** entity category, so it stays
  out of the default dashboard cards.
- No wire-protocol changes; no new BLE traffic (chemistry is pure HA-side state).

## Testing

- **Unit:** 162 tests green. New tests cover each chemistry's curve and the
  chemistry-change-re-gauges behavior (the latter fails on the pre-change code).
- **CI:** Hassfest + HACS both pass on the fork's `validate.yaml`.
- **Hardware (fleet, deployed to HA):**
  - Select appears as a config entity on all 6 BLE devices; the pick survives a restart
    (restore-state).
  - Switching a Gen2 valve Alkaline→Ni-MH re-gauged live with no BLE round-trip: 2628 mV went
    from **38% → 70%**.
  - **Alkaline cross-checked against the B-Hyve app's own gauge:** XD at 2828 mV reads **71%** on
    the alkaline curve, matching the **71%** the B-Hyve app showed for the same device — so the
    default curve reproduces Orbit's gauge, not just my old formula.

## Note for review (honest provenance)

The **alkaline** curve is cross-checked against Orbit's own displayed gauge (above). The **Ni-MH**
and **lithium** endpoints are conservative estimates from published discharge profiles, **not**
calibrated against a known state of charge — there's no cheap ground truth for them (Orbit's cloud
gauge assumes alkaline and mis-reports them the same way). They're chosen to be directionally
right and fail-safe rather than exact, so I'm happy to adjust the values if you have better data.

On the shape: this is deliberately a **per-device select**, not an integration-wide option. A
single global setting would skew every device the moment one valve runs a different chemistry
(e.g. Ni-MH in the Gen2 valves, alkaline in an XD timer), which is the mixed-fleet case
this allows.
