### PR TITLE
feat(mesh): decode HT25 STATUS countdown + opt-in live idle status poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Per discovered sprinkler device:
 - **Sync** button per device — forces a fresh BLE connect + init
   handshake. Useful after a long idle, or to refresh the battery
   reading on demand without waiting for the next poll.
+- **Mesh live status** (HT25, opt-in option) — by default mesh timers are
+  polled passively (state comes from command acks + a wall-clock timer, to
+  spare the AA batteries). Turning on **Mesh live status poll** makes each
+  idle poll connect and read the device's real watering state, countdown
+  and battery — so runs started from the B-Hyve app or a hub schedule show
+  up in HA within one poll. Costs roughly 96 BLE connects/day at the
+  default 15-minute cadence.
 - **Identify** button (protobuf family) — flashes the device LED (#47)
   so you can physically locate it. No-op on the XD, which ignores it.
 - **Automatic watering** switch — the device-global controller mode
@@ -123,6 +130,9 @@ registry.
   station is watering
 - **Polling interval — watering** (sec) — faster polling while a station is
   active
+- **Mesh live status poll** (bool, default off) — HT25 mesh timers connect
+  over BLE on each idle poll to read live watering state and battery.
+  Battery trade-off: ~96 connects/day at the default idle cadence
 
 ## How it works
 

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -33,18 +33,20 @@ from .const import (
     CONF_EMAIL,
     CONF_FLOW_COUNTS_PER_GALLON,
     CONF_IDLE_DISCONNECT,
+    CONF_MESH_STATUS_POLL,
     CONF_PASSWORD,
     CONF_POLL_IDLE,
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
     DEFAULT_FLOW_COUNTS_PER_GALLON,
     DEFAULT_IDLE_DISCONNECT,
+    DEFAULT_MESH_STATUS_POLL,
     DEFAULT_POLL_IDLE,
     DEFAULT_POLL_WATERING,
     DOMAIN,
 )
 from .coordinator import BHyveDeviceCoordinator
-from .devices import UnsupportedModel, build_device
+from .devices import BHyveHT25Device, UnsupportedModel, build_device
 from .devices.base import (
     PROGRAM_SLOTS,
     SLOT_LETTERS,
@@ -89,6 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     flow_counts_per_gallon = opts.get(
         CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
     )
+    mesh_status_poll = opts.get(CONF_MESH_STATUS_POLL, DEFAULT_MESH_STATUS_POLL)
 
     runtime = EntryRuntime()
     for record in devices:
@@ -106,6 +109,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except UnsupportedModel as err:
             _LOGGER.warning("%s: %s — skipping", record.get("name"), err)
             continue
+        if isinstance(device, BHyveHT25Device):
+            device.active_status_poll = mesh_status_poll
         coord = BHyveDeviceCoordinator(
             hass, device, poll_idle_sec=poll_idle, poll_watering_sec=poll_watering,
         )
@@ -175,10 +180,13 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     flow_counts_per_gallon = opts.get(
         CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
     )
+    mesh_status_poll = opts.get(CONF_MESH_STATUS_POLL, DEFAULT_MESH_STATUS_POLL)
     for coord in runtime.coordinators.values():
         coord.poll_idle = poll_idle
         coord.poll_watering = poll_watering
         coord.device.flow_counts_per_gallon = flow_counts_per_gallon
+        if isinstance(coord.device, BHyveHT25Device):
+            coord.device.active_status_poll = mesh_status_poll
         if coord.device.connection is not None:
             coord.device.connection._idle_sec = idle_disconnect
         # Re-apply the interval for the current state so a changed cadence takes

--- a/custom_components/orbit_bhyve/config_flow.py
+++ b/custom_components/orbit_bhyve/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_DEVICES,
     CONF_EMAIL,
     CONF_FLOW_COUNTS_PER_GALLON,
+    CONF_MESH_STATUS_POLL,
     CONF_IDLE_DISCONNECT,
     CONF_INCLUDE,
     CONF_PASSWORD,
@@ -37,6 +38,7 @@ from .const import (
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
     DEFAULT_FLOW_COUNTS_PER_GALLON,
+    DEFAULT_MESH_STATUS_POLL,
     DEFAULT_IDLE_DISCONNECT,
     DEFAULT_POLL_IDLE,
     DEFAULT_POLL_WATERING,
@@ -106,6 +108,7 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_POLL_IDLE: DEFAULT_POLL_IDLE,
                     CONF_POLL_WATERING: DEFAULT_POLL_WATERING,
                     CONF_FLOW_COUNTS_PER_GALLON: DEFAULT_FLOW_COUNTS_PER_GALLON,
+                    CONF_MESH_STATUS_POLL: DEFAULT_MESH_STATUS_POLL,
                 },
             )
 
@@ -196,5 +199,9 @@ class BHyveOptionsFlow(config_entries.OptionsFlow):
                          default=opts.get(CONF_FLOW_COUNTS_PER_GALLON,
                                           DEFAULT_FLOW_COUNTS_PER_GALLON)):
                 vol.All(vol.Coerce(int), vol.Range(min=1, max=100000)),
