### PR TITLE
fix: replace hardcoded network-key table with a user option

### DIFF
--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_EMAIL,
     CONF_FLOW_COUNTS_PER_GALLON,
     CONF_IDLE_DISCONNECT,
+    CONF_HUB_MESH_OVERRIDES,
     CONF_MESH_STATUS_POLL,
     CONF_PASSWORD,
     CONF_POLL_IDLE,
@@ -40,6 +41,7 @@ from .const import (
     DEFAULT_DURATION,
     DEFAULT_FLOW_COUNTS_PER_GALLON,
     DEFAULT_IDLE_DISCONNECT,
+    DEFAULT_HUB_MESH_OVERRIDES,
     DEFAULT_MESH_STATUS_POLL,
     DEFAULT_POLL_IDLE,
     DEFAULT_POLL_WATERING,
@@ -47,6 +49,7 @@ from .const import (
 )
 from .coordinator import BHyveDeviceCoordinator
 from .devices import BHyveHT25Device, UnsupportedModel, build_device
+from .devices.ht25 import parse_hub_mesh_overrides
 from .devices.base import (
     PROGRAM_SLOTS,
     SLOT_LETTERS,
@@ -93,6 +96,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
     )
     mesh_status_poll = opts.get(CONF_MESH_STATUS_POLL, DEFAULT_MESH_STATUS_POLL)
+    hub_mesh_overrides = parse_hub_mesh_overrides(
+        opts.get(CONF_HUB_MESH_OVERRIDES, DEFAULT_HUB_MESH_OVERRIDES)
+    )
 
     runtime = EntryRuntime()
     for record in devices:
@@ -112,6 +118,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             continue
         if isinstance(device, BHyveHT25Device):
             device.active_status_poll = mesh_status_poll
+            device.hub_mesh_override = hub_mesh_overrides.get(device.mac)
         coord = BHyveDeviceCoordinator(
             hass, device, poll_idle_sec=poll_idle, poll_watering_sec=poll_watering,
         )
@@ -182,12 +189,16 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         CONF_FLOW_COUNTS_PER_GALLON, DEFAULT_FLOW_COUNTS_PER_GALLON
     )
     mesh_status_poll = opts.get(CONF_MESH_STATUS_POLL, DEFAULT_MESH_STATUS_POLL)
+    hub_mesh_overrides = parse_hub_mesh_overrides(
+        opts.get(CONF_HUB_MESH_OVERRIDES, DEFAULT_HUB_MESH_OVERRIDES)
+    )
     for coord in runtime.coordinators.values():
         coord.poll_idle = poll_idle
         coord.poll_watering = poll_watering
         coord.device.flow_counts_per_gallon = flow_counts_per_gallon
         if isinstance(coord.device, BHyveHT25Device):
             coord.device.active_status_poll = mesh_status_poll
+            coord.device.hub_mesh_override = hub_mesh_overrides.get(coord.device.mac)
         if coord.device.connection is not None:
             coord.device.connection._idle_sec = idle_disconnect
         # Re-apply the interval for the current state so a changed cadence takes

--- a/custom_components/orbit_bhyve/config_flow.py
+++ b/custom_components/orbit_bhyve/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_DEVICES,
     CONF_EMAIL,
     CONF_FLOW_COUNTS_PER_GALLON,
+    CONF_HUB_MESH_OVERRIDES,
     CONF_MESH_STATUS_POLL,
     CONF_IDLE_DISCONNECT,
     CONF_INCLUDE,
@@ -38,6 +39,7 @@ from .const import (
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
     DEFAULT_FLOW_COUNTS_PER_GALLON,
+    DEFAULT_HUB_MESH_OVERRIDES,
     DEFAULT_MESH_STATUS_POLL,
     DEFAULT_IDLE_DISCONNECT,
     DEFAULT_POLL_IDLE,
@@ -203,5 +205,9 @@ class BHyveOptionsFlow(config_entries.OptionsFlow):
                          default=opts.get(CONF_MESH_STATUS_POLL,
                                           DEFAULT_MESH_STATUS_POLL)):
                 bool,
+            vol.Optional(CONF_HUB_MESH_OVERRIDES,
+                         default=opts.get(CONF_HUB_MESH_OVERRIDES,
+                                          DEFAULT_HUB_MESH_OVERRIDES)):
+                str,
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -45,6 +45,7 @@ CONF_POLL_IDLE = "poll_idle_sec"
 CONF_POLL_WATERING = "poll_watering_sec"
 CONF_FLOW_COUNTS_PER_GALLON = "flow_counts_per_gallon"
 CONF_MESH_STATUS_POLL = "mesh_status_poll"
