### PR TITLE
fix(devices): key HT25 mesh vs protobuf routing on hardware suffix, not firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ when the WAN goes down.
 | Hose-tap timer    | `HT25-0000`    | `0085`           | ✅ Actuated end-to-end                   |
 | Hose-tap timer    | `HT25-0000`    | `0041`           | ✅ Actuated end-to-end (per-device mesh-ID addressing) |
 | Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
+| Hose-tap timer (Gen2, 90205Z) | `HT25A-0001` | `0098`  | ✅ Connect/actuate verified by community member (issue #47); flow-sensor readings not yet confirmed on this variant |
 | 4-port XD         | `HT34A-0001`   | `0107`           | ✅ Battery/status decode verified on hardware; XD actuation proven via HT32A sibling |
 | 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
 | 2-port XD         | `HT32A-0001`   | `0107`           | ✅ Actuated end-to-end (shares the HT34A XD protobuf protocol) |

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -31,20 +31,23 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
     if type_ == "bridge":
         return BHyveHubDevice
     if (hardware or "").startswith("HT25"):
-        # Gen2 HT25G2 valves (fw0111) share the "HT25" hardware prefix but
-        # speak the protobuf protocol (frame magic 0x11) like the HT34A XD,
-        # NOT the d7-47 mesh protocol of the HT25-0000 hose timers. Route
-        # them away from the mesh classes before falling through. Match on
-        # the hardware suffix or fw so HT25-0000 (fw0041/0085) is untouched.
-        if (hardware or "").startswith("HT25G2") or firmware == "0111":
-            return BHyveHT25G2Device
-        # HT25-0000 mesh (d7-47) firmwares. fw0085 keeps upstream's thin
-        # subclass (retains _rebind_sid_delta=3, community-verified); fw0041 and
-        # any other fw use the parameterized base, which builds frames from the
-        # device's own mesh_device_id (not a hardcoded identity).
-        if firmware == "0085":
-            return BHyveHT25Fw0085Device
-        return BHyveHT25Device
+        # Mesh d7-47 hose timers are the only HT25 devices ever observed
+        # reporting the "-0000" hardware suffix — treat that as the
+        # authoritative signal rather than pinning to a firmware whitelist,
+        # which drifts every time Orbit ships a new build (e.g. a fw0098
+        # HT25G2 unit, upstream issue #47). Everything else under the HT25
+        # prefix — HT25G2-0001, the bare HT25-0001 variant, or any future
+        # firmware on either — speaks the protobuf protocol (frame magic
+        # 0x11) like the HT34A XD.
+        if (hardware or "").endswith("-0000"):
+            # fw0085 keeps upstream's thin subclass (retains
+            # _rebind_sid_delta=3, community-verified); fw0041 and any other
+            # fw use the parameterized base, which builds frames from the
+            # device's own mesh_device_id (not a hardcoded identity).
+            if firmware == "0085":
+                return BHyveHT25Fw0085Device
+            return BHyveHT25Device
+        return BHyveHT25G2Device
     if (hardware or "").startswith("HT34"):
         # Both HT34A-0001 and HT34-0001 (fw0058) use the protobuf XD protocol.
         # The older HT34 sharing it is the stuartdenne fork's claim (2026-06-27),

--- a/custom_components/orbit_bhyve/devices/__init__.py
+++ b/custom_components/orbit_bhyve/devices/__init__.py
@@ -35,10 +35,14 @@ def resolve_device_class(*, hardware: str, firmware: str, type_: str) -> type[BH
         # reporting the "-0000" hardware suffix — treat that as the
         # authoritative signal rather than pinning to a firmware whitelist,
         # which drifts every time Orbit ships a new build (e.g. a fw0098
-        # HT25G2 unit, upstream issue #47). Everything else under the HT25
-        # prefix — HT25G2-0001, the bare HT25-0001 variant, or any future
-        # firmware on either — speaks the protobuf protocol (frame magic
-        # 0x11) like the HT34A XD.
+        # HT25A-0001 unit, upstream issue #47). Everything else under the
+        # HT25 prefix — HT25G2-0001, the bare HT25-0001 variant, or any
+        # future firmware on either — speaks the protobuf protocol (frame
+        # magic 0x11) like the HT34A XD. The explicit "HT25G2" prefix is
+        # checked first since it's the strongest signal and should win over
+        # the suffix heuristic even for an (unobserved) "HT25G2-0000".
+        if (hardware or "").startswith("HT25G2"):
+            return BHyveHT25G2Device
         if (hardware or "").endswith("-0000"):
             # fw0085 keeps upstream's thin subclass (retains
             # _rebind_sid_delta=3, community-verified); fw0041 and any other

--- a/custom_components/orbit_bhyve/devices/ht25g2.py
+++ b/custom_components/orbit_bhyve/devices/ht25g2.py
@@ -4,8 +4,8 @@ Protobuf protocol family — the SAME framing, cipher, and timerMode start
 message as the HT34A XD timer (frame magic 0x11), NOT the d7-47 mesh
 protocol the older HT25-0000 hose timers (fw0041/0085) speak. Sharing a
 "HT25" hardware prefix with those mesh devices is the only thing they have
-in common; the dispatcher in __init__.py disambiguates by hardware-suffix /
-firmware so these land here instead of on BHyveHT25Device.
+in common; the dispatcher in __init__.py disambiguates by hardware suffix
+("-0000" = mesh) so these land here instead of on BHyveHT25Device.
 
 The protocol logic lives in `protobuf.BHyveProtobufDevice`, shared with the
 HT34A XD: both are protobuf-family valves differing only in log label and

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -36,9 +36,11 @@ from orbit_bhyve.devices.protobuf import BHyveProtobufDevice
         ("HT34A-0001", "0107", "", BHyveHT34ADevice),     # XD 4-port
         ("HT31-0001", "0058", "", BHyveHT34ADevice),      # 1-port Smart Hose Tap (XD protobuf)
         ("HT25G2-0001", "0111", "", BHyveHT25G2Device),   # Gen2 by suffix
-        ("HT25-0001", "0111", "", BHyveHT25G2Device),       # Gen2 by fw0111
-        ("HT25-0001", "0085", "", BHyveHT25Fw0085Device),   # mesh fw0085 (upstream subclass)
-        ("HT25-0001", "0041", "", BHyveHT25Device),         # mesh base (fw0041)
+        ("HT25-0001", "0111", "", BHyveHT25G2Device),       # Gen2, bare hardware string
+        ("HT25-0000", "0085", "", BHyveHT25Fw0085Device),   # mesh fw0085 (upstream subclass)
+        ("HT25-0000", "0041", "", BHyveHT25Device),         # mesh base (fw0041)
+        ("HT25G2-0001", "0098", "", BHyveHT25G2Device),     # Gen2, unseen firmware (issue #47)
+        ("HT25-0001", "0098", "", BHyveHT25G2Device),       # Gen2, bare hardware + unseen firmware
     ],
 )
 def test_resolve_routes(hardware, firmware, type_, expected):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -41,6 +41,8 @@ from orbit_bhyve.devices.protobuf import BHyveProtobufDevice
         ("HT25-0000", "0041", "", BHyveHT25Device),         # mesh base (fw0041)
         ("HT25G2-0001", "0098", "", BHyveHT25G2Device),     # Gen2, unseen firmware (issue #47)
         ("HT25-0001", "0098", "", BHyveHT25G2Device),       # Gen2, bare hardware + unseen firmware