+            vol.Required(CONF_MESH_STATUS_POLL,
+                         default=opts.get(CONF_MESH_STATUS_POLL,
+                                          DEFAULT_MESH_STATUS_POLL)):
+                bool,
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -44,6 +44,7 @@ CONF_IDLE_DISCONNECT = "idle_disconnect_sec"
 CONF_POLL_IDLE = "poll_idle_sec"
 CONF_POLL_WATERING = "poll_watering_sec"
 CONF_FLOW_COUNTS_PER_GALLON = "flow_counts_per_gallon"
+CONF_MESH_STATUS_POLL = "mesh_status_poll"
 
 DEFAULT_DURATION = 600
 DEFAULT_IDLE_DISCONNECT = 60
@@ -52,6 +53,11 @@ DEFAULT_POLL_IDLE = 900  # 15 min — an idle status poll (#15) connects over BL
                          # last longer and get picked up at least once. Tunable in the
                          # Configure dialog (Poll idle).
 DEFAULT_POLL_WATERING = 30
+# Opt-in, default OFF: an idle mesh (HT25) status poll must CONNECT over BLE
+# (~96 connects/day at the default 15-min idle cadence, each a full bind/init
+# on AA cells), unlike the protobuf family whose poll is already a connect.
+# Without it, mesh idle state stays event-driven (acks + wall clock).
+DEFAULT_MESH_STATUS_POLL = False
 
 # Flow (Gen2 #59.#3) is a CUMULATIVE per-run volume counter in raw device units,
 # not gpm. To convert the counter to gallons, divide by this factor (exposed as

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from ..connection import BHyveBleConnection
@@ -164,6 +164,12 @@ class BHyveBleDeviceBase(abc.ABC):
     # only per app captures; the XD has no flow screen. Verify on hardware
     # before trusting (the `flow` CLI probes both) — see docs/ble_protocol.md.
     has_flow: bool = False
