### PR TITLE
feat(programs): reject watering-program names over the device's 32-byte limit

### DIFF
--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -53,6 +53,7 @@ from .devices.base import (
     ProgramSpec,
     ProgramSummary,
     parse_start_minutes,
+    validate_program_name,
 )
 from .devices.protobuf import BHyveProtobufDevice
 
@@ -243,6 +244,7 @@ def _spec_from_call(call: ServiceCall) -> ProgramSpec:
         raise ServiceValidationError("interval mode needs interval_days")
     try:
         start_mins = [parse_start_minutes(tok) for tok in call.data["start_times"]]
+        name = validate_program_name(call.data.get("name", ""))
     except ValueError as err:
         raise ServiceValidationError(str(err)) from err
     zones: list[tuple[int, int]] = []
@@ -256,7 +258,7 @@ def _spec_from_call(call: ServiceCall) -> ProgramSpec:
         interval_anchor=call.data.get("interval_anchor"),
         start_mins=tuple(start_mins),
         zones=tuple(zones),
-        name=call.data.get("name", ""),
+        name=name,
         budget=int(call.data.get("budget", 100)),
         enabled=bool(call.data.get("enabled", False)),
     )

--- a/custom_components/orbit_bhyve/devices/base.py
+++ b/custom_components/orbit_bhyve/devices/base.py
@@ -61,6 +61,30 @@ SLOT_LETTERS = {v: k for k, v in PROGRAM_SLOTS.items()}
 # and summary sensor.
 UI_SLOTS = ("A", "B", "C", "D")
 
