### PR TITLE
feat(flow): built-in Water used total + device-reported gpm sensor (Gen2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Per discovered sprinkler device:
   reads `unavailable`.
 - **Next run** sensor — the device-computed next scheduled program start
   (timestamp), with the program letter(s) as an attribute.
+- **Flow rate** and **Water used** sensors (flow-capable Gen2 valves) —
+  instantaneous GPM sampled from the inline flow sensor on each watering
+  poll, plus a cumulative gallons total integrated from it that plugs
+  straight into HA's Water dashboard (no Integration helper needed; the
+  total is restored across restarts). Calibrate with the **Flow
+  calibration** option below. A diagnostic **Flow rate (device)** sensor
+  (disabled by default) records the device's own reported GPM field to
+  confirm whether it ever populates.
 - Manufacturer / model / firmware / MAC are exposed via the device's
   "Device info" panel.
 
@@ -123,6 +131,9 @@ registry.
   station is watering
 - **Polling interval — watering** (sec) — faster polling while a station is
   active
+- **Flow calibration** (counts per gallon) — converts the Gen2 flow
+  counter to gallons; default 433 was bucket-measured. Re-calibrate by
+  comparing `Water used` against a bucket/meter over one run
 
 ## How it works
 

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -86,6 +86,20 @@ def parse_start_minutes(tok: object) -> int:
     return hour * 60 + minute
 
 