+    # Opt-in "Mesh live status poll" option: when True, the mesh (HT25)
+    # refresh_state connects and runs the init's STATUS/INFO queries on each
+    # idle poll instead of staying passive. Costs battery (a BLE connect per
+    # idle tick); applied from the options flow by __init__.py. The protobuf
+    # family ignores it — its poll already connects.
+    active_status_poll: bool = False
 
     def __init__(
         self,
@@ -310,12 +316,75 @@ class BHyveBleDeviceBase(abc.ABC):
         elif seq == 0x02 and len(pt) >= 6:
             # Status reply/push: payload[0] (pt[5]) is the watering mode —
             # 0x04 = watering, 0x01 = idle. Authoritative device state, used to
-            # confirm an actuation actually took.
+            # confirm an actuation actually took and — via the active-run
+            # payload — to sync a run HA didn't start (app/hub/schedule).
             mode = pt[5]
+            was_watering = self.state.is_watering
             if mode == 0x04:
                 self.state.is_watering = True
+                self._apply_mesh_run_payload(pt)
+                if not was_watering:
+                    self._notify_state_changed()
             elif mode == 0x01:
+                # Idle: clear any run bookkeeping (mirrors the STOP-ack clears
+                # in ht25.py); idempotent when nothing was running.
                 self.state.is_watering = False
+                self.state.active_zone = None
+                self.state.seconds_remaining = None
+                self.state.started_at = None
+                self.state.expected_off_at = None
+                if was_watering:
+                    self._notify_state_changed()
+
+    # Mesh STATUS countdown tick rate — HYPOTHESIS pending live calibration.
+    # Evidence (docs/findings/d7-47-protocol.md, captured 600 s run): active
+    # payload `04 c0 95 40 58 02 00` = [state][countdown u16 LE][0x40][duration
+    # u16 LE][00]. 0x95c0 = 38336 counts with the duration echoing 600 s →
+    # 38336/64 = 599 s remaining (1 s into the run), and the adjacent capture
+    # `80 95` is exactly -64 counts = -1 s. The 24-bit reading (counter
+    # including the 0x40 byte) fails the same arithmetic. Byte 3's 0x40 needs a
+    # >1023 s run to resolve (constant flag vs. counter bits 16-21 OR'd with
+    # 0x40); until then its low 6 bits are treated as high counter bits and the
+    # result is sanity-gated against the duration echo below.
+    _MESH_COUNTDOWN_HZ = 64
+
+    def _apply_mesh_run_payload(self, pt: bytes) -> None:
+        """Decode the active-STATUS payload (mode 0x04) into the live countdown:
+        payload[1:3]+bits of [3] = remaining counts, payload[4:6] = requested
+        duration (seconds, u16 LE). Frame offsets: payload[k] = pt[5+k]."""
+        if len(pt) < 12:
+            return  # short frame: mode byte only, no countdown payload
+        counts = int.from_bytes(pt[6:8], "little") | ((pt[8] & 0x3F) << 16)
+        duration = int.from_bytes(pt[9:11], "little")
+        # Raw bytes for the calibration/diagnostics loop (mode..payload end).
+        self.state.extra["mesh_status_raw"] = pt[5:12].hex()
+        remaining = counts // self._MESH_COUNTDOWN_HZ
+        if not (0 < duration <= 0xFFFF and remaining <= duration):
+            # Fails the duration cross-check — tick-rate hypothesis doesn't fit
+            # this frame, so keep is_watering but don't trust the countdown.
+            _LOGGER.debug(
+                "%s: mesh STATUS countdown failed sanity (raw=%s counts=%d "
+                "duration=%ds) — not applied",
+                self.mac, pt[5:12].hex(), counts, duration,
+            )
+            return
+        now = datetime.now(timezone.utc)
+        self.state.seconds_remaining = remaining
+        if self.state.active_zone is None:
+            self.state.active_zone = 1  # mesh HT25 is single-station
+        if self.state.started_at is None:
+            # Run discovered externally (app/hub/schedule) — synthesize the
+            # start from the duration echo so attributes stay coherent.
+            self.state.started_at = now - timedelta(seconds=duration - remaining)
+        new_off = now + timedelta(seconds=remaining)
+        if (
+            self.state.expected_off_at is None
+            or new_off < self.state.expected_off_at - timedelta(seconds=15)
+        ):
+            # Same guard as the protobuf path (status.py): only ever move the
+            # wall-clock auto-close EARLIER, so a re-reported run can't keep
+            # postponing the close.
+            self.state.expected_off_at = new_off
 
     @abc.abstractmethod
     async def start_watering(self, station: int, duration_sec: int) -> bool:

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -191,38 +191,42 @@ class BHyveHT25Device(BHyveBleDeviceBase):
     async def start_watering(self, station: int, duration_sec: int) -> bool:
         if self.connection is None:
             return False
-        try:
-            # HT25 is single-station; `station` is a no-op placeholder for API parity.
-            # Stash before sending so the START-ack (which can arrive after a write
-            # timeout) can arm the off-timer in _observe_plaintext.
-            self._pending_start_duration = duration_sec
-            self._pending_start_zone = station
-            plaintext = self._build_start(0xB6, duration_sec)
-            _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
-            notifs = await self._send_command(plaintext, "START")
-            self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
-            self._mark_reached()  # connected + sent → device reached this cycle
-            # The off-timer is armed by the device's START-ack (_observe_plaintext),
-            # not by send()'s return — so this holds even when the write-response
-            # times out. Report whatever state the ack has produced by now.
-            return self.state.is_watering
-        finally:
-            if self.connection is not None:
-                await self.connection.disconnect()
+        # _api_lock: an active status poll (_connect_refresh) must never
+        # interleave with an actuation on the device's single BLE session.
+        async with self._api_lock:
+            try:
+                # HT25 is single-station; `station` is a no-op placeholder for API parity.
+                # Stash before sending so the START-ack (which can arrive after a write
+                # timeout) can arm the off-timer in _observe_plaintext.
+                self._pending_start_duration = duration_sec
+                self._pending_start_zone = station
+                plaintext = self._build_start(0xB6, duration_sec)
+                _LOGGER.debug("%s: START tx pt=%s", self.mac, plaintext.hex())
+                notifs = await self._send_command(plaintext, "START")
+                self._stamp_command(f"start s={station} d={duration_sec}", len(notifs))
+                self._mark_reached()  # connected + sent → device reached this cycle
+                # The off-timer is armed by the device's START-ack (_observe_plaintext),
+                # not by send()'s return — so this holds even when the write-response
+                # times out. Report whatever state the ack has produced by now.
+                return self.state.is_watering
+            finally:
+                if self.connection is not None:
+                    await self.connection.disconnect()
 
     async def stop_watering(self, station: int | None = None) -> bool:
         if self.connection is None:
             return False
-        try:
-            plaintext = self._build_stop(0xB7)
-            _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
-            notifs = await self._send_command(plaintext, "STOP")
-            self._stamp_command("stop", len(notifs))
-            self._mark_reached()  # connected + sent → device reached this cycle
-            return not self.state.is_watering
-        finally:
-            if self.connection is not None:
-                await self.connection.disconnect()
+        async with self._api_lock:
+            try:
+                plaintext = self._build_stop(0xB7)
+                _LOGGER.debug("%s: STOP tx pt=%s", self.mac, plaintext.hex())
+                notifs = await self._send_command(plaintext, "STOP")
+                self._stamp_command("stop", len(notifs))
+                self._mark_reached()  # connected + sent → device reached this cycle
+                return not self.state.is_watering
+            finally:
+                if self.connection is not None:
+                    await self.connection.disconnect()
 
     async def _send_command(self, plaintext: bytes, label: str) -> list[bytes]:
         """Send a command frame via send_actuation, which re-runs the bind/init
@@ -244,33 +248,54 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         return notifs
 
     async def refresh_state(self):
-        """Passive poll: return the last-known state without opening BLE.
-        Connectivity is event-driven (stamped by _mark_reached on each actual
-        connect: Sync / start / stop), so this poll deliberately does NOT touch
-        state.is_connected — reading the torn-down live socket would pin the
-        Connected sensor off. is_watering is driven by the device's START/STOP
-        ack (_observe_plaintext) and the coordinator's wall-clock auto-close;
-        eliciting live idle status would need a connect + STATUS query (future
-        enhancement, needs hardware verification)."""
-        await super().refresh_state()
+        """Poll. Default (option off): passive — return the last-known state
+        without opening BLE. Connectivity is event-driven (stamped by
+        _mark_reached on each actual connect: Sync / start / stop), so the
+        passive poll deliberately does NOT touch state.is_connected — reading
+        the torn-down live socket would pin the Connected sensor off.
+        is_watering is driven by the device's START/STOP ack
+        (_observe_plaintext) and the coordinator's wall-clock auto-close.
+
+        With the "Mesh live status poll" option on (active_status_poll), an
+        IDLE poll instead forces a connect: the init's STATUS (seq 0x02) and
+        INFO (seq 0x03) replies refresh watering state, countdown and battery
+        via _observe_plaintext — so app/hub/schedule runs surface within one
+        idle tick. Never while watering: at the watering cadence a connect per
+        tick would hammer the AA cells and race actuations, and the STATUS
+        countdown + wall clock already track an active run."""
+        if self.active_status_poll and not self.state.is_watering:
+            recent = self.state.last_successful_poll
+            # Skip if something else (Sync button, an actuation) reached the
+            # device moments ago — no point paying for a second connect.
+            if recent is None or (
+                datetime.now(timezone.utc) - recent
+            ).total_seconds() > 10:
+                await self._connect_refresh()
         return self.state
 
-    async def async_manual_sync(self) -> None:
-        """Sync button: this mesh class's periodic refresh_state is passive (it
-        never opens BLE), so force a fresh connect here. The connect-time 8-step
-        init's status (seq 0x02) and info (seq 0x03) replies refresh watering
-        state and battery via _observe_plaintext — the on-demand refresh #24
-        dropped when it stopped forcing a connect on the button. Ephemeral:
+    async def _connect_refresh(self) -> None:
+        """Force a fresh ephemeral connect purely for its init replies: the
+        8-step init's status (seq 0x02) and info (seq 0x03) responses refresh
+        watering state and battery via _observe_plaintext. Disconnect first so
+        the init actually re-runs (a pooled session would skip it), and
         disconnect afterwards so we don't hold the device's single session."""
         if self.connection is None:
             return