+CONF_HUB_MESH_OVERRIDES = "hub_mesh_overrides"
 
 DEFAULT_DURATION = 600
 DEFAULT_IDLE_DISCONNECT = 60
@@ -58,6 +59,15 @@ DEFAULT_POLL_WATERING = 30
 # on AA cells), unlike the protobuf family whose poll is already a connect.
 # Without it, mesh idle state stays event-driven (acks + wall clock).
 DEFAULT_MESH_STATUS_POLL = False
+
+# HT25's magic2 init step references the paired hub's mesh id. The cloud
+# /api/networks response doesn't always surface bridge_device_id, and without
+# it the init falls back to a 0x0000 placeholder (see ht25.hub_mesh_address).
+# This option lets a user supply the value per device rather than the
+# integration shipping a lookup table. Format: comma-separated MAC=id pairs,
+# id decimal or 0x-hex, e.g. "AA:BB:CC:DD:EE:FF=0xEB42, 11:22:33:44:55:66=9021".
+# Read it off a BTSnoop capture of the vendor app's magic2 frame.
+DEFAULT_HUB_MESH_OVERRIDES = ""
 
 # Flow (Gen2 #59.#3) is a CUMULATIVE per-run volume counter in raw device units,
 # not gpm. To convert the counter to gallons, divide by this factor (exposed as

--- a/custom_components/orbit_bhyve/devices/ht25.py
+++ b/custom_components/orbit_bhyve/devices/ht25.py
@@ -34,16 +34,41 @@ INIT_INTER_STEP_SEC = 0.15
 
 BIND_TAIL = bytes.fromhex("f66910ff")
 