+def accumulate_gallons(
+    total: float, prev_gpm: float | None, dt_sec: float, cap_sec: float
+) -> float:
+    """One left-rectangle step of the "Water used" integral: book `prev_gpm` —
+    the rate that was live at the START of the interval — over `dt_sec`,
+    bounded by `cap_sec` so a restart/outage gap can't book a huge block of
+    phantom gallons. The caller gates on "previous update was watering"; this
+    handles only the math. Kept HA-free so it is unit-testable standalone
+    (same rationale as parse_start_minutes)."""
+    if not prev_gpm or prev_gpm <= 0 or dt_sec <= 0:
+        return total
+    return total + prev_gpm * (min(dt_sec, cap_sec) / 60.0)
+
+
 @dataclass
 class ProgramSpec:
     """A watering program to WRITE (#19 setProgramSchedule).
@@ -128,6 +142,7 @@ class DeviceState:
     seconds_remaining: int | None = None
     flow_total: int | None = None  # #59.#3 raw cumulative counter (transient; feeds flow_gpm)
     flow_gpm: float | None = None  # instantaneous flow rate from read_flow's slope (Gen2)
+    flow_gpm_device: float | None = None  # #59.#4 device-reported gpm float (unconfirmed on HW)
     started_at: datetime | None = None
     expected_off_at: datetime | None = None
     last_command_at: datetime | None = None

--- a/custom_components/orbit_bhyve/devices/status.py
+++ b/custom_components/orbit_bhyve/devices/status.py
@@ -54,8 +54,11 @@ RX_F_WATERING = 59        # flow sensor data (knobunc: FlowSensorData). Gen2 onl
 RX_F_WATERING_ACTIVE = 1  #   #59.#1: knobunc currentFlowRateFrequency_Hz — ~0 when no water moving,
                           #     so we use it as a "water currently flowing" signal (not "valve open").
 RX_F_FLOW_TOTAL = 3       #   #59.#3: knobunc currentCycleVolumeTicks — CUMULATIVE per-run counter (gpm
-                          #     = its slope). #59.#4 currentFlowRateGpm (float) exists but is unused
-                          #     here pending HW confirmation that it populates.
+                          #     = its slope).
+RX_F_FLOW_RATE_GPM = 4    #   #59.#4: knobunc currentFlowRateGpm — float32 (wire 5). Never yet observed
+                          #     populated on fw0111, so it feeds only the disabled-by-default
+                          #     "Flow rate (device)" sensor to gather field confirmation; the primary
+                          #     gauge stays the #59.#3 slope (read_flow).
 RX_F_WATERING_STATUS = 30  # WateringStatus notification { #1 = status enum } — the "stop ack"
 RX_F_WSTATUS_CODE = 1      #   #30.#1: 1=complete, 2=inProgress, 3=pumpDelay, 4=stationComplete,
                            #   5=stationDelay, 6=programPreDelay, 7=programPostDelay
@@ -187,6 +190,7 @@ class DeviceStatus(NamedTuple):
     active_station: int | None = None      # #16.#6.#4 (fallback #16.#2.#2.#3.#1), 0-indexed (zone = +1)
     seconds_remaining: int | None = None   # #16.#6.#5 (counts down), present only while watering
     flow_total: int | None = None          # #59.#3 cumulative volume counter (Gen2)
+    flow_rate_gpm: float | None = None     # #59.#4 device-reported gpm float32 (unconfirmed)
     rain_delay_minutes: int | None = None  # #16.#13.#1
     rain_delay_expiry: int | None = None   # #16.#13.#3, Unix epoch seconds
     rain_delay_active: bool | None = None  # #16.#13.#4
@@ -273,6 +277,12 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         ws = _pb_subfield(top, RX_F_WATERING_STATUS, RX_F_WSTATUS_CODE)
         is_watering = ws in RX_WSTATUS_ACTIVE
     flow_total = _pb_subfield(top, RX_F_WATERING, RX_F_FLOW_TOTAL)   # #59.#3 cumulative
+    # #59.#4 device-reported instantaneous gpm — a float32 (wire 5), which
+    # pb_parse returns as the raw 4 bytes.
+    flow_rate_gpm = None
+    raw_gpm = _pb_subfield(top, RX_F_WATERING, RX_F_FLOW_RATE_GPM)
+    if isinstance(raw_gpm, (bytes, bytearray)) and len(raw_gpm) == 4:
+        flow_rate_gpm = round(struct.unpack("<f", bytes(raw_gpm))[0], 2)
 
     return DeviceStatus(
         run_state=run_state,
@@ -282,6 +292,7 @@ def extract_status(protobuf: bytes) -> DeviceStatus:
         active_station=active_station,
         seconds_remaining=seconds_remaining,
         flow_total=flow_total,
+        flow_rate_gpm=flow_rate_gpm,
         rain_delay_minutes=rd_minutes,
         rain_delay_expiry=rd_expiry,
         rain_delay_active=rd_active,
@@ -435,6 +446,11 @@ def apply_status_plaintext(device, pt: bytes) -> None:
     if st.flow_total is not None:
         device.state.flow_total = st.flow_total
 
+    # Device-reported instantaneous gpm (#59.#4) — feeds the diagnostic
+    # "Flow rate (device)" sensor; not yet observed populated on hardware.
+    if st.flow_rate_gpm is not None:
+        device.state.flow_gpm_device = st.flow_rate_gpm
+
     if st.is_watering is not None:
         device.state.is_watering = st.is_watering
         if hasattr(device, "_status_parsed"):
@@ -468,6 +484,7 @@ def apply_status_plaintext(device, pt: bytes) -> None:
             device.state.seconds_remaining = None
             device.state.flow_total = None
             device.state.flow_gpm = 0.0  # valve closed → no flow
+            device.state.flow_gpm_device = None
             device.state.started_at = None
             device.state.expected_off_at = None
 

--- a/custom_components/orbit_bhyve/sensor.py
+++ b/custom_components/orbit_bhyve/sensor.py
@@ -7,6 +7,7 @@ discharge approximation (`devices.base._mv_to_pct`).
 """
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from typing import Any
 
@@ -22,15 +23,22 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfElectricPotential,
+    UnitOfVolume,
     UnitOfVolumeFlowRate,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BHyveDeviceCoordinator
-from .devices.base import PROGRAM_SLOTS, SLOT_LETTERS, UI_SLOTS, ProgramSummary
+from .devices.base import (
+    PROGRAM_SLOTS,
+    SLOT_LETTERS,
+    UI_SLOTS,
+    ProgramSummary,
+    accumulate_gallons,
+)
 from .devices.protobuf import BHyveProtobufDevice
 
 _WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
