### PR TITLE
feat(diagnostics): config-entry and per-device diagnostics download

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Per discovered sprinkler device:
   (timestamp), with the program letter(s) as an attribute.
 - Manufacturer / model / firmware / MAC are exposed via the device's
   "Device info" panel.
+- **Download diagnostics** — the integration and each device support HA's
+  standard diagnostics download (Settings → Devices & Services → ⋮ →
+  Download diagnostics): device records, live state and poll health, with
+  credentials and BLE network keys redacted. Attach it to bug reports.
 
 Hubs (`BH1-0001`) are filtered out at discovery — they don't actuate
 anything, so they don't appear in the device picker or the device

--- a/custom_components/orbit_bhyve/diagnostics.py
+++ b/custom_components/orbit_bhyve/diagnostics.py
@@ -1,0 +1,139 @@
+"""Diagnostics support: Settings → Devices & Services → Download diagnostics.
+
+Kept free of module-level Home Assistant imports (the same pattern as
+connection.py) so the snapshot/redaction helpers stay unit-testable under
+tests/conftest.py's HA-less namespace shim — including the redaction rules,
+which are exactly the part a regression must never break silently.
+
+Redaction policy: account credentials and each device's AES network_key are
+redacted. MACs, cloud_id and mesh_id are deliberately KEPT — every BLE log
+line is keyed by MAC and cloud_id is the device-registry identifier, so an
+issue report is uncorrelatable without them; none of them is a credential.
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from .const import CONF_DEVICES, CONF_EMAIL, CONF_PASSWORD, DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceEntry
+
+REDACTED = "**REDACTED**"
+TO_REDACT = {CONF_EMAIL, CONF_PASSWORD, "network_key"}
+
+
+def _redact(value: Any) -> Any:
+    """Recursively replace TO_REDACT keys' values with a placeholder.
+
+    Empty values ("" / None) are kept as-is: a key-less device record showing
+    network_key "" is itself diagnostic (it's why the device has no BLE
+    connection), and there is nothing to leak."""
+    if isinstance(value, dict):
+        return {
+            k: (REDACTED if k in TO_REDACT and v not in (None, "") else _redact(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact(v) for v in value]
+    return value
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce snapshot values to JSON-safe types (datetimes, bytes, dataclass
+    program summaries, int dict keys)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    if isinstance(value, (bytes, bytearray)):
+        return value.hex()
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _jsonable(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable(v) for v in value]
+    return value
+
+
+def _device_snapshot(coord: Any) -> dict[str, Any]:
+    """One coordinator's device identity, live state and poll health."""
+    device = coord.device
+    conn = device.connection
+    try:
+        rssi = device.rssi  # imports HA bluetooth internally; None off-HA
+    except Exception:  # noqa: BLE001
+        rssi = None
+    return {
+        "class": type(device).__name__,
+        "name": device.name,
+        "mac": device.mac,
+        "hardware": device.hardware,
+        "firmware": device.firmware,
+        "stations": device.stations,
+        "mesh_id": device.mesh_id,
+        "mesh_device_id": device.mesh_device_id,
+        "hub_mesh_device_id": device.hub_mesh_device_id,
+        "has_flow": device.has_flow,
+        "frame_magic": f"0x{device.frame_magic:02x}",
+        "flow_counts_per_gallon": device.flow_counts_per_gallon,
+        "battery_mv": device.battery_mv,
+        "battery_pct": device.battery_pct,
+        "battery_chemistry": device.battery_chemistry,
+        "rssi": rssi,
+        "state": _jsonable(dataclasses.asdict(device.state)),
+        "connection": None
+        if conn is None
+        else {
+            "is_connected": conn.is_connected,
+            "idle_disconnect_sec": conn._idle_sec,
+        },
+        "coordinator": {
+            "last_update_success": coord.last_update_success,
+            "last_exception": str(coord.last_exception) if coord.last_exception else None,
+            "update_interval_sec": _jsonable(coord.update_interval),
+            "poll_idle_sec": coord.poll_idle,
+            "poll_watering_sec": coord.poll_watering,
+            "preferred_duration_sec": coord.preferred_duration_sec,
+        },
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Account-level dump: redacted entry (data + options) and every device.
+
+    Devices skipped at setup (UnsupportedModel) have no coordinator but still
+    appear in the entry's device records — exactly what an issue report needs.
+    """
+    runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    return {
+        "entry": _redact(entry.as_dict()),
+        "devices": [_device_snapshot(coord) for coord in runtime.coordinators.values()]
+        if runtime
+        else [],
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Single-device dump: its redacted cloud record + live snapshot."""
+    cloud_ids = {ident[1] for ident in device.identifiers if ident[0] == DOMAIN}
+    records = [
+        r for r in entry.data.get(CONF_DEVICES, []) if r.get("cloud_id") in cloud_ids
+    ]
+    runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    snapshot = None
+    if runtime is not None:
+        for cloud_id, coord in runtime.coordinators.items():
+            if cloud_id in cloud_ids:
+                snapshot = _device_snapshot(coord)
+                break
+    return {"record": _redact(records), "device": snapshot}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,91 @@
+"""Diagnostics snapshot + redaction tests.
+
+Exercises the pure helpers in diagnostics.py — no Home Assistant required
+(the module keeps HA imports out of module level for exactly this reason).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from orbit_bhyve.diagnostics import REDACTED, _device_snapshot, _jsonable, _redact
+from orbit_bhyve.devices.base import ProgramSummary
+from orbit_bhyve.devices.ht25g2 import BHyveHT25G2Device
+
+
+def _fake_coord() -> SimpleNamespace:
+    # Key-less record -> no BLE connection, no hass needed (same trick as
+    # test_devices.py::test_battery_pct_property_follows_chemistry).
+    record = {
+        "cloud_id": "abc123", "name": "Deck", "mac": "AA:BB:CC:DD:EE:FF",
+        "hardware": "HT25G2-0001", "firmware": "0111", "stations": 1,
+        "network_key": "",
+    }
+    dev = BHyveHT25G2Device(None, record)
+    dev.battery_mv = 2828
+    dev.state.is_watering = True
+    dev.state.started_at = datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)
+    dev.state.programs = {1: ProgramSummary(slot=1, empty=False, name="Lawn")}
+    return SimpleNamespace(
+        device=dev,
+        last_update_success=True,
+        last_exception=None,
+        update_interval=timedelta(seconds=900),
+        poll_idle=900,
+        poll_watering=30,
+        preferred_duration_sec=600,
+    )
+
+
+def test_device_snapshot_is_json_serializable():
+    snap = _device_snapshot(_fake_coord())
+    # The whole point: HA's diagnostics view renders JSON, so datetimes,
+    # program dataclasses and int dict keys must already be coerced.
+    encoded = json.loads(json.dumps(snap))
+    assert encoded["class"] == "BHyveHT25G2Device"
+    assert encoded["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert encoded["has_flow"] is True
+    assert encoded["battery_mv"] == 2828
+    assert encoded["battery_pct"] == 71  # alkaline curve, HW cross-checked value
+    assert encoded["state"]["started_at"] == "2026-07-18T12:00:00+00:00"
+    assert encoded["state"]["programs"]["1"]["name"] == "Lawn"
+    assert encoded["connection"] is None  # key-less record -> no BLE
+    assert encoded["coordinator"]["update_interval_sec"] == 900.0
+    assert encoded["rssi"] is None  # HA bluetooth unavailable here -> swallowed
+
+
+def test_redact_entry_shaped_dict():
+    entry = {
+        "data": {
+            "email": "user@example.com",
+            "password": "hunter2",
+            "devices": [
+                {"cloud_id": "abc", "mac": "AA:BB:CC:DD:EE:FF",
+                 "network_key": "f0983e39083a335644614ffb3bd67ee4"},
+                {"cloud_id": "hub", "mac": "11:22:33:44:55:66", "network_key": ""},
+            ],
+        },
+        "options": {"poll_idle_sec": 900},
+    }
+    red = _redact(entry)
+    assert red["data"]["email"] == REDACTED
+    assert red["data"]["password"] == REDACTED
+    assert red["data"]["devices"][0]["network_key"] == REDACTED
+    # Correlation fields survive; an empty key stays visibly empty.
+    assert red["data"]["devices"][0]["mac"] == "AA:BB:CC:DD:EE:FF"
+    assert red["data"]["devices"][1]["network_key"] == ""
+    assert red["options"]["poll_idle_sec"] == 900
+    # No secret string anywhere in the encoded output.
+    blob = json.dumps(red)
+    assert "hunter2" not in blob
+    assert "f0983e39" not in blob
+    assert "user@example.com" not in blob
+    # Input is not mutated.
+    assert entry["data"]["password"] == "hunter2"
+
+
+def test_jsonable_edge_types():
+    assert _jsonable(b"\xaa\x77") == "aa77"
+    assert sorted(_jsonable({1: {"s": {2, 1}}})["1"]["s"]) == [1, 2]
+    assert _jsonable(timedelta(minutes=2)) == 120.0


### PR DESCRIPTION
## What

Adds HA's standard **Download diagnostics** support (`diagnostics.py`):

- **Entry-level**: redacted config entry (email / password / per-device `network_key`) plus a live snapshot per coordinator — device identity, full `DeviceState`, connection state, and poll health (last success, intervals, consecutive-timeout context).
- **Per-device**: the device's redacted cloud record + the same snapshot.
- MACs, `cloud_id` and `mesh_id` are deliberately **kept**: BLE log lines are keyed by MAC and `cloud_id` is the registry identifier, so a report without them can't be correlated; none is a credential.

## Why

Issue reports currently arrive with hand-copied fragments. One attached JSON gives model/firmware/state/poll-health in a consistent shape, pre-redacted.

## Notes

- No module-level HA imports (same pattern as `connection.py`), so the snapshot **and the redaction rules** are unit-tested under the HA-less test shim (3 new tests; suite 165/165).
- Devices skipped at setup (`UnsupportedModel`) still appear via the entry's device records — useful for exactly those reports.

## Verify

Settings → Devices & Services → Orbit B-Hyve → ⋮ → Download diagnostics; grep the JSON for your email/password/network-key hex — all absent. Works on any device family.