-# Empirical hub mesh_device_id per network key. The cloud /api/networks
-# response doesn't surface ble_device_id for hubs in our wizard cache, so
-# magic2 (which references the paired hub) needs this fallback. Values
-# captured from phone-app BTSnoop logs:
-#   Topology A (Deck, Hub Guest BR):    hub mesh_id 0xEB42 = 60226
-#   Topology B (Hill, Corner, Hub Garage): hub mesh_id 0x233D = 9021
-_HUB_MESH_BY_NETWORK_KEY = {
-    "f0983e39083a335644614ffb3bd67ee4": 0xEB42,
-    "bcd2ff1a23290e00482ee1d0d4376a95": 0x233D,
-}
+def parse_hub_mesh_overrides(raw: str) -> dict[str, int]:
+    """Parse the `hub_mesh_overrides` option into {MAC: hub_mesh_id}.
+
+    Format is comma-separated `MAC=id` pairs, id decimal or 0x-hex:
+        "AA:BB:CC:DD:EE:FF=0xEB42, 11:22:33:44:55:66=9021"
+
+    MACs are upper-cased so lookup matches BHyveBleDeviceBase.mac. Malformed
+    pairs are skipped with a warning rather than failing the whole entry — one
+    typo shouldn't take the integration down at setup. Kept HA-free so it is
+    unit-testable standalone (same rationale as accumulate_gallons)."""
+    out: dict[str, int] = {}
+    for chunk in (raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        mac, sep, value = chunk.partition("=")
+        if not sep:
+            _LOGGER.warning("hub_mesh_overrides: missing '=' in %r, skipped", chunk)
+            continue
+        try:
+            hub_id = int(value.strip(), 0)
+        except ValueError:
+            _LOGGER.warning(
+                "hub_mesh_overrides: %r is not a number in %r, skipped",
+                value.strip(), chunk,
+            )
+            continue
+        if not 0 <= hub_id <= 0xFFFF:
+            _LOGGER.warning(
+                "hub_mesh_overrides: %d out of range (0..65535) in %r, skipped",
+                hub_id, chunk,
+            )
+            continue
+        out[mac.strip().upper()] = hub_id
+    return out
 
 
 class BHyveHT25Device(BHyveBleDeviceBase):
@@ -64,6 +89,11 @@ class BHyveHT25Device(BHyveBleDeviceBase):
     _pending_start_duration: int | None = None
     _pending_start_zone: int | None = None
 
+    # User-supplied hub mesh id, from the `hub_mesh_overrides` option. Only
+    # consulted when the cloud record has no bridge_device_id. Set in place by
+    # _async_update_listener, so it tracks an options edit without a reload.
+    hub_mesh_override: int | None = None
+
     @property
     def mesh_address(self) -> bytes:
         """The 2-byte device-address prefix on every command frame.
@@ -80,12 +110,13 @@ class BHyveHT25Device(BHyveBleDeviceBase):
         """The 2-byte hub-address embedded in the magic2 init step."""
         hub_id = self.hub_mesh_device_id
         if hub_id is None:
-            hub_id = _HUB_MESH_BY_NETWORK_KEY.get(self.network_key.lower())
+            hub_id = self.hub_mesh_override
             if hub_id is None:
                 _LOGGER.warning(
-                    "%s: hub_mesh_device_id unresolved (network_key not in fallback "
-                    "table); using 0x0000 in magic2. Init still completes with a "
-                    "placeholder hub id, but if START is dropped this is a suspect.",
+                    "%s: hub_mesh_device_id unresolved (cloud record has no "
+                    "bridge_device_id and no hub_mesh_overrides entry for this MAC); "
+                    "using 0x0000 in magic2. Init still completes with a placeholder "
+                    "hub id, but if START is dropped this is a suspect.",
                     self.mac,
                 )
                 hub_id = 0

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -45,7 +45,8 @@
           "poll_idle_sec": "State polling interval — idle (seconds)",
           "poll_watering_sec": "State polling interval — watering (seconds)",
           "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)",
-          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)"
+          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)",
+          "hub_mesh_overrides": "Hub mesh ID overrides — optional, only if the cloud doesn't report your hub's mesh ID. Comma-separated MAC=id pairs, decimal or 0x-hex (e.g. \"AA:BB:CC:DD:EE:FF=0xEB42\"). Leave blank unless watering commands are being dropped."
         }
       }
     }

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -45,7 +45,8 @@
           "poll_idle_sec": "State polling interval — idle (seconds)",
           "poll_watering_sec": "State polling interval — watering (seconds)",
           "flow_counts_per_gallon": "Flow calibration (sensor counts per gallon)",
-          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)"
+          "mesh_status_poll": "Mesh live status poll — HT25 connects over BLE on each idle poll to read watering state and battery (costs battery: ~96 connects/day at the default cadence)",
+          "hub_mesh_overrides": "Hub mesh ID overrides — optional, only if the cloud doesn't report your hub's mesh ID. Comma-separated MAC=id pairs, decimal or 0x-hex (e.g. \"AA:BB:CC:DD:EE:FF=0xEB42\"). Leave blank unless watering commands are being dropped."
         }
       }
     }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -62,7 +62,7 @@ def test_redact_entry_shaped_dict():
             "password": "hunter2",
             "devices": [
                 {"cloud_id": "abc", "mac": "AA:BB:CC:DD:EE:FF",
-                 "network_key": "f0983e39083a335644614ffb3bd67ee4"},
+                 "network_key": "00112233445566778899aabbccddeeff"},
                 {"cloud_id": "hub", "mac": "11:22:33:44:55:66", "network_key": ""},
             ],
         },

--- a/tests/test_hub_mesh_override.py
+++ b/tests/test_hub_mesh_override.py
@@ -1,0 +1,77 @@
+"""hub_mesh_overrides option parsing + the magic2 hub-address fallback.
+
+Replaces the hardcoded _HUB_MESH_BY_NETWORK_KEY table that used to live in
+ht25.py. Covers the parse format, malformed-input tolerance, and the three-tier
+resolution in hub_mesh_address (cloud record -> override -> 0x0000 placeholder).
+No hardware or Home Assistant required.
+"""
+from __future__ import annotations
+
+from orbit_bhyve.devices.ht25 import BHyveHT25Device, parse_hub_mesh_overrides
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+def _dev(hub_mesh_device_id=None, mac: str = MAC) -> BHyveHT25Device:
+    record = {
+        "cloud_id": "abc", "name": "Deck", "mac": mac,
+        "hardware": "HT25-0000", "firmware": "0085", "stations": 1,
+        "network_key": "", "mesh_device_id": 0x47D7,
+        "hub_mesh_device_id": hub_mesh_device_id,
+    }
+    return BHyveHT25Device(None, record)
+
+
+# --- parsing ---------------------------------------------------------------
+
+def test_parses_hex_and_decimal():
+    got = parse_hub_mesh_overrides("AA:BB:CC:DD:EE:FF=0xEB42, 11:22:33:44:55:66=9021")
+    assert got == {"AA:BB:CC:DD:EE:FF": 0xEB42, "11:22:33:44:55:66": 9021}
+
+
+def test_empty_and_blank_yield_empty_map():
+    assert parse_hub_mesh_overrides("") == {}
+    assert parse_hub_mesh_overrides("   ,  , ") == {}
+
+
+def test_mac_is_uppercased_to_match_device_mac():
+    # BHyveBleDeviceBase.mac is upper-case, so lookup must not be case-sensitive
+    # on what the user typed into the options box.
+    assert parse_hub_mesh_overrides("aa:bb:cc:dd:ee:ff=1") == {MAC: 1}
+
+
+def test_malformed_pairs_are_skipped_not_fatal():
+    # One typo must not take the whole entry down at setup.
+    got = parse_hub_mesh_overrides(
+        f"nonsense, {MAC}=0xEB42, 11:22:33:44:55:66=notanumber"
+    )
+    assert got == {MAC: 0xEB42}
+
+
+def test_out_of_range_ids_are_skipped():
+    # The value is written into a 2-byte field; anything wider is a typo.
+    assert parse_hub_mesh_overrides(f"{MAC}=65536") == {}
+    assert parse_hub_mesh_overrides(f"{MAC}=-1") == {}
+    assert parse_hub_mesh_overrides(f"{MAC}=65535") == {MAC: 0xFFFF}
+
+
+# --- hub_mesh_address resolution -------------------------------------------
+
+def test_cloud_record_wins_over_override():
+    dev = _dev(hub_mesh_device_id=0x1234)
+    dev.hub_mesh_override = 0xEB42
+    assert dev.hub_mesh_address == (0x1234).to_bytes(2, "little")
+
+
+def test_override_used_when_cloud_record_lacks_bridge():
+    dev = _dev(hub_mesh_device_id=None)
+    dev.hub_mesh_override = 0xEB42
+    assert dev.hub_mesh_address == (0xEB42).to_bytes(2, "little")
+
+
+def test_placeholder_when_neither_available():
+    # Init still completes with 0x0000 — the pre-existing documented behaviour
+    # for an unresolved hub, now also the path when no override is configured.
+    dev = _dev(hub_mesh_device_id=None)
+    assert dev.hub_mesh_override is None
+    assert dev.hub_mesh_address == b"\x00\x00"


### PR DESCRIPTION
`devices/ht25.py` carried `_HUB_MESH_BY_NETWORK_KEY`, a dict mapping two 32-hex strings to hub mesh ids. Those strings are AES-128 BLE network keys — `connection.py` does `bytes.fromhex(network_key)` and feeds the result to `AES(self._key)` — so the repo was publishing working keys for two real mesh networks. `tests/test_diagnostics.py` carried one of them as a fixture.

Reported privately by @FabsFabios, who found it during a static pass and deliberately left it out of #43 rather than ripping unrelated working code out of someone else's project. Good call, and the right way to handle it.

## Why not just delete the dict

The table is a live fallback: `hub_mesh_address` uses it when the cloud record has no `bridge_device_id`, and `magic2` needs a hub id. Deleting it alone `NameError`s, and deleting the lookup too would silently drop affected setups onto the `0x0000` placeholder — the existing comment already warns that's a suspect when START gets dropped.

So the value moves out of source rather than disappearing:

- **New `hub_mesh_overrides` option** — comma-separated `MAC=id` pairs, id decimal or `0x`-hex, e.g. `AA:BB:CC:DD:EE:FF=0xEB42`. Keyed by **MAC**, so configuring it needs nothing secret.
- `parse_hub_mesh_overrides()` is a pure function, HA-free and unit-tested, following the `accumulate_gallons` precedent. Malformed pairs are skipped with a warning rather than failing setup — one typo shouldn't take the integration down.
- Applied in place by `_async_update_listener` alongside the other tuning options, so an edit takes effect without the reload that would wipe in-progress run state.
- `hub_mesh_address` resolution is now: cloud record → user override → `0x0000` placeholder + warning.

## Impact

Unchanged for anyone whose cloud record has `bridge_device_id`. Anyone relying on the removed table lands on the placeholder path and can restore exact prior behaviour by setting the option — the warning names the option so it's self-directing.

## Verification

- 194 passed (186 baseline + 8 new).
- New `tests/test_hub_mesh_override.py` covers the parse format, MAC upper-casing, malformed and out-of-range tolerance, and all three resolution tiers.
- Scripted check that neither key appears anywhere in the working tree — clean.
- Test fixture replaced with an obvious dummy (`00112233...eeff`).

## What this does NOT fix

Both keys remain in git history from the initial commit, and in every existing clone and fork. **They should be treated as compromised regardless of this PR.** The exposure is proximity-gated — an attacker needs BLE range — but within range the keys allow decrypting and forging valve traffic. Rotation (if the devices support it) is the real remedy; history rewriting is a separate decision and can't reach existing forks.