+        ("HT25A-0001", "0098", "", BHyveHT25G2Device),      # issue #47, HW-verified (quadcom)
+        ("HT25G2-0000", "0111", "", BHyveHT25G2Device),     # explicit G2 prefix wins over -0000 suffix
     ],
 )
 def test_resolve_routes(hardware, firmware, type_, expected):


### PR DESCRIPTION
Fixes #47.

### The bug

`resolve_device_class()` disambiguates the shared `"HT25"` hardware prefix between the
mesh (d7-47) and protobuf (0x11) protocol families by checking
`hardware.startswith("HT25G2")` OR `firmware == "0111"`, and falls back to the **mesh**
class for anything matching neither.

That default is backwards. Every mesh device ever observed reports hardware
`HT25-0000`, while the known non-`G2` protobuf hardware string (`HT25-0001`) has no such
suffix. Pinning the protobuf branch to the single firmware literal `"0111"` means any
newer firmware build on protobuf-family hardware that isn't `G2`-prefixed silently
misroutes to the mesh class, which speaks a different wire protocol. The device still
gets discovered and added (cloud-backed setup doesn't touch the wire protocol), but the
BLE session never completes and the device stays unusable.

This is exactly what #47 reports: a `90205Z` (Gen2 single-station) unit on `fw0098`
reporting hardware `HT25A-0001` — a variant not covered by either branch of the old
check — gets added but never connects.

### The fix

Check the explicit `HT25G2` prefix first, then key the remaining fallback off the
`-0000` hardware suffix (the only signal ever observed on real mesh hardware) to select
the mesh class; everything else under the `HT25` prefix defaults to the protobuf class.
This removes the firmware whitelist entirely, so future firmware drift on either family
can no longer misroute a device across protocol families.

Routing for `HT25-0000` (mesh) and `HT25G2-0001` (protobuf) on every previously-observed
firmware is unchanged. One combination does change: `HT25-0001` on `fw0085`/`fw0041`
routed to mesh under the old firmware whitelist; those rows in the prior test suite were
synthetic (no unit reporting that hardware/firmware pair has actually been observed), and
the rest of the codebase already treats `HT25-0001` as protobuf-family hardware. This PR
routes it there consistently instead.

### Verification

- `resolve_device_class()` unit tests in `tests/test_devices.py` (`test_resolve_routes`),
  including the `HT25A-0001` string from #47 and a case confirming the `HT25G2` prefix
  takes priority over the `-0000` suffix.
- 231/231 local pytest green.
- Hardware-verified by @quadcom (issue #47) on his `90205Z` unit
  (hardware `HT25A-0001`, fw `0098`) — confirmed the branch resolves the device to the
  protobuf class and it connects/actuates correctly after a full HA restart (not just a
  config-entry reload — custom-component modules are cached in-process, so file changes
  need a real restart to take effect).

### Notes for review

- Updated per review: `HT25G2` prefix now checked before the `-0000` suffix, added the
  `HT25A-0001`/`HT25G2-0000` test cases, fixed the stale dispatcher comment in
  `ht25g2.py`, and added the `HT25A-0001` row to the README support table.
- Following up on #47 to ask whether the flow sensor populates on quadcom's unit, since
  `has_flow` now applies to `HT25A-0001` and `HT25-0001` as a side effect of routing —
  will report back here.
- Diff is scoped to `custom_components/orbit_bhyve/devices/__init__.py` (dispatcher),
  `devices/ht25g2.py` (comment), `tests/test_devices.py`, and the README table.