@@ -84,6 +92,8 @@ async def async_setup_entry(
         # Flow-rate gauge only for models with a flow sensor (Gen2, not the XD).
         if getattr(device, "has_flow", False):
             entities.append(BHyveFlowRateSensor(coord))
+            entities.append(BHyveWaterUsedSensor(coord))
+            entities.append(BHyveDeviceFlowRateSensor(coord))
     async_add_entities(entities)
 
 
@@ -188,10 +198,9 @@ class BHyveFlowRateSensor(_BHyveDeviceSensorBase):
     (Check-flow button / automation).
 
     `state_class = MEASUREMENT`: each reading is a real ~4 s slope of actual flow,
-    so long-term avg/min/max statistics are honest. For cumulative gallons, add
-    HA's built-in Riemann-sum Integration helper on this entity (see the README)
-    — that integrates the rate into a proper volume total; the raw counter can't
-    be a passive meter here. See docs/ble_protocol.md.
+    so long-term avg/min/max statistics are honest. For cumulative gallons see
+    BHyveWaterUsedSensor below, which integrates this rate over wall time — the
+    raw counter can't be a passive meter here. See docs/ble_protocol.md.
     """
 
     _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
@@ -209,6 +218,102 @@ class BHyveFlowRateSensor(_BHyveDeviceSensorBase):
     def native_value(self) -> float | None:
         state = self.coordinator.data or self.coordinator.device.state
         return state.flow_gpm
+
+
+class BHyveWaterUsedSensor(_RestoreLastValueSensor):
+    """Cumulative water used (gallons), integrated from the flow gauge (Gen2).
+
+    The raw #59.#3 counter only advances while a #57 subscription is live — a
+    few-second sampling window per watering poll — so exposing it directly
+    would undercount most of the run (see BHyveFlowRateSensor). Instead this
+    integrates the slope-derived `flow_gpm` over wall time between coordinator
+    updates: a left-rectangle sum (each interval booked at the rate live at
+    its start), the same rule as HA's Integration helper with `method: left`,
+    which this sensor replaces.
+
+    Gating and bounds:
+    - an interval accrues only if the PREVIOUS update was watering, so a
+      nonzero gpm left by an idle-time Check-flow press (a leak spot-check)
+      never silently accumulates for a whole idle period;
+    - each interval is capped at max(120 s, 2x the watering cadence) so a
+      restart/outage gap can't book phantom gallons;
+    - the run's final stretch is booked at the last live rate: the idle #16
+      forces flow_gpm to 0.0, which lands here one update later.
+
+    TOTAL_INCREASING + RestoreSensor keeps the total monotonic across
+    restarts, so HA's long-term statistics / Water dashboard see clean deltas.
+    Counter resets on the device are irrelevant — the raw counter is never
+    consumed here.
+    """
+
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_icon = "mdi:water"
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_water_used"
+        self._attr_name = "Water used"
+        self._total = 0.0
+        self._last_update: float | None = None  # time.monotonic()
+        self._prev_gpm: float | None = None
+        self._prev_watering = False
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self._restored_value is not None:
+            try:
+                self._total = float(self._restored_value)
+            except (TypeError, ValueError):
+                self._total = 0.0
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        now = time.monotonic()
+        if self._last_update is not None and self._prev_watering:
+            cap = max(120.0, 2.0 * self.coordinator.poll_watering)
+            self._total = accumulate_gallons(
+                self._total, self._prev_gpm, now - self._last_update, cap
+            )
+        state = self.coordinator.data or self.coordinator.device.state
+        self._last_update = now
+        self._prev_gpm = state.flow_gpm
+        self._prev_watering = bool(state.is_watering)
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float:
+        return round(self._total, 3)
+
+
+class BHyveDeviceFlowRateSensor(_BHyveDeviceSensorBase):
+    """The device's own #59.#4 currentFlowRateGpm float (Gen2).
+
+    Named in the vendor schema but never yet observed populated on fw0111 —
+    disabled by default purely to gather field confirmation. If reports show
+    it live, a later release can prefer it over the slope-derived Flow rate.
+    """
+
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
+    _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_icon = "mdi:water"
+
+    def __init__(self, coordinator: BHyveDeviceCoordinator):
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_unique_id = f"{device.unique_id}_flow_rate_device"
+        self._attr_name = "Flow rate (device)"
+
+    @property
+    def native_value(self) -> float | None:
+        state = self.coordinator.data or self.coordinator.device.state
+        return state.flow_gpm_device
 
 
 class BHyveRainDelayEndsSensor(_BHyveDeviceSensorBase):

--- a/docs/ble-messages.md
+++ b/docs/ble-messages.md
@@ -815,9 +815,9 @@ Confidence levels reflect the strength of the APK evidence:
 | f49 | `manualPresetRunTime` | d2h | `0x16` | **live-verified 2026-06-28**: `getManualPresetRunTime`->`0x16`/f49 = `08d804` (`presetRunTimeSec=600`). Parser: not implemented in this integration. | high |
 | f55 | `getFlowSensorParams` | h2d | unknown | `flow_sensor_params_BANG_` writer; keyword confirmed | high |
 | f56 | `flowSensorParams` | d2h | unknown | implied counterpart to `getFlowSensorParams` | medium |
-| f57 | `enableFlowSensorData` | h2d | unknown | `enable_flow_sensor_event_BANG_` writer; keyword confirmed | high |
-| f58 | `getFlowSensorData` | h2d | unknown | `get_instantaneous_flow_BANG_` writer; keyword confirmed | high |
-| f59 | `flowSensorData` | d2h | unknown | implied counterpart to `getFlowSensorData` | medium |
+| f57 | `enableFlowSensorData` | h2d | unknown | **HW-verified 2026-07-03 (Gen2 fw0111)**: subscribe `ca030508e8071002` = `#57{#1=1000ms, #2=2}`, unsubscribe `ca030408001002` = `#57{#1=0, #2=2}`. A live subscription persists across reconnects and starves the `#16` status read, so `read_flow` always unsubscribes after its ~4 s sampling window. Implemented: `devices/protobuf.py` (`_FLOW_SUBSCRIBE_PB` / `_FLOW_UNSUBSCRIBE_PB`). | high |
+| f58 | `getFlowSensorData` | h2d | unknown | `get_instantaneous_flow_BANG_` writer; keyword confirmed. Not used by this integration — the f57 subscription stream serves the same data. | high |
+| f59 | `flowSensorData` | d2h | unknown | **HW-verified 2026-07-03 (Gen2 fw0111)**: streamed ~1/s after an f57 subscribe. `#59.#1` flow-rate frequency Hz (~0 when no water moving), `#59.#3` `currentCycleVolumeTicks` cumulative per-run counter (~433 counts/gal, bucket-calibrated), `#59.#4` `currentFlowRateGpm` float32 (decoded; not yet observed populated). Parser: `devices/status.py::extract_status`. | high |
 | f69 | `getProgramSchedule` | h2d | unknown | `get_program_schedule` keyword confirmed; `set_program_BANG_` write patterns | high |
 | f76 | `programSchedule` | d2h | unknown | implied counterpart to `getProgramSchedule` | medium |
 | f77 | `getActivePrograms` | h2d | unknown | keyword confirmed; implied writer | medium |

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -474,3 +474,49 @@ def test_apply_ignores_desynced_frame():
     rx.apply_status_plaintext(dev, bytes(frame))
     assert dev.battery_mv is None
     assert dev.state.is_watering is True  # unchanged from the fake's initial state
+
+
+# --- flow: #59.#4 device gpm float + Water-used accumulation ---------------
+
+def _flow_pb_with_gpm(active, total, gpm) -> bytes:
+    """A #59 flow frame carrying the device-reported gpm float:
+    { #1=flow-active, #3=cumulative, #4=float32 } — #4 is wire 5, which the
+    existing varint/bytes builders can't emit, so hand-pack its tag."""
+    import struct
+    inner = (
+        tx._pb_field_varint(rx.RX_F_WATERING_ACTIVE, active)
+        + tx._pb_field_varint(rx.RX_F_FLOW_TOTAL, total)
+        + bytes([(rx.RX_F_FLOW_RATE_GPM << 3) | 5])   # tag: field 4, wire 5
+        + struct.pack("<f", gpm)
+    )
+    return tx._pb_field_bytes(rx.RX_F_WATERING, inner)
+
+
+def test_extract_status_decodes_device_gpm_float():
+    st = rx.extract_status(_flow_pb_with_gpm(active=1, total=489, gpm=4.49))
+    assert st.flow_total == 489
+    assert st.flow_rate_gpm == 4.49        # rounded to 2dp at decode
+    # A #59 without #4 leaves it None (the so-far-observed hardware shape).
+    assert rx.extract_status(_flow_pb(active=1, total=489)).flow_rate_gpm is None
+
+
+def test_apply_stores_and_clears_device_gpm():
+    dev = _fake_device()
+    rx.apply_status_plaintext(dev, tx._build_message(_flow_pb_with_gpm(1, 489, 4.49)))
+    assert dev.state.flow_gpm_device == 4.49
+    # Idle #16 clears it alongside the other flow fields.
+    rx.apply_status_plaintext(dev, tx._build_message(_status_pb(run_state=1)))
+    assert dev.state.flow_gpm_device is None
+
+
+def test_accumulate_gallons_left_rectangle():
+    from orbit_bhyve.devices.base import accumulate_gallons
+    # 4.5 gpm over 30 s = 2.25 gal.
+    assert accumulate_gallons(10.0, 4.5, 30.0, 120.0) == pytest.approx(12.25)
+    # Interval capped: a 900 s gap at 4.5 gpm books only cap_sec worth.
+    assert accumulate_gallons(0.0, 4.5, 900.0, 120.0) == pytest.approx(4.5 * 2.0)
+    # No rate / zero rate / bogus dt -> unchanged.
+    assert accumulate_gallons(7.0, None, 30.0, 120.0) == 7.0
+    assert accumulate_gallons(7.0, 0.0, 30.0, 120.0) == 7.0
+    assert accumulate_gallons(7.0, -1.0, 30.0, 120.0) == 7.0
+    assert accumulate_gallons(7.0, 4.5, -5.0, 120.0) == 7.0


### PR DESCRIPTION
## What

- **Water used** sensor (gallons, `WATER` / `TOTAL_INCREASING`, RestoreSensor) — plugs straight into HA's Water dashboard and replaces the old 'add a Riemann-sum Integration helper' guidance.
- **Flow rate (device)** sensor (diagnostic, disabled by default) — decodes the schema-named `#59.#4 currentFlowRateGpm` float32, which has never been observed populated on fw0111; shipped purely to gather field confirmation. If it proves live, a later release can prefer it over the slope.

## Why integrate instead of exposing the raw counter

The `#59.#3` counter only advances while a `#57` subscription is live, and subscriptions are ~4 s sampling windows per watering poll — a raw-counter `total_increasing` sensor would undercount most of the run. Holding the subscription open is off the table: a persistent `#59` stream starves the `#16` status read and has wedged a valve (2026-07-03). So the sensor integrates the slope-derived `flow_gpm` over wall time between coordinator updates (left-rectangle rule, same as HA's `method: left`).

Guards:
- accrues only when the **previous** update was watering — an idle-time Check-flow spot-check (nonzero gpm = leak hint) never silently accumulates;
- each interval capped at max(120 s, 2× watering cadence) so restart/outage gaps can't book phantom gallons;
- device counter resets are irrelevant (the raw counter is never consumed).

`accumulate_gallons()` lives in `devices/base.py`, HA-free and unit-tested.

## Docs

`ble-messages.md` f57/f58/f59 rows updated from 'unknown' to the hardware-verified subscribe/unsubscribe bytes and `#59` field semantics; README flow section + Flow calibration option documented.

## Testing

3 new tests (wire-5 float decode, apply/clear, accumulation math incl. cap and gating). Suite 165/165.

**Field validation wanted**: end-to-end gallons accuracy needs a Gen2 (`has_flow`) valve — compare Water used against a bucket/meter over one run (the 433 counts/gal methodology in `const.py`). In-house fleet is mesh-only.