-        try:
-            await self.connection.disconnect()
-            await self.connection.ensure_connected()
-        except (BleakError, asyncio.TimeoutError, OSError) as err:
-            _LOGGER.warning("%s: manual sync connect failed: %s", self.mac, err)
-            self._mark_unreachable()
-        else:
-            self._mark_reached()  # connect + init succeeded → device reached
-        finally:
-            await self.connection.disconnect()
+        async with self._api_lock:
+            try:
+                await self.connection.disconnect()
+                await self.connection.ensure_connected()
+            except (BleakError, asyncio.TimeoutError, OSError) as err:
+                _LOGGER.warning("%s: status refresh connect failed: %s", self.mac, err)
+                self._mark_unreachable()
+            else:
+                self._mark_reached()  # connect + init succeeded → device reached
+            finally:
+                await self.connection.disconnect()
+
+    async def async_manual_sync(self) -> None:
+        """Sync button: this mesh class's periodic refresh_state can be passive
+        (it never opens BLE unless the live-status option is on), so force a
+        fresh connect here — the on-demand refresh #24 dropped when it stopped
+        forcing a connect on the button."""
+        await self._connect_refresh()

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -44,7 +44,8 @@
           "idle_disconnect_sec": "Disconnect after idle (seconds)",
           "poll_idle_sec": "State polling interval — idle (seconds)",
           "poll_watering_sec": "State polling interval — watering (seconds)",
