### PR TITLE
feat(faults): decode #16.#7 faultStatus into Problem / Leak / No-flow sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Per discovered sprinkler device:
 - **Connected** and **Watering** binary sensors — device connectivity
   (diagnostic) and whether a station is currently running, for automations
   and dashboards.
+- **Problem** binary sensor (protobuf family) — the device's own fault
+  report: pump, battery, voltage-boost, flow anomalies and per-station
+  faults, with each flag as an attribute. On flow-capable Gen2 valves two
+  dedicated sensors ride along: **Leak detected** (water moving while the
+  valve is commanded closed) and **No flow** (valve open but nothing
+  flowing; disabled by default until field-confirmed — you can test it by
+  starting a run with the faucet closed).
 - **Default watering duration** (`number` entity, minutes) — per device.
   The valve uses this when `start_watering` is called without an
   explicit duration. Restored across HA restarts.

--- a/custom_components/orbit_bhyve/binary_sensor.py
+++ b/custom_components/orbit_bhyve/binary_sensor.py
@@ -1,10 +1,14 @@
-"""Binary sensor platform — BLE connectivity and watering state.
+"""Binary sensor platform — BLE connectivity, watering state and fault report.
 
 One Connected (diagnostic) and one Watering binary sensor per non-hub device.
 Both read DeviceState, which the coordinator refreshes on each poll and which