+# The device stores the program name (#17 in setProgramSchedule) in a fixed
+# 32-byte field. A longer name makes the device reject the WHOLE #19 store while
+# the separate #20 enable still lands, so the slot reports "enabled" but keeps its
+# OLD schedule (a silent write-and-lose). Verified on HT34A fw0107 and HT25G2
+# fw0111 (32 bytes stored; 33 rejected on both). Reject early instead.
+MAX_PROGRAM_NAME_BYTES = 32
+
+
+def validate_program_name(name: str) -> str:
+    """Return `name` unchanged, or raise ``ValueError`` if it overflows the
+    device's 32-byte program-name field (see ``MAX_PROGRAM_NAME_BYTES``). The
+    limit is UTF-8 *bytes*, not characters — the firmware buffer is byte-sized, so
+    a 16-char accented name can already be 32 bytes. Kept HA-free so it is
+    unit-testable standalone; the service layer maps ``ValueError`` to a
+    ``ServiceValidationError`` (same contract as ``parse_start_minutes``)."""
+    n = len(name.encode("utf-8"))
+    if n > MAX_PROGRAM_NAME_BYTES:
+        raise ValueError(
+            f"program name is too long: {n} bytes (max {MAX_PROGRAM_NAME_BYTES}). "
+            "The device silently rejects the whole program when the name overflows "
+            "its 32-byte field — shorten the name."
+        )
+    return name
+
 
 def parse_start_minutes(tok: object) -> int:
     """Parse one program start-time token to minutes-from-midnight (0..1439).

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -97,7 +97,7 @@ set_program:
         object:
     name:
       name: Program name
-      description: Optional label stored on the device.
+      description: Optional label stored on the device (max 32 bytes; longer names are rejected by the device).
       required: false
       example: Front lawn
       selector:

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -81,7 +81,7 @@
         "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
         "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
         "zones": {"name": "Zones", "description": "Per-zone run time — a list of zone/minutes pairs."},
-        "name": {"name": "Program name", "description": "Optional label stored on the device."},
+        "name": {"name": "Program name", "description": "Optional label stored on the device (max 32 bytes; longer names are rejected by the device)."},
         "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
         "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}
       }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -81,7 +81,7 @@
         "interval_anchor": {"name": "Interval anchor date", "description": "For day mode \"interval\" — ISO date the interval counts from (default today)."},
         "start_times": {"name": "Start times", "description": "One or more start times (HH:MM, device-local)."},
         "zones": {"name": "Zones", "description": "Per-zone run time — a list of zone/minutes pairs."},
-        "name": {"name": "Program name", "description": "Optional label stored on the device."},
+        "name": {"name": "Program name", "description": "Optional label stored on the device (max 32 bytes; longer names are rejected by the device)."},
         "budget": {"name": "Seasonal budget (%)", "description": "Seasonal adjust percentage (default 100)."},
         "enabled": {"name": "Enable", "description": "Enable and arm the program so it runs on schedule."}
       }

--- a/docs/ble-messages.md
+++ b/docs/ble-messages.md
@@ -297,7 +297,7 @@ Decoded: `setDateTime { currentTimeIso8601: "2026-05-31T08:36:30-04:00" }` -- sy
 | f14 | `lastChangeId` | `OrbitPbApi_InterfaceId` | |
 | f15 | `groupWateringPreDelaySec` | uint32 | |
 | f16 | `groupWateringPostDelaySec` | uint32 | |
-| f17 | `programName` | string | |
+| f17 | `programName` | string | Max **32 bytes** (UTF-8). A longer name makes the device reject the whole `setProgramSchedule` while the separate `#20` enable still lands — the slot then reports enabled but keeps its old schedule. Verified HT34A fw0107 + HT25G2 fw0111. |
 | f18 | `intervalHours` | uint32 | |
 | f19 | `basicProgramMode` | bool | |
 | f20 | `databaseId` | uint32 | |

--- a/tests/test_ha_programs.py
+++ b/tests/test_ha_programs.py
@@ -17,10 +17,12 @@ from orbit_bhyve.connection import BHyveBleConnection
 from orbit_bhyve.devices import protobuf as tx
 from orbit_bhyve.devices import status as rx
 from orbit_bhyve.devices.base import (
+    MAX_PROGRAM_NAME_BYTES,
     DeviceState,
     ProgramSpec,
     ProgramSummary,
     parse_start_minutes,
+    validate_program_name,
 )
 from orbit_bhyve.devices.ht25g2 import BHyveHT25G2Device
 
@@ -621,3 +623,29 @@ def test_parse_start_minutes_rejects_footguns(bad):
     # rather than wrap, and reject out-of-range / non-time tokens.
     with pytest.raises(ValueError):
         parse_start_minutes(bad)
+
+
+# --- program-name length guard (device #17 field is a fixed 32 bytes) --------
+
+def test_validate_program_name_accepts_up_to_32_bytes():
+    # HW-verified boundary: 32 bytes stored on HT34A fw0107 and HT25G2 fw0111.
+    assert MAX_PROGRAM_NAME_BYTES == 32
+    assert validate_program_name("") == ""
+    assert validate_program_name("Tomatoes And Peppers") == "Tomatoes And Peppers"
+    assert validate_program_name("A" * 32) == "A" * 32
+
+
+@pytest.mark.parametrize("name", ["A" * 33, "Squash, Beans, Cucumbers, and Herbs", "z" * 64])
+def test_validate_program_name_rejects_over_32_bytes(name):
+    # 33+ bytes: the device silently drops the whole store (keeping the old
+    # schedule) while the #20 enable lands. Reject up front instead of write-and-lose.
+    with pytest.raises(ValueError):
+        validate_program_name(name)
+
+
+def test_validate_program_name_counts_utf8_bytes_not_chars():
+    # The firmware buffer is byte-sized: 16 two-byte chars = 32 bytes is OK, but
+    # 17 (= 34 bytes) overflows even though it's only 17 characters.
+    assert validate_program_name("é" * 16) == "é" * 16
+    with pytest.raises(ValueError):
+        validate_program_name("é" * 17)


### PR DESCRIPTION
## Summary

The `set_program` service silently loses the whole program when the name is too long.

The device stores the program name (`#17 programName` in `setProgramSchedule`) in a **fixed
32-byte field**. When the name overflows, the device rejects the entire `#19` store — but the
separate `#20 setActivePrograms` enable write still lands. The result is a slot that reports
**enabled** while keeping its **previous** schedule: a write-and-lose the user gets no signal
about. In the field it shows up as `set_program slot X not confirmed by the device` +
`program set X enabled no next-start` in the log, with the sensor still showing the old program.

This validates the name up front in `_spec_from_call` and raises a clear `ServiceValidationError`
instead of writing and losing — the same `ValueError → ServiceValidationError` contract the
service already uses for `parse_start_minutes`. The limit is measured in **UTF-8 bytes, not
characters**, matching the byte-sized firmware buffer (a 16-char accented name is already 32 bytes).

## Changes

- **`devices/base.py`** — `MAX_PROGRAM_NAME_BYTES = 32` and a HA-free `validate_program_name(name)`
  helper that returns the name or raises `ValueError` when it exceeds 32 UTF-8 bytes (kept
  standalone-testable, mirroring `parse_start_minutes`).
- **`__init__.py`** — `_spec_from_call` runs the name through `validate_program_name` inside the
  existing `ValueError → ServiceValidationError` try-block, and passes the validated name into
  `ProgramSpec`.
- **`docs/ble-messages.md`** — documents the 32-byte cap and the silent-reject failure mode on the
  `f17 programName` row.
- **`services.yaml` / `strings.json` / `translations/en.json`** — note the 32-byte limit in the
  Program-name field description.
- **`tests/test_ha_programs.py`** — regression tests: ≤32 bytes accepted (incl. exactly 32),
  33+ rejected, and the UTF-8-bytes-not-characters boundary. Fail on the pre-change code.

## Backwards compatibility

Strictly additive. Any name that stored successfully before (≤32 bytes) still stores. The only
behavior change is that a name the device would have **silently dropped** now returns an
actionable error instead — no wire-protocol change, no new BLE traffic.

## Testing

- **Unit:** 186 tests green; the 3 new tests fail on the pre-change code.
- **CI:** Hassfest + HACS pass on my fork's `validate.yaml`.
- **Hardware — boundary verified on both device families:**
  - **HT34A fw0107 (XD):** 32-byte name stored and read back intact; 33-byte name rejected
    (slot kept its prior program, `not confirmed` + `no next-start` in the log). Binary-searched
    31 ✓ / 33 ✗ / 32 ✓ on an empty scratch slot.
  - **HT25G2 fw0111 (Gen2):** identical — 32 ✓, 33 ✗ on an empty scratch slot.
  - Deployed to HA and live-tested: a 35-byte name now raises the `ServiceValidationError` before
    any BLE write (the slot stays untouched); a 32-byte name stores normally.
  - Real trigger that surfaced this: a 35-char program name ("Squash, Beans, Cucumbers, and
    Herbs") failed to store three times in a row while shorter names on adjacent slots stored
    first try.

## Note for review

Verified on HT34A fw0107 and HT25G2 fw0111 — the whole hardware family I have. Same `#19`
message and same behavior on both, so I've written it as a family-wide limit; if any firmware
uses a different field size the guard is still safe (it only rejects names that the current
firmware also rejects). Reject-vs-truncate was a deliberate call: truncating would silently
rename the user's program, so a clear error the user can act on felt better — happy to switch to
truncate-with-warning if you'd prefer.
