### PR TITLE
ci: make the HA test-plugin pin visible to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  # Action refs in .github/workflows/. Note validate.yaml tracks the shared
+  # python-test action at @main, which Dependabot cannot pin or bump — only
+  # tagged/SHA refs are actionable here.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+
+  # tests/requirements-test.txt and tests/requirements-ha.txt. The latter holds
+  # the pytest-homeassistant-custom-component pin, which drags in an exact
+  # Home Assistant version — without a bump it silently tests an ever-older HA.
+  - package-ecosystem: pip
+    directory: /tests
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: test

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -48,15 +48,11 @@ jobs:
         uses: actions/checkout@v4
       # The suite itself needs no Home Assistant (see tests/requirements-test.txt),
       # and the `tests` job above proves that stays true. This job additionally
-      # installs the HA test plugin, whose autouse fixtures (verify_cleanup,
-      # socket blocking, lingering-timer detection) catch a class of defect the
-      # bare suite cannot see — e.g. a test that monkeypatches a stdlib global
-      # and leaves it in a broken state. Pinned because the plugin pulls an
-      # exact homeassistant version and pins pytest itself.
+      # installs the HA test plugin — see tests/requirements-ha.txt for why.
       - uses: ljmerza/misc-actions/actions/python-test@main
         with:
           python-version: "3.13"
           requirements-file: tests/requirements-test.txt
-          extra-packages: pytest-homeassistant-custom-component==0.13.205
+          extra-packages: -r tests/requirements-ha.txt
           # homeassistant pins aiohasupervisor==0.2.2b5, which uv rejects by default.
           prerelease: allow

--- a/tests/requirements-ha.txt
+++ b/tests/requirements-ha.txt
@@ -1,0 +1,11 @@
+# Extra deps for the "Tests (HA plugin)" job in .github/workflows/validate.yaml.
+# NOT needed to run the suite — see requirements-test.txt, which stands alone.
+#
+# This plugin drags in a pinned Home Assistant and registers autouse fixtures
+# (verify_cleanup, socket blocking, lingering-timer detection) that catch a
+# class of defect the bare suite cannot see: e.g. a test that monkeypatches a
+# stdlib global and leaves it exhausted passes without it and errors with it.
+#
+# Kept in its own file rather than inline in the workflow so Dependabot's pip
+# ecosystem can see the pin and open bumps as Home Assistant moves.
+pytest-homeassistant-custom-component==0.13.205


### PR DESCRIPTION
Follow-up to #44. The `pytest-homeassistant-custom-component==0.13.205` pin sat in a workflow input string, where Dependabot can't see it. That plugin pins an exact Home Assistant version, so with no bumps the nightly cron quietly tests an ever-older HA.

## Changes

- **`tests/requirements-ha.txt`** (new) — holds the pin, with a comment explaining what the plugin buys us and why it's a separate file.
- **`validate.yaml`** — `extra-packages: -r tests/requirements-ha.txt` instead of the inline pin. The action forwards `extra-packages` to `uv pip install` unquoted, so `-r <file>` passes straight through.
- **`.github/dependabot.yml`** (new) — `pip` on `/tests` (picks up both requirements files) and `github-actions` on `/`, both monthly.

`tests/requirements-test.txt` is deliberately untouched: the suite still needs no Home Assistant, and the `Tests` job keeps proving that.

## Verified

Ran the action's steps end to end on Python 3.13 against this tree:

```
install exit=0
plugin installed OK
186 passed in 32.15s
```

So the `-r` indirection installs the plugin exactly as the inline pin did.

## Note

Dependabot can't do anything about `ljmerza/misc-actions/actions/python-test@main` — only tagged or SHA refs are actionable. Called out in a comment in the config so it isn't mistaken for an oversight.