-the device also updates out of band from its notification acks.
+the device also updates out of band from its notification acks. Protobuf-family
+devices additionally expose the #16.#7 faultStatus block as a Problem sensor
+(plus Leak / No-flow sensors on flow-capable Gen2 hardware).
 """
 from __future__ import annotations
+
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -19,6 +23,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
 from .devices import BHyveHubDevice
+from .devices.base import FaultStatus
+from .devices.protobuf import BHyveProtobufDevice
 
 
 async def async_setup_entry(
@@ -35,6 +41,15 @@ async def async_setup_entry(
             continue
         entities.append(BHyveConnectedBinarySensor(coord))
         entities.append(BHyveWateringBinarySensor(coord))
+        if isinstance(coord.device, BHyveProtobufDevice):
+            entities.append(BHyveProblemBinarySensor(coord))
+            # The flow faults (#7.#5-#8) need the inline flow sensor, which only
+            # the Gen2 (has_flow) hardware carries — the XD never populates them.
+            # The Problem sensor above still surfaces the XD's pump/battery/
+            # voltage-boost faults.
+            if getattr(coord.device, "has_flow", False):
+                entities.append(BHyveLeakBinarySensor(coord))
+                entities.append(BHyveNoFlowBinarySensor(coord))
     async_add_entities(entities)
 
 
@@ -85,3 +100,89 @@ class BHyveWateringBinarySensor(_BHyveBinarySensorBase):
     @property
     def is_on(self) -> bool:
         return self.coordinator.device.state.is_watering
+
+
+class _BHyveFaultSensorBase(_BHyveBinarySensorBase):
+    """Base for sensors reading the #16.#7 fault report. Unknown (None) until
+    the first decoded status carries the block; a status without the block
+    keeps the last-known report (see FaultStatus in devices/base.py)."""
+
+    @property
+    def _faults(self) -> FaultStatus | None:
+        return self.coordinator.device.state.faults
+
+
+class BHyveProblemBinarySensor(_BHyveFaultSensorBase):
+    """Aggregate device fault: on when the device reports ANY fault — pump,
+    battery, voltage-boost, flow anomalies or a per-station fault. The
+    individual flags ride along as attributes for automations; the
+    leak-specific flag also gets its own alerting entity on Gen2."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_problem"
+        self._attr_name = "Problem"
+
+    @property
+    def is_on(self) -> bool | None:
+        faults = self._faults
+        return None if faults is None else faults.any_fault
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        faults = self._faults
+        if faults is None:
+            return None
+        return {
+            "pump_fault": faults.pump_fault,
+            "battery_fault": faults.battery_fault,
+            "voltage_boost_fail": faults.voltage_boost_fail,
+            "valve_off_flow_detected": faults.valve_off_flow,
+            "valve_on_no_flow_detected": faults.valve_on_no_flow,
+            "valve_low_flow_detected": faults.valve_low_flow,
+            "valve_high_flow_detected": faults.valve_high_flow,
+            "station_faults": list(faults.station_faults),
+            "accessory_fault_flags": faults.accessory_fault_flags,
+        }
+
+
+class BHyveLeakBinarySensor(_BHyveFaultSensorBase):
+    """Leak: valveOffFlowDetected (#7.#5) — the inline flow sensor saw water
+    moving while the valve was commanded CLOSED (seeping/stuck valve or a
+    downstream break). MOISTURE class so HA dashboards/alerts treat it as a
+    leak detector. Primary alerting entity, so not diagnostic-category."""
+
+    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_leak_detected"
+        self._attr_name = "Leak detected"
+
+    @property
+    def is_on(self) -> bool | None:
+        faults = self._faults
+        return None if faults is None else faults.valve_off_flow
+
+
+class BHyveNoFlowBinarySensor(_BHyveFaultSensorBase):
+    """No flow during a run: valveOnNoFlowDetected (#7.#6) — valve open but the
+    flow sensor sees nothing (supply tap closed, blocked line, broken head).
+    Disabled by default until the signal is field-confirmed — deliberately
+    inducible by starting a run with the upstream faucet closed."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device.unique_id}_no_flow"
+        self._attr_name = "No flow"
+
+    @property
+    def is_on(self) -> bool | None:
+        faults = self._faults
+        return None if faults is None else faults.valve_on_no_flow

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -121,6 +121,44 @@ class ProgramSummary:
     budget: int | None = None
 
 
+@dataclass(frozen=True)
+class FaultStatus:
+    """Decoded #16.#7 faultStatus block (OrbitPbApi_FaultStatus, see
+    docs/ble-messages.md). Protobuf omits false bools, so a present-but-empty
+    block (`3a 00` — what a healthy idle status carries) decodes to the
+    all-False "no faults" report; a MISSING block means the frame carried no
+    fault report at all and the consumer must keep its last-known value."""
+
+    pump_fault: bool = False           # #7.#1
+    voltage_boost_fail: bool = False   # #7.#4 voltageBoostCircuitFail
+    valve_off_flow: bool = False       # #7.#5 flow with valve commanded closed = leak
+    valve_on_no_flow: bool = False     # #7.#6 no flow during a run
+    valve_low_flow: bool = False       # #7.#7
+    valve_high_flow: bool = False      # #7.#8
+    battery_fault: bool = False        # #7.#10
+    station_fault_flags: int = 0       # #7.#2 | (#7.#3 << 32), bit = 0-indexed station
+    accessory_fault_flags: int = 0     # #7.#9 smartAccessoryFaultFlags
+
+    @property
+    def any_fault(self) -> bool:
+        return bool(
+            self.pump_fault
+            or self.voltage_boost_fail
+            or self.valve_off_flow
+            or self.valve_on_no_flow
+            or self.valve_low_flow
+            or self.valve_high_flow
+            or self.battery_fault
+            or self.station_fault_flags
+            or self.accessory_fault_flags
+        )
+
+    @property
+    def station_faults(self) -> tuple[int, ...]:
+        """1-indexed stations whose fault bit is set (bit N = station N+1)."""
+        return tuple(i + 1 for i in range(64) if self.station_fault_flags >> i & 1)
+
+
 @dataclass
 class DeviceState:
     is_watering: bool = False
@@ -144,6 +182,9 @@ class DeviceState:
     next_start_flags: int | None = None  # #16.#9 nextStartProgramFlags (slot bitmask, A=bit0)
     next_start_at: datetime | None = None  # #16.#10 nextStartTimeSecEpochUTC as an aware datetime
     programs: dict[int, ProgramSummary] = field(default_factory=dict)  # slot(1-6) -> summary
+    # Last fault report (#16.#7). None until a decoded status carries the block;
+    # a frame WITHOUT the block keeps the last-known report (see FaultStatus).
+    faults: FaultStatus | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -17,7 +17,7 @@ import struct
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
-from .base import ProgramSummary
+from .base import FaultStatus, ProgramSummary
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,6 +64,21 @@ RX_F_WSTATUS_CODE = 1      #   #30.#1: 1=complete, 2=inProgress, 3=pumpDelay, 4=
 RX_WSTATUS_ACTIVE = (2, 3, 5, 6, 7)  # in-progress + delay states = a run is still active
 RX_F_STATUS_NEXTSTART_FLAGS = 9   # #16.#9: nextStartProgramFlags (slot bitmask, A=bit0)
 RX_F_STATUS_NEXTSTART = 10        # #16.#10: nextStartTimeSecEpochUTC
+RX_F_STATUS_FAULT = 7     # #16.#7: faultStatus block (OrbitPbApi_FaultStatus,
+                          #   ble-messages.md "Nested: OrbitPbApi_FaultStatus"). A healthy
+                          #   status carries it EMPTY (`3a 00`, per the captured idle
+                          #   example) = "no faults"; protobuf omits false bools, so any
+                          #   absent field inside the block is False. Fields:
+_FLT_PUMP = 1             #   #16.#7.#1  pumpFault (bool)
+_FLT_STATIONS_LO = 2      #   #16.#7.#2  stationFaultFlags_0_31
+_FLT_STATIONS_HI = 3      #   #16.#7.#3  stationFaultFlags_32_63
+_FLT_VBOOST = 4           #   #16.#7.#4  voltageBoostCircuitFail (bool)
+_FLT_OFF_FLOW = 5         #   #16.#7.#5  valveOffFlowDetected (bool) — leak while closed
+_FLT_NO_FLOW = 6          #   #16.#7.#6  valveOnNoFlowDetected (bool)
+_FLT_LOW_FLOW = 7         #   #16.#7.#7  valveLowFlowDetected (bool)
+_FLT_HIGH_FLOW = 8        #   #16.#7.#8  valveHighFlowDetected (bool)
+_FLT_ACCESSORY = 9        #   #16.#7.#9  smartAccessoryFaultFlags
+_FLT_BATTERY = 10         #   #16.#7.#10 batteryFault (bool)
 
 # --- watering-program (#19 WateringProgram) decode ------------------------
 # Field numbers inside a #19 body. Exactly one day-mode field is present.
@@ -193,6 +208,7 @@ class DeviceStatus(NamedTuple):
     controller_mode: int | None = None     # #16.#2.#1 timerMode.mode: 0=off, 1=auto, 2=manual
     next_start_flags: int | None = None    # #16.#9 nextStartProgramFlags (slot bitmask, A=bit0)
     next_start_epoch: int | None = None    # #16.#10 nextStartTimeSecEpochUTC
+    faults: FaultStatus | None = None      # #16.#7 faultStatus; None = block absent
 
 
 def extract_status(protobuf: bytes) -> DeviceStatus:
@@ -202,7 +218,7 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
 
     run_state = battery_mv = is_watering = seconds_remaining = None
     active_station = rd_minutes = rd_expiry = rd_active = None
-    controller_mode = next_start_flags = next_start_epoch = None
+    controller_mode = next_start_flags = next_start_epoch = faults = None
 
     device_clock = _pb_field(top, RX_F_CLOCK)     # #7 wrapper field
     status = _pb_field(top, RX_F_STATUS)          # #16 submessage
@@ -229,6 +245,22 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         )
         if not isinstance(seconds_remaining, int):
             seconds_remaining = None
+        flt = _pb_field(sfields, RX_F_STATUS_FAULT)      # #16.#7
+        if isinstance(flt, (bytes, bytearray)):
+            # b"" (the healthy `3a 00` empty block) parses to [] → all-False.
+            ff = pb_parse(flt)
+            faults = FaultStatus(
+                pump_fault=bool(_pb_field(ff, _FLT_PUMP)),
+                voltage_boost_fail=bool(_pb_field(ff, _FLT_VBOOST)),
+                valve_off_flow=bool(_pb_field(ff, _FLT_OFF_FLOW)),
+                valve_on_no_flow=bool(_pb_field(ff, _FLT_NO_FLOW)),
+                valve_low_flow=bool(_pb_field(ff, _FLT_LOW_FLOW)),
+                valve_high_flow=bool(_pb_field(ff, _FLT_HIGH_FLOW)),
+                battery_fault=bool(_pb_field(ff, _FLT_BATTERY)),
+                station_fault_flags=(_pb_field(ff, _FLT_STATIONS_LO) or 0)
+                | ((_pb_field(ff, _FLT_STATIONS_HI) or 0) << 32),
+                accessory_fault_flags=_pb_field(ff, _FLT_ACCESSORY) or 0,
+            )
         rd = _pb_field(sfields, RX_F_STATUS_RAINDELAY)   # #16.#13
         if isinstance(rd, (bytes, bytearray)):
             rdf = pb_parse(rd)
@@ -288,6 +320,7 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         controller_mode=controller_mode,
         next_start_flags=next_start_flags,
         next_start_epoch=next_start_epoch,
+        faults=faults,
     )
 
 
@@ -490,6 +523,15 @@ def apply_status_plaintext(device, pt: bytes) -> None:
         # after expiry (the "7 hours ago" bug).
         device.state.rain_delay_minutes = 0
         device.state.rain_delay_ends = None
+
+    # Fault report (#16.#7) — the Problem / Leak binary sensors read this.
+    # Present-but-empty decodes to the all-False report (all-clear); a status
+    # WITHOUT the block keeps the last-known report rather than clearing it —
+    # absence means "no fault report in this frame", not "faults gone" (unlike
+    # #16.#13, there is no evidence the device ever drops #7 to signal a clear;
+    # the captured healthy idle status still carries the empty block).
+    if st.faults is not None:
+        device.state.faults = st.faults
 
     # Controller mode (#16.#2.#1: 0=off, 1=auto, 2=manual) — the "Automatic
     # watering" switch reads this. Present whenever a #16 status block is decoded.

--- a/docs/ble-messages.md
+++ b/docs/ble-messages.md
@@ -629,7 +629,7 @@ Decoded (partial): `deviceInfo { numStations: 4, hwVersion: "HT34A-0001", fwVers
 **Frame types:** `0x003E` (standard status), `0x005E` (watering-summary variant -- carries `f18 wateringStatusSummary`)  
 **OrbitPbApi_Message field:** f16 `deviceStatusInfo`  
 **Class:** `OrbitPbApi_DeviceStatusInfo`  
-**Parser:** `BHyveHT34ADevice._parse_status()` in `devices/ht34a.py` (decodes run-state (f1) + time-remaining (f6/f7) only; the remaining fields below are protocol reference, not all parsed)
+**Parser:** `extract_status()` in `devices/status.py` (decodes run-state (f1), run progress (f6), faultStatus (f7), next-start (f9/f10), rain delay (f13), battery (f14); the remaining fields below are protocol reference, not all parsed)
 
 Both type codes carry the same protobuf class. `0x003E` is the typical device status update;
 `0x005E` is seen when the device sends a watering status summary (its `OrbitPbApi_DeviceStatusInfo`

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -191,16 +191,17 @@ device-to-host messages (`wateringStatus`, `batteryStatus`, `deviceInfo`, and th
 message. Its length varies with content (a status with no rain-delay or schedule
 block is shorter), so detect it by decoding the protobuf, never by the frame length
 field. The full `OrbitPbApi_DeviceStatusInfo` submessage is documented below as
-protocol reference; this integration's decoder, `BHyveHT34ADevice._parse_status()`
-(`devices/ht34a.py`), reads only the run state (f1) and the time-remaining inside the
-`wateringStatus` block (f6) — it does not extract every field in the table:
+protocol reference; this integration's decoder, `extract_status()`
+(`devices/status.py`), reads the run state (f1), run progress (f6), fault status
+(f7), next-start (f9/f10), rain delay (f13) and battery (f14) — it does not
+extract every field in the table:
 
 | Field | Name | Notes |
 |-------|------|-------|
 | f1 | `deviceStatus` (enum) | `deviceOff`, `deviceIdle`, `lowBattery`, `rainDelayEnabled`, `wateringInProgress` (4), `meshDeviceOffline` |
 | f2 | `timerMode.mode` | off / on / program |
 | f6 | `wateringStatus` | running station and `time_remaining_sec` |
-| f7 | `faultStatus` | empty message means no faults |
+| f7 | `faultStatus` | empty message means no faults; parsed into the Problem / Leak / No-flow binary sensors |
 | f9 | `nextStartProgramFlags` | program bitmask for the next scheduled start |
 | f10 | `nextStartTimeSecEpochUTC` | epoch time of the next scheduled start |
 | f13 | `rainDelay` | `{mins, end_epoch, type}` |

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -474,3 +474,74 @@ def test_apply_ignores_desynced_frame():
     rx.apply_status_plaintext(dev, bytes(frame))
     assert dev.battery_mv is None
     assert dev.state.is_watering is True  # unchanged from the fake's initial state
+
+
+# --- faultStatus (#16.#7) decode -------------------------------------------
+
+def _status_with_faults(fault_body, run_state=1) -> bytes:
+    """A #16 status carrying a #16.#7 faultStatus block. b"" builds the healthy
+    EMPTY block (the `3a 00` from the captured idle example); None omits the
+    block entirely (frame carries no fault report)."""
+    sub = tx._pb_field_varint(rx.RX_F_STATUS_MODE, run_state)
+    if fault_body is not None:
+        sub += tx._pb_field_bytes(rx.RX_F_STATUS_FAULT, fault_body)
+    return tx._pb_field_bytes(rx.RX_F_STATUS, sub)
+
+
+def test_extract_status_empty_fault_block_is_all_clear():
+    # Byte-level anchor: field 7 wire 2 length 0 == `3a 00` (captured idle
+    # status). Present-but-empty must decode to a real all-False report, NOT
+    # None — that distinction is what lets "Problem: off" mean "device said
+    # no faults" instead of "never heard".
+    pb = _status_with_faults(b"")
+    assert bytes.fromhex("3a00") in pb
+    st = rx.extract_status(pb)
+    assert st.faults is not None
+    assert st.faults.any_fault is False
+    assert st.faults.station_faults == ()
+
+
+def test_extract_status_fault_flags_decode():
+    body = (
+        tx._pb_field_varint(rx._FLT_OFF_FLOW, 1)      # leak while closed
+        + tx._pb_field_varint(rx._FLT_BATTERY, 1)
+        + tx._pb_field_varint(rx._FLT_STATIONS_LO, 0b101)  # stations 1 and 3
+    )
+    st = rx.extract_status(_status_with_faults(body))
+    f = st.faults
+    assert f.valve_off_flow is True
+    assert f.battery_fault is True
+    assert f.pump_fault is False          # omitted bool -> False
+    assert f.valve_on_no_flow is False
+    assert f.station_fault_flags == 0b101
+    assert f.station_faults == (1, 3)     # 1-indexed
+    assert f.any_fault is True
+
+
+def test_extract_status_fault_hi_flags_shifted():
+    body = tx._pb_field_varint(rx._FLT_STATIONS_HI, 1)  # station bit 32
+    st = rx.extract_status(_status_with_faults(body))
+    assert st.faults.station_fault_flags == 1 << 32
+    assert st.faults.station_faults == (33,)
+
+
+def test_extract_status_absent_fault_block_is_none():
+    st = rx.extract_status(_status_pb(run_state=1, battery_mv=2700))
+    assert st.faults is None
+
+
+def test_apply_keeps_last_known_faults_when_block_absent():
+    # A later #16 WITHOUT #7 must not clear a stored fault — absence means
+    # "no report in this frame", not "faults gone".
+    dev = _fake_device()
+    leak = tx._pb_field_varint(rx._FLT_OFF_FLOW, 1)
+    rx.apply_status_plaintext(dev, tx._build_message(_status_with_faults(leak)))
+    assert dev.state.faults.valve_off_flow is True
+
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1)))
+    assert dev.state.faults is not None
+    assert dev.state.faults.valve_off_flow is True  # kept
+
+    # ...but a fresh EMPTY block is an explicit all-clear.
+    rx.apply_status_plaintext(dev, tx._build_message(_status_with_faults(b"")))
+    assert dev.state.faults.any_fault is False


### PR DESCRIPTION
## What

Every protobuf status frame (`#16`) carries an `OrbitPbApi_FaultStatus` block (`#16.#7`) that `extract_status()` has always discarded. This decodes it:

- **`FaultStatus`** dataclass (`devices/base.py`) + `DeviceState.faults`.
- `devices/status.py`: a **present-but-empty** block (the `3a 00` in the captured healthy idle status) decodes to an explicit all-False report; an **absent** block keeps the last-known report (absence = no report in this frame, not faults-cleared). Protobuf omits false bools, so absent fields inside the block are False.
- New binary sensors (`binary_sensor.py`):
  - **Problem** (diagnostic, all protobuf devices) — aggregate of pump / battery / voltage-boost / flow / per-station faults, each flag as an attribute.
  - **Leak detected** (MOISTURE, Gen2 `has_flow` only) — `valveOffFlowDetected`: water moving while the valve is commanded closed.
  - **No flow** (Gen2, disabled by default) — `valveOnNoFlowDetected`.
  - Flow faults (f5–f8) need the inline flow sensor, so the two flow entities are gated to Gen2; the XD's pump/battery/boost faults still surface via Problem.
- Docs: retires the stale `BHyveHT34ADevice._parse_status()` / `devices/ht34a.py` decoder attribution (moved to `devices/status.py` long ago).

## Testing

5 new protocol tests (empty-block all-clear incl. the `3a 00` byte anchor, flag decode, hi-flags shift, absent-block None, keep-last-known). Suite 167/167.

**Field validation wanted**: fault semantics beyond the empty block need protobuf hardware. `valveOnNoFlowDetected` is deliberately inducible — close the upstream faucet and start a run. The in-house fleet is mesh-only, so reports from Gen2/XD owners are welcome.