-          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)"
+          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)",
+          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)"
         }
       }
     }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -44,7 +44,8 @@
           "idle_disconnect_sec": "Disconnect after idle (seconds)",
           "poll_idle_sec": "State polling interval — idle (seconds)",
           "poll_watering_sec": "State polling interval — watering (seconds)",
-          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)"
+          "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)",
+          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)"
         }
       }
     }

--- a/docs/findings/d7-47-protocol.md
+++ b/docs/findings/d7-47-protocol.md
@@ -207,15 +207,31 @@ a state flag; the rest is meaningful only while active.
 | Watering | `04 c0 95 40 58 02 00`              |
 | Watering | `04 80 95 40 58 02 00` (counting down) |
 
-Working byte layout of the payload:
+Working byte layout of the payload (revised 2026-07 — the earlier "bytes 1-3
+counter / byte 4 flag / bytes 5-6 duration" reading did not match the captured
+hex, which has only seven payload bytes):
 
 - **byte 0** — state flag: `0x01` idle, `0x04` active.
-- **bytes 1-3** — remaining-time counter (24-bit LE; possibly 32-bit including
-  byte 4). Idle fills these with `ff ff ff ff` (no active run).
-- **byte 4** — `0x40` while active (alignment / part of the counter; unresolved).
-- **bytes 5-6** — requested duration uint16_LE. `58 02` = 600 s, matching the
-  labelled 10-minute run and the START payload's duration field.
-- **byte 7** — `0x00`.
+- **bytes 1-2** — remaining-time countdown, **uint16 LE in 1/64-second ticks**
+  (hypothesis, see below). Idle fills bytes 1-4 with `ff` (no active run).
+- **byte 3** — `0x40` while active. Suspected to carry countdown bits 16-21 in
+  its low 6 bits for runs longer than 1023 s (needs a >17-minute run to
+  resolve; both captures were 600 s).
+- **bytes 4-5** — requested duration uint16_LE **seconds**. `58 02` = 600 s,
+  matching the labelled 10-minute run and the START payload's duration field.
+- **byte 6** — `0x00`.
+
+**64 Hz tick-rate evidence** (from the two captured active frames alone):
+`c0 95` = 38336 = 600·64 − 64 → exactly **599 s remaining, 1 s into the 600 s
+run**; the adjacent capture `80 95` = 38272 is exactly **−64 counts = −1 s**
+(consistent with back-to-back ~1 Hz status pushes). A 24-bit reading including
+the `0x40` byte (4,232,640 counts) fits no plausible tick rate to a clean
+remaining-time for this run. Implemented in
+`devices/base.py::_apply_mesh_run_payload` behind a duration cross-check
+(countdown decoding longer than the requested run is discarded); live
+calibration on a mesh device — comparing `state.extra["mesh_status_raw"]`
+against wall clock at known offsets into a run, plus one >17-minute run for
+byte 3 — should confirm before this is considered settled.
 
 Idle is unambiguous (`01 ffffffff 0000`); active is `04 <countdown> … <dur> 00`.
 There is **no standard GATT Battery Service (0x180F)** and no separate watering
