### PR TITLE
ci: run pytest in the validate workflow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -35,16 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: ljmerza/misc-actions/actions/python-test@main
         with:
           python-version: "3.13"
-          cache: pip
-          cache-dependency-path: tests/requirements-test.txt
-      - name: Install test dependencies
-        run: pip install -r tests/requirements-test.txt
-      - name: Run pytest
-        run: pytest -q
+          requirements-file: tests/requirements-test.txt
 
   tests-ha:
     name: Tests (HA plugin)
@@ -52,12 +46,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: tests/requirements-test.txt
       # The suite itself needs no Home Assistant (see tests/requirements-test.txt),
       # and the `tests` job above proves that stays true. This job additionally
       # installs the HA test plugin, whose autouse fixtures (verify_cleanup,
@@ -65,9 +53,10 @@ jobs:
       # bare suite cannot see — e.g. a test that monkeypatches a stdlib global
       # and leaves it in a broken state. Pinned because the plugin pulls an
       # exact homeassistant version and pins pytest itself.
-      - name: Install test dependencies
-        run: |
-          pip install -r tests/requirements-test.txt
-          pip install pytest-homeassistant-custom-component==0.13.205
-      - name: Run pytest
-        run: pytest -q
+      - uses: ljmerza/misc-actions/actions/python-test@main
+        with:
+          python-version: "3.13"
+          requirements-file: tests/requirements-test.txt
+          extra-packages: pytest-homeassistant-custom-component==0.13.205
+          # homeassistant pins aiohasupervisor==0.2.2b5, which uv rejects by default.
+          prerelease: allow

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,3 +28,46 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: tests/requirements-test.txt
+      - name: Install test dependencies
+        run: pip install -r tests/requirements-test.txt
+      - name: Run pytest
+        run: pytest -q
+
+  tests-ha:
+    name: Tests (HA plugin)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: tests/requirements-test.txt
+      # The suite itself needs no Home Assistant (see tests/requirements-test.txt),
+      # and the `tests` job above proves that stays true. This job additionally
+      # installs the HA test plugin, whose autouse fixtures (verify_cleanup,
+      # socket blocking, lingering-timer detection) catch a class of defect the
+      # bare suite cannot see — e.g. a test that monkeypatches a stdlib global
+      # and leaves it in a broken state. Pinned because the plugin pulls an
+      # exact homeassistant version and pins pytest itself.
+      - name: Install test dependencies
+        run: |
+          pip install -r tests/requirements-test.txt
+          pip install pytest-homeassistant-custom-component==0.13.205
+      - name: Run pytest
+        run: pytest -q


### PR DESCRIPTION
`validate.yaml` ran hassfest and HACS but never ran the test suite, so a branch with failing tests reached review looking green — #43 is the live example.

## Two jobs, because the failure mode depends on what's installed

| Job | Installs | Purpose |
|---|---|---|
| `Tests` | `tests/requirements-test.txt` only | Fast signal, and keeps that file's "no Home Assistant needed" claim honest |
| `Tests (HA plugin)` | + `pytest-homeassistant-custom-component==0.13.205` | Its autouse fixtures (`verify_cleanup`, socket blocking, lingering-timer detection) catch defects the bare suite cannot see |

That split is the whole point. #43 currently:

```
Tests            -> 197 passed                    exit 0
Tests (HA plugin) -> 197 passed, 2 errors          exit 1
```

Both are `tests/test_gen1_flow.py` rate tests, which patch the global `time.monotonic` with a two-element iterator and leave it exhausted. Nothing in the bare suite trips over it; `verify_cleanup` calls `time.monotonic()` at teardown and gets `StopIteration`. Without the second job, #43 merges green.

For reference, `main` is 181 passed under both jobs.

## Implementation

Uses `ljmerza/misc-actions/actions/python-test@main`, extended in ljmerza/misc-actions#3 to accept a requirements file and extra packages. `prerelease: allow` is needed on the second job because `homeassistant` pins `aiohasupervisor==0.2.2b5` and `uv pip` rejects pre-releases by default.

## ⚠️ Merge order

**ljmerza/misc-actions#3 must merge first.** These jobs reference the action at `@main` and will fail until the new inputs exist there.