@@ -225,7 +241,12 @@ In this repo `is_watering` is driven optimistically from command stamping plus
 the START-ack: `_observe_plaintext` in `devices/ht25.py` watches for the
 `seq=0x0D` reply (`0x40` bit set), reads the echoed `04 <dur_LE> …`, and arms an
 off-timer for that duration. That makes the auto-off reliable even when the
-BLE write-response times out.
+BLE write-response times out. Additionally, the STATUS reply itself (seq
+`0x02`) is decoded in `devices/base.py` — active/idle plus the countdown
+payload above — so a run started from the app/hub syncs on any connect, and
+the opt-in **Mesh live status poll** option makes the idle coordinator poll
+perform that connect (`BHyveHT25Device.refresh_state` →
+`_connect_refresh`).
 
 ---
 
@@ -305,9 +326,10 @@ firmware byte and the battery voltage.
 
 ## Open questions
 
-- The active-STATUS counter (bytes 1-4) is not fully decoded — whether it is a
-  24-bit or 32-bit remaining-time value, and the role of byte 4 (`0x40` while
-  active), needs more captures at different durations.
+- The active-STATUS countdown is decoded as uint16 LE at 64 Hz (see the status
+  section above) — a hypothesis that fits both captures exactly but still wants
+  live confirmation at other run offsets, and byte 3's `0x40` (constant flag
+  vs. countdown bits 16-21) needs a >17-minute run to resolve.
 - Whether any of the 8 init steps are optional (a minimal "connect → start →
   stop" capture would show which acks the device actually requires).
 - The write-only characteristic in the custom service is unused; its purpose

--- a/tests/test_mesh_status.py
+++ b/tests/test_mesh_status.py
@@ -1,0 +1,171 @@
+"""Mesh (d7-47) STATUS decode + live-status poll gating tests.
+
+Covers the seq 0x02 active/idle payload decode in
+BHyveBleDeviceBase._observe_plaintext (countdown at the 64 Hz hypothesis,
+duration cross-check, only-move-earlier off-timer guard) and the opt-in
+active idle poll in BHyveHT25Device.refresh_state. No hardware or Home
+Assistant required.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from orbit_bhyve.devices.ht25 import BHyveHT25Device
+
+MESH = bytes([0xD7, 0x47])
+TYPE_STATUS_REPLY = 0x42  # 0x02 with the 0x40 reply bit
+ROUTING = 0x40
+
+
+def _dev() -> BHyveHT25Device:
+    # Key-less record -> no BLE connection, no hass needed.
+    record = {
+        "cloud_id": "abc", "name": "Deck", "mac": "AA:BB:CC:DD:EE:FF",
+        "hardware": "HT25-0000", "firmware": "0085", "stations": 1,
+        "network_key": "",
+    }
+    return BHyveHT25Device(None, record)
+
+
+def _status_frame(payload: bytes) -> bytes:
+    """[mesh:2][type:1][seq:1][routing:1][payload:N] with the reply bit set."""
+    return MESH + bytes([TYPE_STATUS_REPLY, 0x02, ROUTING]) + payload
+
+
+def _active_payload(remaining_sec: int, duration_sec: int) -> bytes:
+    """Active STATUS payload per the captured layout:
+    [04][countdown u16 LE @64 Hz][0x40][duration u16 LE][00]."""
+    counts = remaining_sec * 64
+    return (
+        bytes([0x04])
+        + (counts & 0xFFFF).to_bytes(2, "little")
+        + bytes([0x40 | ((counts >> 16) & 0x3F)])
+        + duration_sec.to_bytes(2, "little")
+        + b"\x00"
+    )
+
+
+IDLE_PAYLOAD = bytes.fromhex("01ffffffff0000")  # captured idle shape
+
+
+def test_active_status_decodes_countdown():
+    dev = _dev()
+    before = datetime.now(timezone.utc)
+    # The doc's captured frame: 1 s into a 600 s run -> 599 s remaining.
+    dev._observe_plaintext(_status_frame(_active_payload(599, 600)))
+    assert dev.state.is_watering is True
+    assert dev.state.seconds_remaining == 599
+    assert dev.state.active_zone == 1
+    assert dev.state.extra["mesh_status_raw"] == _active_payload(599, 600).hex()
+    # started_at synthesized from the duration echo (~1 s before now).
+    assert dev.state.started_at is not None
+    assert abs((before - dev.state.started_at).total_seconds() - 1) < 2
+    # Off-timer armed ~599 s out.
+    off_in = (dev.state.expected_off_at - before).total_seconds()
+    assert 597 < off_in < 601
+
+
+def test_captured_bytes_decode_to_599():
+    # Byte-for-byte captured active frame: `04 c0 95 40 58 02 00`.
+    dev = _dev()
+    dev._observe_plaintext(_status_frame(bytes.fromhex("04c09540580200")))
+    assert dev.state.seconds_remaining == 599
+    # And the adjacent capture (`80 95`) is exactly one second later.
+    dev2 = _dev()
+    dev2._observe_plaintext(_status_frame(bytes.fromhex("04809540580200")))
+    assert dev2.state.seconds_remaining == 598
+
+
+def test_idle_status_clears_run_state():
+    dev = _dev()
+    dev.state.is_watering = True
+    dev.state.active_zone = 1
+    dev.state.seconds_remaining = 300
+    dev.state.expected_off_at = datetime.now(timezone.utc) + timedelta(seconds=300)
+    dev._observe_plaintext(_status_frame(IDLE_PAYLOAD))
+    assert dev.state.is_watering is False
+    assert dev.state.active_zone is None
+    assert dev.state.seconds_remaining is None
+    assert dev.state.expected_off_at is None
+
+
+def test_status_transition_notifies_coordinator():
+    dev = _dev()
+    pokes: list[int] = []
+    dev.set_state_changed_callback(lambda: pokes.append(1))
+    dev._observe_plaintext(_status_frame(_active_payload(599, 600)))
+    assert len(pokes) == 1          # idle -> watering
+    dev._observe_plaintext(_status_frame(_active_payload(598, 600)))
+    assert len(pokes) == 1          # still watering: no re-poke
+    dev._observe_plaintext(_status_frame(IDLE_PAYLOAD))
+    assert len(pokes) == 2          # watering -> idle
+
+
+def test_countdown_failing_duration_crosscheck_not_applied():
+    # A countdown decoding LONGER than the requested run means the tick-rate
+    # hypothesis doesn't fit this frame: keep is_watering, drop the countdown.
+    dev = _dev()
+    payload = (
+        bytes([0x04]) + b"\xff\xff" + bytes([0x40]) + (600).to_bytes(2, "little") + b"\x00"
+    )  # 65535 counts -> 1023 s "remaining" of a 600 s run
+    dev._observe_plaintext(_status_frame(payload))
+    assert dev.state.is_watering is True
+    assert dev.state.seconds_remaining is None
+    assert dev.state.extra["mesh_status_raw"] == payload.hex()  # raw still logged
+
+
+def test_off_timer_only_moves_earlier():
+    dev = _dev()
+    near = datetime.now(timezone.utc) + timedelta(seconds=300)
+    dev.state.is_watering = True
+    dev.state.expected_off_at = near
+    # Device claims 599 s remaining -> later than the armed off-timer: ignored.
+    dev._observe_plaintext(_status_frame(_active_payload(599, 600)))
+    assert dev.state.expected_off_at == near
+    # Device claims 100 s remaining -> earlier: re-anchored.
+    dev._observe_plaintext(_status_frame(_active_payload(100, 600)))
+    assert dev.state.expected_off_at < near
+
+
+def test_short_status_frame_sets_mode_only():
+    # Legacy/short reply (mode byte only) must keep working: no countdown data.
+    dev = _dev()
+    dev._observe_plaintext(_status_frame(bytes([0x04])))
+    assert dev.state.is_watering is True
+    assert dev.state.seconds_remaining is None
+
+
+def test_refresh_state_active_poll_gating():
+    dev = _dev()
+    calls: list[int] = []
+
+    async def fake_connect_refresh():
+        calls.append(1)
+
+    dev._connect_refresh = fake_connect_refresh  # type: ignore[method-assign]
+
+    # Option off (default): passive poll, no connect.
+    asyncio.run(dev.refresh_state())
+    assert calls == []
+
+    # Option on + idle: connects.
+    dev.active_status_poll = True
+    asyncio.run(dev.refresh_state())
+    assert calls == [1]
+
+    # Option on + watering: never connects mid-run.
+    dev.state.is_watering = True
+    asyncio.run(dev.refresh_state())
+    assert calls == [1]
+
+    # Option on + idle but reached moments ago (Sync/actuation): skipped.
+    dev.state.is_watering = False
+    dev.state.last_successful_poll = datetime.now(timezone.utc)
+    asyncio.run(dev.refresh_state())
+    assert calls == [1]
+
+    # Stale last reach -> connects again.
+    dev.state.last_successful_poll = datetime.now(timezone.utc) - timedelta(seconds=60)
+    asyncio.run(dev.refresh_state())
+    assert calls == [1, 1]


### PR DESCRIPTION
## Part 1 — STATUS (seq 0x02) countdown decode (passive, zero battery cost)

The active payload is `[04][countdown u16 LE][40][duration u16 LE][00]` — **revised from the doc's earlier 24-bit reading**, which doesn't fit its own captured hex:

- `c0 95` = 38336 counts with the duration echoing 600 s → **exactly 599 s at 64 Hz** (1 s into the run);
- the adjacent capture `80 95` is **exactly −64 counts = −1 s** (back-to-back ~1 Hz pushes);
- the 24-bit reading (4,232,640 counts) fits no clean tick rate.

Decode is sanity-gated against the duration echo (a countdown longer than the requested run is discarded), and the raw payload is logged to `state.extra["mesh_status_raw"]` for live calibration. Byte 3's `0x40` (constant flag vs. countdown bits 16-21) needs a >17-minute run to resolve; its low 6 bits are treated as high counter bits until then.

Effects: `seconds_remaining` re-anchors the wall-clock auto-close (only-move-earlier guard, same as the protobuf path), app/hub-started runs get a synthesized `started_at` from the duration echo, an idle reply clears run state, and idle↔watering transitions poke the coordinator so the cadence flips immediately.

## Part 2 — 'Mesh live status poll' option (default OFF)

`async_manual_sync` already was the status query in all but name (connect → 8-step init whose STATUS/INFO replies carry state + battery). Part 2 runs it from the poll, behind an option:

- **Idle polls only** — never mid-run (a connect per 30 s tick would hammer the AA cells and race actuations; Part 1 + wall clock cover active runs). Skipped when the device was reached <10 s ago (e.g. right after Sync).
- `start_watering` / `stop_watering` / `_connect_refresh` now serialize on `_api_lock` so a poll can never interleave with an actuation on the single BLE session.
- Battery cost in the option label: **~96 connects/day** at the default 15-min idle cadence — hence opt-in.

## Testing

8 new tests (`tests/test_mesh_status.py`): byte-for-byte captured-frame decode (599/598 s), transitions/notify, duration cross-check rejection, only-move-earlier guard, short-frame compat, poll gating. Suite 170/170.

## Hardware calibration plan (mesh fleet)

1. Start a ~600 s run; press **Sync** at a few known offsets; compare `mesh_status_raw` to wall clock (should confirm 64 Hz).
2. One >17-minute run to resolve byte 3.
3. Enable the option on one device; start a run from the **B-hyve app** — the HA valve should open within one idle poll with a sane countdown and close on schedule.
4. Leave a second device with the option off for a week; compare battery-voltage traces to quantify the cost.
5. Regression: HA START/STOP with the option on — no interleave errors.

Docs: `d7-47-protocol.md` status byte-layout section rewritten with the 64 Hz evidence; open question updated.