### PR TITLE
feat(config-flow): add reconfigure flow so devices bought after setup appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ when the WAN goes down.
 | Hose-tap timer    | `HT25-0000`    | `0085`           | ✅ Actuated end-to-end                   |
 | Hose-tap timer    | `HT25-0000`    | `0041`           | ✅ Actuated end-to-end (per-device mesh-ID addressing) |
 | Hose-tap timer (Gen2) | `HT25G2-0001` | `0111`          | ✅ Actuated end-to-end (protobuf protocol) |
-| Hose-tap timer (Gen2, 90205Z) | `HT25A-0001` | `0098`  | ✅ Connect/actuate verified by community member (issue #47); flow-sensor readings not yet confirmed on this variant |
+| Hose-tap timer (Gen2, 90205Z) | `HT25A-0001` | `0098`  | ✅ Actuated end-to-end on hardware, plus programs (A–D) and rain delay / next run; flow-sensor readings not yet confirmed on this variant |
 | 4-port XD         | `HT34A-0001`   | `0107`           | ✅ Battery/status decode verified on hardware; XD actuation proven via HT32A sibling |
 | 4-port XD         | `HT34-0001`    | `0058`           | ⚠️ Shares the XD protobuf protocol; not tested here |
 | 2-port XD         | `HT32A-0001`   | `0107`           | ✅ Actuated end-to-end (shares the HT34A XD protobuf protocol) |
@@ -170,7 +170,11 @@ registry.
 - `orbit_bhyve.start_watering` — `entity_id` + optional `duration` (sec)
 - `orbit_bhyve.stop_all` — stop everything on the targeted device
 - `orbit_bhyve.refresh_devices` — re-query the cloud (for new devices, key
-  rotation, or fw changes); manual, no background polling
+  rotation, or fw changes) and **merge** the result: adds new devices, keeps
+  devices you excluded excluded, and never overwrites a working network key or
+  mesh ID with a blank one. Optional `config_entry_id` targets one account;
+  omit it to refresh all. Manual, no background polling. For a UI equivalent
+  with a device picker, use **Reconfigure** (below)
 - `orbit_bhyve.get_program` — read back a program slot (A–F) as structured
   data (`SupportsResponse.ONLY`): days, start times, per-zone durations
 - `orbit_bhyve.set_program` — store/replace a program in a slot: watering
@@ -206,9 +210,41 @@ registry.
   over BLE on each idle poll to read live watering state and battery.
   Battery trade-off: ~96 connects/day at the default idle cadence
 
+## Reconfigure (adding a device you bought later)
+
+The device list is captured in the config entry at setup and is **not**
+refreshed by a reload or an HA restart, so a newly-purchased timer won't appear
+on its own. Adding the account a second time doesn't work either — the entry is
+keyed on your email, so the flow aborts with "already configured".
+
+Settings → Devices & Services → Orbit B-Hyve BLE → ⋮ → **Reconfigure**:
+
+1. Re-runs cloud discovery with the saved credentials. You're only prompted for
+   a password if Orbit rejects them
+2. Re-shows the device picker. **New devices are pre-checked**; devices you
+   excluded before stay unchecked
+3. Devices the cloud no longer returns are labelled *"no longer on the Orbit
+   account"* and stay pre-checked — they keep working over BLE. Uncheck one to
+   remove it and its entities. This is deliberate: cloud discovery skips
+   anything missing a `mesh_id`, so a partial response must not silently delete
+   a working device
+4. Submitting updates the entry and reloads it
+
+Two things worth knowing:
+
+- The **first** reconfigure of an entry created before this feature existed may
+  show previously-excluded devices as checked, because the old entry never
+  recorded which ones you excluded. Uncheck them once and the choice sticks.
+- Re-discovery never overwrites a working `network_key` or `hub_mesh_device_id`
+  with a blank cloud value. This matters if you rely on **Hub mesh ID
+  overrides** — a partial `/networks` response would otherwise drop the device
+  back to the `0x0000` placeholder and your watering commands would start
+  getting dropped with only a log warning to show for it.
+
 ## How it works
 
-1. **Setup**: log into Orbit cloud once → fetch device list → fetch one AES
+1. **Setup**: log into Orbit cloud at setup — and again only when you
+   reconfigure or call `refresh_devices` → fetch device list → fetch one AES
    network key per mesh → cache everything in the config entry
 2. **Per command**: the integration's pooled BLE connection (one per device)
    does an AES handshake, runs the model-specific init sequence on first

--- a/custom_components/orbit_bhyve/__init__.py
+++ b/custom_components/orbit_bhyve/__init__.py
@@ -2,7 +2,8 @@
 
 Discovers all devices on an Orbit account, instantiates a per-device class
 based on hardware/firmware, and creates entity platforms. Cloud is touched
-only at setup time and on user-triggered refresh; runtime is BLE-only.
+only at setup time and on a user-triggered refresh (the refresh_devices service
+or the reconfigure flow); runtime is BLE-only.
 """
 from __future__ import annotations
 
@@ -13,29 +14,24 @@ from typing import Any
 
 import voluptuous as vol
 from bleak.exc import BleakError
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
     ConfigEntryNotReady,
     HomeAssistantError,
     ServiceValidationError,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .cloud import CloudAuthError, CloudConnectionError, OrbitCloudClient
 from .const import (
     CONF_DEFAULT_DURATION,
     CONF_DEVICES,
-    CONF_EMAIL,
     CONF_FLOW_COUNTS_PER_GALLON,
     CONF_IDLE_DISCONNECT,
     CONF_HUB_MESH_OVERRIDES,
     CONF_MESH_STATUS_POLL,
-    CONF_PASSWORD,
     CONF_POLL_IDLE,
     CONF_POLL_WATERING,
     DEFAULT_DURATION,
@@ -59,6 +55,7 @@ from .devices.base import (
     validate_program_name,
 )
 from .devices.protobuf import BHyveProtobufDevice
+from .refresh import async_refresh_entry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +125,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime
 
+    # Before the platforms recreate device entries: drop registry devices the
+    # user removed via the reconfigure picker, so they don't linger forever as
+    # unavailable. Must run here, not after the forward.
+    _purge_unconfigured_devices(
+        hass, entry, {r["cloud_id"] for r in devices if r.get("cloud_id")}
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     _register_services(hass)
@@ -154,6 +158,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _purge_unconfigured_devices(
+    hass: HomeAssistant, entry: ConfigEntry, keep: set[str]
+) -> None:
+    """Drop registry devices whose cloud_id is no longer in CONF_DEVICES.
+
+    Keyed off CONF_DEVICES, NOT runtime.coordinators: build_device legitimately
+    skips an UnsupportedModel while the record stays configured, and purging on
+    that would delete a device the user still owns. CONF_DEVICES only shrinks
+    from an explicit user action in the reconfigure picker, so this is
+    deterministic rather than driven by whatever the cloud happened to return.
+    """
+    reg = dr.async_get(hass)
+    for dev in dr.async_entries_for_config_entry(reg, entry.entry_id):
+        ids = {i[1] for i in dev.identifiers if i[0] == DOMAIN}
+        if ids and not (ids & keep):
+            _LOGGER.debug("%s: removing unconfigured device %s", entry.entry_id, ids)
+            reg.async_update_device(dev.id, remove_config_entry_id=entry.entry_id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Enable the device page's delete button once a device is deconfigured.
+
+    Refuses while the device is still in CONF_DEVICES — the supported way to
+    remove one is to uncheck it in the reconfigure picker, which then makes this
+    return True on the next setup.
+    """
+    cloud_ids = {i[1] for i in device_entry.identifiers if i[0] == DOMAIN}
+    configured = {
+        r.get("cloud_id") for r in entry.data.get(CONF_DEVICES, [])
+    }
+    return not (cloud_ids & configured)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     runtime: EntryRuntime | None = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     if runtime:
@@ -176,10 +215,15 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     (a full HA restart) clears the stale session. So for our tuning options (flow
     calibration, poll intervals, idle disconnect) we mutate the live coordinators
     instead. Device-list/credential changes take a different path
-    (refresh_devices / reauth) that reloads explicitly."""
+    (refresh_devices / reconfigure / reauth) that reloads explicitly."""
     runtime: EntryRuntime | None = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     if runtime is None:
-        await hass.config_entries.async_reload(entry.entry_id)
+        # Those explicit paths call async_update_entry (which fires this
+        # listener) and then reload themselves. Without the state guard the two
+        # reloads overlap on one entry — so only reload when nothing else is
+        # already mid-flight.
+        if entry.state is ConfigEntryState.LOADED:
+            await hass.config_entries.async_reload(entry.entry_id)
         return
     opts = entry.options
     idle_disconnect = opts.get(CONF_IDLE_DISCONNECT, DEFAULT_IDLE_DISCONNECT)
@@ -300,27 +344,27 @@ def _register_services(hass: HomeAssistant) -> None:
         return
 
     async def refresh_devices(call: ServiceCall) -> None:
-        for entry in hass.config_entries.async_entries(DOMAIN):
-            email = entry.data.get(CONF_EMAIL)
-            password = entry.data.get(CONF_PASSWORD)
-            if not (email and password):
-                continue
-            client = OrbitCloudClient(async_get_clientsession(hass))
-            try:
-                discovered = await client.discover(email, password)
-            except CloudAuthError as err:
-                _LOGGER.error("Refresh: auth failed for %s: %s", email, err)
-                raise ConfigEntryAuthFailed(str(err)) from err
-            except CloudConnectionError as err:
-                _LOGGER.error("Refresh: cloud unreachable for %s: %s", email, err)
-                continue
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_DEVICES: discovered},
-            )
-            await hass.config_entries.async_reload(entry.entry_id)
+        wanted = call.data.get("config_entry_id")
+        entries = hass.config_entries.async_entries(DOMAIN)
+        if wanted:
+            wanted_ids = set(wanted)
+            entries = [e for e in entries if e.entry_id in wanted_ids]
+            if not entries:
+                raise ServiceValidationError(
+                    f"No orbit_bhyve config entry matches {sorted(wanted_ids)}"
+                )
+        for entry in entries:
+            await async_refresh_entry(hass, entry)
 
     hass.services.async_register(
-        DOMAIN, "refresh_devices", refresh_devices, schema=vol.Schema({}),
+        DOMAIN,
+        "refresh_devices",
+        refresh_devices,
+        # Optional target; omitting it keeps the historical all-entries
+        # behaviour so existing automations don't change meaning.
+        schema=vol.Schema({
+            vol.Optional("config_entry_id"): vol.All(cv.ensure_list, [cv.string]),
+        }),
     )
 
     async def start_watering(call: ServiceCall) -> None:

--- a/custom_components/orbit_bhyve/config_flow.py
+++ b/custom_components/orbit_bhyve/config_flow.py
@@ -4,6 +4,11 @@ Two-step setup:
   1. Email + password → cloud login + device discovery.
   2. Device picker — uncheck any to exclude.
 
+Reconfigure flow (⋮ → Reconfigure) re-runs discovery against the same account
+and re-shows the picker, so a device bought after setup can be added without
+deleting the entry — entry.data[CONF_DEVICES] is otherwise a frozen snapshot
+that async_setup_entry never refreshes.
+
 Reauth flow re-prompts only the password.
 Options flow exposes polling intervals + idle disconnect.
 """
@@ -34,6 +39,7 @@ from .const import (
     CONF_MESH_STATUS_POLL,
     CONF_IDLE_DISCONNECT,
     CONF_INCLUDE,
+    CONF_KNOWN_CLOUD_IDS,
     CONF_PASSWORD,
     CONF_POLL_IDLE,
     CONF_POLL_WATERING,
@@ -46,6 +52,7 @@ from .const import (
     DEFAULT_POLL_WATERING,
     DOMAIN,
 )
+from .merge import default_selection, merge_device_lists, next_known_ids
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +64,32 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._email: str | None = None
         self._password: str | None = None
         self._discovered: list[dict[str, Any]] = []
+        # Reconfigure-only state.
+        self._stored: list[dict[str, Any]] = []      # entry.data[CONF_DEVICES]
+        self._catalogue: list[dict[str, Any]] = []   # discovered + stored-only survivors
+        self._default_ids: list[str] = []            # picker pre-check set
+
+    async def _async_discover(self) -> str | None:
+        """Run cloud discovery into self._discovered.
+
+        Returns a strings.json error key, or None on success. Shared by the
+        setup, reconfigure and reconfigure-auth steps so all three classify
+        cloud failures identically.
+        """
+        client = OrbitCloudClient(async_get_clientsession(self.hass))
+        try:
+            self._discovered = await client.discover(self._email, self._password)
+        except CloudAuthError:
+            return "invalid_auth"
+        except CloudConnectionError:
+            return "cannot_connect"
+        except CloudKeyNotFound as err:
+            _LOGGER.error("Network key fetch failed: %s", err)
+            return "unknown"
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Unexpected error during discovery")
+            return "unknown"
+        return None if self._discovered else "no_devices"
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
@@ -68,24 +101,10 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(self._email.lower())
             self._abort_if_unique_id_configured()
 
-            client = OrbitCloudClient(async_get_clientsession(self.hass))
-            try:
-                self._discovered = await client.discover(self._email, self._password)
-            except CloudAuthError:
-                errors["base"] = "invalid_auth"
-            except CloudConnectionError:
-                errors["base"] = "cannot_connect"
-            except CloudKeyNotFound as err:
-                _LOGGER.error("Network key fetch failed: %s", err)
-                errors["base"] = "unknown"
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Unexpected error during discovery")
-                errors["base"] = "unknown"
-            else:
-                if not self._discovered:
-                    errors["base"] = "no_devices"
-                else:
-                    return await self.async_step_pick_devices()
+            error = await self._async_discover()
+            if error is None:
+                return await self.async_step_pick_devices()
+            errors["base"] = error
 
         schema = vol.Schema({
             vol.Required(CONF_EMAIL, default=self._email or ""): str,
@@ -93,9 +112,58 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
+    def _picker_form(
+        self, step_id: str, errors: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
+        """Shared device-picker form for the setup and reconfigure paths."""
+        stored_ids = {r["cloud_id"] for r in self._stored}
+        discovered_ids = {r["cloud_id"] for r in self._discovered}
+
+        options_list = [
+            SelectOptionDict(
+                value=d["cloud_id"],
+                label=f"{d['name']} ({d['hardware']} fw{d['firmware']})"
+                + (
+                    ""
+                    if d["cloud_id"] in discovered_ids
+                    else "  —  no longer on the Orbit account"
+                ),
+            )
+            for d in self._catalogue
+        ]
+        schema = vol.Schema({
+            vol.Required(CONF_INCLUDE, default=self._default_ids): SelectSelector(
+                SelectSelectorConfig(
+                    options=options_list,
+                    multiple=True,
+                    mode=SelectSelectorMode.LIST,
+                )
+            ),
+        })
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "count": str(len(self._catalogue)),
+                "new": str(len([c for c in self._default_ids if c not in stored_ids])),
+                "missing": str(
+                    len([r for r in self._catalogue if r["cloud_id"] not in discovered_ids])
+                ),
+            },
+        )
+
     async def async_step_pick_devices(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        self._catalogue = list(self._discovered)
+        self._default_ids = [d["cloud_id"] for d in self._discovered]
+
         if user_input is not None:
             included = set(user_input[CONF_INCLUDE] or [])
+            if not included:
+                # vol.Required accepts [] on a multi-select, and an empty device
+                # list makes async_setup_entry return False — the entry would be
+                # bricked with nothing but a log warning to explain it.
+                return self._picker_form("pick_devices", {"base": "no_devices_selected"})
             kept = [d for d in self._discovered if d["cloud_id"] in included]
             return self.async_create_entry(
                 title=self._email or "B-Hyve",
@@ -103,6 +171,7 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_EMAIL: self._email,
                     CONF_PASSWORD: self._password,
                     CONF_DEVICES: kept,
+                    CONF_KNOWN_CLOUD_IDS: next_known_ids(None, [], self._default_ids),
                 },
                 options={
                     CONF_DEFAULT_DURATION: DEFAULT_DURATION,
@@ -114,29 +183,97 @@ class BHyveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        options_list = [
-            SelectOptionDict(
-                value=d["cloud_id"],
-                label=f"{d['name']} ({d['hardware']} fw{d['firmware']})",
-            )
-            for d in self._discovered
-        ]
-        defaults = [d["cloud_id"] for d in self._discovered]
+        return self._picker_form("pick_devices")
 
-        schema = vol.Schema({
-            vol.Required(CONF_INCLUDE, default=defaults): SelectSelector(
-                SelectSelectorConfig(
-                    options=options_list,
-                    multiple=True,
-                    mode=SelectSelectorMode.LIST,
-                )
-            ),
-        })
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """⋮ → Reconfigure: re-run cloud discovery and re-show the device picker.
+
+        Saved credentials are reused silently; only a CloudAuthError drops the
+        user to a password prompt.
+        """
+        entry = self._get_reconfigure_entry()
+        self._email = entry.data.get(CONF_EMAIL)
+        self._password = entry.data.get(CONF_PASSWORD)
+        self._stored = list(entry.data.get(CONF_DEVICES, []))
+
+        if not (self._email and self._password):
+            return await self.async_step_reconfigure_auth()
+
+        error = await self._async_discover()
+        if error == "invalid_auth":
+            return await self.async_step_reconfigure_auth()
+        if error is not None:
+            # No form is on screen yet, so there's nowhere to render an inline
+            # error — abort with a reason the user can read, entry untouched.
+            return self.async_abort(reason=error)
+        return await self.async_step_reconfigure_devices()
+
+    async def async_step_reconfigure_auth(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Password re-prompt when the saved credential no longer authenticates.
+
+        The password captured here is written back to entry.data by the finish
+        path, so a reconfigure doubles as a reauth.
+        """
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._password = user_input[CONF_PASSWORD]
+            error = await self._async_discover()
+            if error is None:
+                return await self.async_step_reconfigure_devices()
+            errors["base"] = error
+
         return self.async_show_form(
-            step_id="pick_devices",
-            data_schema=schema,
-            description_placeholders={"count": str(len(self._discovered))},
+            step_id="reconfigure_auth",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
+            description_placeholders={"email": self._email or ""},
         )
+
+    async def async_step_reconfigure_devices(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        entry = self._get_reconfigure_entry()
+        stored_ids = [r["cloud_id"] for r in self._stored]
+        discovered_ids = {r["cloud_id"] for r in self._discovered}
+
+        # Catalogue = fresh discovery, plus still-configured devices the cloud no
+        # longer returns. Keeping the vanished ones visible and pre-checked is
+        # deliberate: discover() silently skips bridges and anything without a
+        # mesh_id, so a partial response must not delete a working BLE device.
+        self._catalogue = list(self._discovered) + [
+            r for r in self._stored if r["cloud_id"] not in discovered_ids
+        ]
+        known = entry.data.get(CONF_KNOWN_CLOUD_IDS)  # None => pre-reconfigure entry
+        catalogue_ids = [r["cloud_id"] for r in self._catalogue]
+        self._default_ids = default_selection(stored_ids, known, catalogue_ids)
+
+        if user_input is not None:
+            included = set(user_input[CONF_INCLUDE] or [])
+            if not included:
+                return self._picker_form(
+                    "reconfigure_devices", {"base": "no_devices_selected"}
+                )
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    **entry.data,
+                    CONF_PASSWORD: self._password,  # picked up if reconfigure_auth ran
+                    CONF_DEVICES: merge_device_lists(
+                        self._stored, self._discovered, included
+                    ),
+                    CONF_KNOWN_CLOUD_IDS: next_known_ids(
+                        known, stored_ids, catalogue_ids
+                    ),
+                },
+            )
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reconfigure_successful")
+
+        return self._picker_form("reconfigure_devices")
+
+    def _get_reconfigure_entry(self) -> ConfigEntry:
+        # Deliberately shadows HA >= 2024.11's ConfigFlow._get_reconfigure_entry
+        # so this flow still works on the 2024.6 floor declared in hacs.json —
+        # same trick as _get_reauth_entry below.
+        return self.hass.config_entries.async_get_entry(self.context["entry_id"])
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         self._email = entry_data.get(CONF_EMAIL)

--- a/custom_components/orbit_bhyve/const.py
+++ b/custom_components/orbit_bhyve/const.py
@@ -38,6 +38,12 @@ CLOUD_KEY_FIELDS = ("ble_network_key", "network_key")
 CONF_EMAIL = "email"
 CONF_PASSWORD = "password"
 CONF_DEVICES = "devices"
+# Every cloud_id ever offered in a device picker — kept AND excluded. Lets the
+# reconfigure flow tell "you unchecked this on purpose" apart from "this is new
+# hardware", which CONF_DEVICES alone can't express (it only holds the keepers).
+# Append-only, so a bug degrades to a device showing up pre-checked in a form
+# the user is looking at, never to a device being permanently hidden.
+CONF_KNOWN_CLOUD_IDS = "known_cloud_ids"
 CONF_INCLUDE = "include"
 CONF_DEFAULT_DURATION = "default_duration_sec"
 CONF_IDLE_DISCONNECT = "idle_disconnect_sec"
@@ -89,7 +95,12 @@ DEFAULT_FLOW_COUNTS_PER_GALLON = 433
 #     "mesh_id":        str,
 #     "mesh_device_id": int | None,
 #     "bridge_device_id": str | None,
+#     "hub_mesh_device_id": int | None,
 #     "network_key":    str (32 hex chars),
 #     "battery_pct":    int | None,
 #     "battery_mv":     int | None,
 #   }
+#
+# Sibling of "devices" under entry.data:
+#   "known_cloud_ids": list[str] — see CONF_KNOWN_CLOUD_IDS. Absent on entries
+#   created before the reconfigure flow existed; readers must tolerate None.

--- a/custom_components/orbit_bhyve/merge.py
+++ b/custom_components/orbit_bhyve/merge.py
@@ -1,0 +1,107 @@
+"""Record-merge + picker-selection rules for cloud re-discovery.
+
+No Home Assistant imports at module level — same rule as diagnostics.py — so
+these rules stay unit-testable under tests/conftest.py's HA-less namespace shim.
+
+Shared by the reconfigure flow (config_flow.py) and the refresh_devices service
+(refresh.py) so both apply identical semantics: new devices get added, devices
+the user excluded stay excluded, and a degraded cloud response never destroys a
+working device record.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Fields where a blank fresh value must NOT clobber a good stored one.
+# cloud._join_device legitimately returns None for all of these on a partial
+# response, and each one is load-bearing:
+#   network_key        base.py reads it to derive the AES session; no key, no BLE
+#   mesh_device_id     ht25.mesh_address raises RuntimeError when it's missing
+#   hub_mesh_device_id ht25.hub_mesh_address falls back to a 0x0000 placeholder,
+#                      which silently drops START frames on some meshes
+#   bridge_device_id   hub_mesh_device_id is derived from it (cloud.py:227-230)
+#   mesh_id / mac      identity; a blank is always a cloud-schema gap
+#   stations           valve.py sizes the zone list off it, so 0 deletes zones
+STICKY_FIELDS = (
+    "network_key",
+    "mesh_device_id",
+    "hub_mesh_device_id",
+    "bridge_device_id",
+    "mesh_id",
+    "mac",
+    "stations",
+)
+
+
+def _blank(value: Any) -> bool:
+    """None / "" / 0 all mean "the cloud didn't tell us" for a sticky field."""
+    return value is None or value == "" or value == 0
+
+
+def merge_device_record(old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+    """Fresh discovery wins, except a blank fresh value on a STICKY_FIELDS key.
+
+    Volatile fields (name, firmware, battery_pct, ...) are never sticky — a
+    battery_pct of 0 is a real reading, not a missing one.
+    """
+    merged = {**old, **new}
+    for field in STICKY_FIELDS:
+        if _blank(merged.get(field)) and not _blank(old.get(field)):
+            merged[field] = old[field]
+    return merged
+
+
+def merge_device_lists(
+    stored: list[dict[str, Any]],
+    discovered: list[dict[str, Any]],
+    selected_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Build the new entry.data["devices"] from a picker selection.
+
+    Discovered records are merged onto their stored counterpart; selected
+    devices the cloud no longer returns are carried over VERBATIM so they keep
+    working over BLE. Order is discovery order, then stored-only survivors, so
+    the list stays stable across runs.
+    """
+    by_stored = {r["cloud_id"]: r for r in stored if r.get("cloud_id")}
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for rec in discovered:
+        cid = rec.get("cloud_id")
+        if not cid or cid not in selected_ids:
+            continue
+        old = by_stored.get(cid)
+        out.append(merge_device_record(old, rec) if old else rec)
+        seen.add(cid)
+    for rec in stored:
+        cid = rec.get("cloud_id")
+        if cid and cid in selected_ids and cid not in seen:
+            out.append(rec)
+    return out
+
+
+def default_selection(
+    stored_ids: list[str],
+    known_ids: list[str] | None,
+    catalogue_ids: list[str],
+) -> list[str]:
+    """Picker pre-check set: currently-kept devices ∪ never-seen-before devices.
+
+    known_ids is None on entries created before CONF_KNOWN_CLOUD_IDS existed.
+    Those entries never recorded what the user excluded, so the fallback treats
+    every unknown id as new and pre-checks it ONCE — the alternative (pre-check
+    only what's kept) would mean a legacy user's newly-bought device isn't
+    pre-checked, i.e. the feature fails on exactly the entries that need it.
+    """
+    kept = set(stored_ids)
+    known = set(known_ids) if known_ids is not None else kept
+    return [cid for cid in catalogue_ids if cid in kept or cid not in known]
+
+
+def next_known_ids(
+    known_ids: list[str] | None,
+    stored_ids: list[str],
+    catalogue_ids: list[str],
+) -> list[str]:
+    """Everything ever offered, so exclusions stick from this submit onward."""
+    return sorted(set(known_ids or []) | set(stored_ids) | set(catalogue_ids))

--- a/custom_components/orbit_bhyve/refresh.py
+++ b/custom_components/orbit_bhyve/refresh.py
@@ -1,0 +1,72 @@
+"""Non-destructive cloud re-discovery, behind the refresh_devices service.
+
+Lives outside __init__.py on purpose: tests/conftest.py shims `orbit_bhyve` as an
+empty namespace package so the HA-heavy __init__ never executes, which means
+anything importable by the test suite has to be its own module.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .cloud import CloudAuthError, CloudConnectionError, OrbitCloudClient
+from .const import CONF_DEVICES, CONF_EMAIL, CONF_KNOWN_CLOUD_IDS, CONF_PASSWORD
+from .merge import default_selection, merge_device_lists, next_known_ids
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_refresh_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Re-query the cloud and MERGE into entry.data[CONF_DEVICES], then reload.
+
+    Same semantics as the reconfigure picker with its defaults accepted:
+    currently-kept devices stay, never-seen-before devices are added,
+    previously-excluded devices stay excluded, devices the cloud no longer
+    returns are kept, and a blank fresh value never clobbers a good stored
+    network key or mesh id (see merge.STICKY_FIELDS).
+
+    Returns False if the entry has no usable credentials.
+    """
+    email = entry.data.get(CONF_EMAIL)
+    password = entry.data.get(CONF_PASSWORD)
+    if not (email and password):
+        return False
+
+    client = OrbitCloudClient(async_get_clientsession(hass))
+    try:
+        discovered = await client.discover(email, password)
+    except CloudAuthError as err:
+        _LOGGER.error("Refresh: auth failed for %s: %s", email, err)
+        # ConfigEntryAuthFailed is only honoured inside async_setup_entry and
+        # coordinator updates; raised from a service handler it just produces a
+        # traceback and no reauth card, so start the flow explicitly.
+        entry.async_start_reauth(hass)
+        raise HomeAssistantError(
+            f"Orbit cloud rejected the saved credentials for {email}"
+        ) from err
+    except CloudConnectionError as err:
+        raise HomeAssistantError(f"Orbit cloud unreachable: {err}") from err
+
+    stored = list(entry.data.get(CONF_DEVICES, []))
+    stored_ids = [r["cloud_id"] for r in stored]
+    discovered_ids = {r["cloud_id"] for r in discovered}
+    known = entry.data.get(CONF_KNOWN_CLOUD_IDS)
+    catalogue_ids = [r["cloud_id"] for r in discovered] + [
+        cid for cid in stored_ids if cid not in discovered_ids
+    ]
+    selected = set(default_selection(stored_ids, known, catalogue_ids))
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_DEVICES: merge_device_lists(stored, discovered, selected),
+            CONF_KNOWN_CLOUD_IDS: next_known_ids(known, stored_ids, catalogue_ids),
+        },
+    )
+    await hass.config_entries.async_reload(entry.entry_id)
+    return True

--- a/custom_components/orbit_bhyve/services.yaml
+++ b/custom_components/orbit_bhyve/services.yaml
@@ -25,7 +25,19 @@ stop_all:
 
 refresh_devices:
   name: Refresh devices from cloud
-  description: Re-query the Orbit cloud for new/changed devices and updated network keys. Manual; no background polling.
+  description: >-
+    Re-query the Orbit cloud and merge the result into the config entry: adds
+    newly-discovered devices, keeps devices you excluded excluded, and never
+    overwrites a working network key or mesh ID with a blank one. Manual; no
+    background polling.
+  fields:
+    config_entry_id:
+      name: Account
+      description: Which B-Hyve account to refresh. Omit to refresh every configured account.
+      required: false
+      selector:
+        config_entry:
+          integration: orbit_bhyve
 
 set_program:
   name: Set watering program

--- a/custom_components/orbit_bhyve/strings.json
+++ b/custom_components/orbit_bhyve/strings.json
@@ -22,17 +22,36 @@
         "data": {
           "password": "Password"
         }
+      },
+      "reconfigure_auth": {
+        "title": "B-Hyve — confirm password",
+        "description": "The saved password for {email} was rejected by the Orbit cloud. Enter it again to re-run device discovery.",
+        "data": {
+          "password": "Password"
+        }
+      },
+      "reconfigure_devices": {
+        "title": "Update B-Hyve devices",
+        "description": "Re-queried the Orbit cloud: {count} device(s), {new} new, {missing} no longer on the account. New devices are pre-checked; devices you excluded before stay unchecked. Devices marked \"no longer on the Orbit account\" keep working over BLE while they stay checked — uncheck one to remove it and its entities. If this is the first time you have reconfigured this entry, devices you excluded during the original setup may reappear checked: the entry never recorded them. Uncheck them once and the choice sticks.",
+        "data": {
+          "include": "Devices to keep"
+        }
       }
     },
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Cannot reach the Orbit cloud API. Check your network connection.",
       "no_devices": "Login succeeded but no devices were found on this account.",
-      "unknown": "Unexpected error."
+      "unknown": "Unexpected error.",
+      "no_devices_selected": "Select at least one device — an empty selection would disable the integration."
     },
     "abort": {
       "already_configured": "An account is already configured.",
-      "reauth_successful": "Re-authentication successful."
+      "reauth_successful": "Re-authentication successful.",
+      "reconfigure_successful": "Device list updated.",
+      "cannot_connect": "Cannot reach the Orbit cloud API. Nothing was changed — try again later.",
+      "no_devices": "The Orbit cloud returned no devices for this account. Nothing was changed.",
+      "unknown": "Unexpected error re-querying the Orbit cloud. Nothing was changed."
     }
   },
   "options": {
@@ -68,7 +87,10 @@
     },
     "refresh_devices": {
       "name": "Refresh devices from cloud",
-      "description": "Re-query the Orbit cloud for new/changed devices and updated network keys."
+      "description": "Re-query the Orbit cloud and merge the result into the config entry: adds newly-discovered devices, keeps devices you excluded excluded, and never overwrites a working network key or mesh ID with a blank one.",
+      "fields": {
+        "config_entry_id": {"name": "Account", "description": "Which B-Hyve account to refresh. Omit to refresh every configured account."}
+      }
     },
     "set_program": {
       "name": "Set watering program",

--- a/custom_components/orbit_bhyve/translations/en.json
+++ b/custom_components/orbit_bhyve/translations/en.json
@@ -22,17 +22,36 @@
         "data": {
           "password": "Password"
         }
+      },
+      "reconfigure_auth": {
+        "title": "B-Hyve — confirm password",
+        "description": "The saved password for {email} was rejected by the Orbit cloud. Enter it again to re-run device discovery.",
+        "data": {
+          "password": "Password"
+        }
+      },
+      "reconfigure_devices": {
+        "title": "Update B-Hyve devices",
+        "description": "Re-queried the Orbit cloud: {count} device(s), {new} new, {missing} no longer on the account. New devices are pre-checked; devices you excluded before stay unchecked. Devices marked \"no longer on the Orbit account\" keep working over BLE while they stay checked — uncheck one to remove it and its entities. If this is the first time you have reconfigured this entry, devices you excluded during the original setup may reappear checked: the entry never recorded them. Uncheck them once and the choice sticks.",
+        "data": {
+          "include": "Devices to keep"
+        }
       }
     },
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Cannot reach the Orbit cloud API. Check your network connection.",
       "no_devices": "Login succeeded but no devices were found on this account.",
-      "unknown": "Unexpected error."
+      "unknown": "Unexpected error.",
+      "no_devices_selected": "Select at least one device — an empty selection would disable the integration."
     },
     "abort": {
       "already_configured": "An account is already configured.",
-      "reauth_successful": "Re-authentication successful."
+      "reauth_successful": "Re-authentication successful.",
+      "reconfigure_successful": "Device list updated.",
+      "cannot_connect": "Cannot reach the Orbit cloud API. Nothing was changed — try again later.",
+      "no_devices": "The Orbit cloud returned no devices for this account. Nothing was changed.",
+      "unknown": "Unexpected error re-querying the Orbit cloud. Nothing was changed."
     }
   },
   "options": {
@@ -68,7 +87,10 @@
     },
     "refresh_devices": {
       "name": "Refresh devices from cloud",
-      "description": "Re-query the Orbit cloud for new/changed devices and updated network keys."
+      "description": "Re-query the Orbit cloud and merge the result into the config entry: adds newly-discovered devices, keeps devices you excluded excluded, and never overwrites a working network key or mesh ID with a blank one.",
+      "fields": {
+        "config_entry_id": {"name": "Account", "description": "Which B-Hyve account to refresh. Omit to refresh every configured account."}
+      }
     },
     "set_program": {
       "name": "Set watering program",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,317 @@
+"""Reconfigure flow: re-discover devices without clobbering the user's choices.
+
+entry.data["devices"] is a frozen snapshot — async_setup_entry never re-queries
+the cloud, and re-running the config flow with the same email aborts on the
+unique_id. So a device bought after setup was unreachable without deleting the
+entry. These tests pin the flow that fixes it.
+
+config_flow.py imports Home Assistant at module level, so this module is skipped
+in the HA-less `tests` job and exercised by `tests-ha`. The flow handler is
+driven DIRECTLY rather than through the flow manager: async_show_form and
+async_abort are pure dict builders, so a fake hass plus a hand-set context is
+enough — and it keeps the asyncio.run()-in-a-sync-test style used elsewhere in
+this suite (see test_gen1_flow_lifecycle.py) instead of requiring pytest-asyncio.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("homeassistant")
+
+from orbit_bhyve import config_flow as cf  # noqa: E402
+from orbit_bhyve.cloud import CloudAuthError, CloudConnectionError  # noqa: E402
+from orbit_bhyve.const import (  # noqa: E402
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_INCLUDE,
+    CONF_KNOWN_CLOUD_IDS,
+    CONF_PASSWORD,
+)
+
+KEY = "0123456789abcdef0123456789abcdef"
+
+
+def _rec(cloud_id="a", **over):
+    rec = {
+        "cloud_id": cloud_id,
+        "name": f"Valve {cloud_id}",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "type": "sprinkler_timer",
+        "hardware": "HT25-0000",
+        "firmware": "0085",
+        "stations": 1,
+        "mesh_id": "mesh-1",
+        "mesh_device_id": 0x47D7,
+        "bridge_device_id": "bridge-1",
+        "hub_mesh_device_id": 0xEB42,
+        "network_key": KEY,
+        "battery_pct": 88,
+        "battery_mv": 3100,
+    }
+    rec.update(over)
+    return rec
+
+
+class _FakeEntry:
+    def __init__(self, data):
+        self.entry_id = "entry-1"
+        self.data = data
+
+
+class _FakeConfigEntries:
+    """Records what the flow does to the entry."""
+
+    def __init__(self, entry):
+        self._entry = entry
+        self.updated: list[dict] = []
+        self.reloaded: list[str] = []
+
+    def async_get_entry(self, entry_id):
+        return self._entry if entry_id == self._entry.entry_id else None
+
+    def async_update_entry(self, entry, data=None, **_kw):
+        entry.data = data
+        self.updated.append(data)
+
+    async def async_reload(self, entry_id):
+        self.reloaded.append(entry_id)
+
+
+class _FakeHass:
+    def __init__(self, entry):
+        self.config_entries = _FakeConfigEntries(entry)
+
+
+class _FakeCloud:
+    """Stands in for OrbitCloudClient. `results` is consumed per discover()."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    async def discover(self, email, password):
+        outcome = self._results.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _flow(monkeypatch, entry, results, source="reconfigure"):
+    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: None)
+    cloud = _FakeCloud(results)
+    monkeypatch.setattr(cf, "OrbitCloudClient", lambda session: cloud)
+    flow = cf.BHyveConfigFlow()
+    flow.hass = _FakeHass(entry)
+    flow.context = {"source": source, "entry_id": entry.entry_id}
+    flow.flow_id = "test-flow"
+    flow.handler = "orbit_bhyve"
+    return flow
+
+
+def _entry(devices, known=None, email="a@b.c", password="pw"):
+    data = {CONF_EMAIL: email, CONF_PASSWORD: password, CONF_DEVICES: devices}
+    if known is not None:
+        data[CONF_KNOWN_CLOUD_IDS] = known
+    return _FakeEntry(data)
+
+
+def _defaults(result):
+    """Pull the pre-checked cloud_ids out of a rendered picker form."""
+    for key in result["data_schema"].schema:
+        if key == CONF_INCLUDE:
+            return list(key.default())
+    raise AssertionError("no include key in schema")
+
+
+def _labels(result):
+    for key, validator in result["data_schema"].schema.items():
+        if key == CONF_INCLUDE:
+            return [o["label"] for o in validator.config["options"]]
+    raise AssertionError("no include key in schema")
+
+
+# --- picker defaults -------------------------------------------------------
+
+def test_reconfigure_prechecks_new_device(monkeypatch):
+    # The reported bug: a device bought after setup never showed up.
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure_devices"
+    assert _defaults(result) == ["a", "b"]
+
+
+def test_previously_excluded_device_stays_unchecked(monkeypatch):
+    entry = _entry([_rec("a")], known=["a", "b"])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert _defaults(result) == ["a"]
+
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+    assert [r["cloud_id"] for r in entry.data[CONF_DEVICES]] == ["a"]
+
+
+def test_legacy_entry_without_known_ids_prechecks_all(monkeypatch):
+    # Entries created before CONF_KNOWN_CLOUD_IDS existed never recorded what
+    # was excluded, so everything unknown reads as new — once.
+    entry = _entry([_rec("a")])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert _defaults(result) == ["a", "b"]
+
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+    assert entry.data[CONF_KNOWN_CLOUD_IDS] == ["a", "b"]
+
+
+def test_exclusions_stick_after_the_first_reconfigure(monkeypatch):
+    entry = _entry([_rec("a")])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    asyncio.run(flow.async_step_reconfigure())
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+
+    flow2 = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    result = asyncio.run(flow2.async_step_reconfigure())
+    assert _defaults(result) == ["a"]
+
+
+# --- submit path -----------------------------------------------------------
+
+def test_reconfigure_submit_updates_entry_and_aborts(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]])
+    asyncio.run(flow.async_step_reconfigure())
+    result = asyncio.run(
+        flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a", "b"]})
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert [r["cloud_id"] for r in entry.data[CONF_DEVICES]] == ["a", "b"]
+    assert flow.hass.config_entries.reloaded == ["entry-1"]
+
+
+def test_empty_selection_reshows_form_with_error(monkeypatch):
+    # vol.Required accepts [] on a multi-select, and an empty device list makes
+    # async_setup_entry return False — the entry would brick silently.
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [[_rec("a")]])
+    asyncio.run(flow.async_step_reconfigure())
+    result = asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: []}))
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "no_devices_selected"}
+    assert flow.hass.config_entries.updated == []
+
+
+def test_merge_preserves_hub_mesh_device_id_through_flow(monkeypatch):
+    # End-to-end guard: a partial cloud response returning None must not drop
+    # HT25 to the 0x0000 placeholder and start silently eating START frames.
+    entry = _entry([_rec("a")], known=["a"])
+    stale = _rec("a", hub_mesh_device_id=None, network_key=None, name="Renamed")
+    flow = _flow(monkeypatch, entry, [[stale]])
+    asyncio.run(flow.async_step_reconfigure())
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+    kept = entry.data[CONF_DEVICES][0]
+    assert kept["hub_mesh_device_id"] == 0xEB42
+    assert kept["network_key"] == KEY
+    assert kept["name"] == "Renamed"
+
+
+# --- credentials -----------------------------------------------------------
+
+def test_auth_failure_falls_back_to_password_prompt(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [CloudAuthError("nope")])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure_auth"
+
+
+def test_password_prompt_success_reaches_picker_and_persists_password(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [CloudAuthError("nope"), [_rec("a")]])
+    asyncio.run(flow.async_step_reconfigure())
+    result = asyncio.run(flow.async_step_reconfigure_auth({CONF_PASSWORD: "new-pw"}))
+    assert result["step_id"] == "reconfigure_devices"
+
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+    assert entry.data[CONF_PASSWORD] == "new-pw"
+
+
+def test_password_prompt_shows_inline_error_on_second_failure(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [CloudAuthError("a"), CloudAuthError("b")])
+    asyncio.run(flow.async_step_reconfigure())
+    result = asyncio.run(flow.async_step_reconfigure_auth({CONF_PASSWORD: "wrong"}))
+    assert result["step_id"] == "reconfigure_auth"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+def test_missing_credentials_go_straight_to_password_prompt(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"], password="")
+    flow = _flow(monkeypatch, entry, [[_rec("a")]])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert result["step_id"] == "reconfigure_auth"
+
+
+def test_connection_failure_aborts_without_touching_entry(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    flow = _flow(monkeypatch, entry, [CloudConnectionError("down")])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+    assert flow.hass.config_entries.updated == []
+    assert flow.hass.config_entries.reloaded == []
+
+
+# --- devices the cloud no longer returns -----------------------------------
+
+def test_disappeared_device_is_listed_and_prechecked(monkeypatch):
+    entry = _entry([_rec("a"), _rec("b")], known=["a", "b"])
+    flow = _flow(monkeypatch, entry, [[_rec("a")]])
+    result = asyncio.run(flow.async_step_reconfigure())
+    assert "b" in _defaults(result)
+    assert any("no longer on the Orbit account" in lb for lb in _labels(result))
+
+
+def test_disappeared_device_record_survives_verbatim(monkeypatch):
+    gone = _rec("b", network_key=KEY, mesh_device_id=0x1234)
+    entry = _entry([_rec("a"), gone], known=["a", "b"])
+    flow = _flow(monkeypatch, entry, [[_rec("a")]])
+    asyncio.run(flow.async_step_reconfigure())
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a", "b"]}))
+    kept = next(r for r in entry.data[CONF_DEVICES] if r["cloud_id"] == "b")
+    assert kept == gone
+
+
+def test_unchecking_disappeared_device_removes_it(monkeypatch):
+    entry = _entry([_rec("a"), _rec("b")], known=["a", "b"])
+    flow = _flow(monkeypatch, entry, [[_rec("a")]])
+    asyncio.run(flow.async_step_reconfigure())
+    asyncio.run(flow.async_step_reconfigure_devices({CONF_INCLUDE: ["a"]}))
+    assert [r["cloud_id"] for r in entry.data[CONF_DEVICES]] == ["a"]
+
+
+# --- initial setup must be unchanged ---------------------------------------
+
+def test_initial_setup_still_creates_entry(monkeypatch):
+    entry = _entry([])
+    flow = _flow(monkeypatch, entry, [[_rec("a"), _rec("b")]], source="user")
+    flow._email = "a@b.c"
+    flow._password = "pw"
+    flow._discovered = [_rec("a"), _rec("b")]
+    result = asyncio.run(flow.async_step_pick_devices({CONF_INCLUDE: ["a"]}))
+    assert result["type"] == "create_entry"
+    assert [r["cloud_id"] for r in result["data"][CONF_DEVICES]] == ["a"]
+    # Both offered ids are recorded, so "b" reads as excluded — not new — next time.
+    assert result["data"][CONF_KNOWN_CLOUD_IDS] == ["a", "b"]
+    assert result["options"]
+
+
+def test_initial_setup_rejects_empty_selection(monkeypatch):
+    entry = _entry([])
+    flow = _flow(monkeypatch, entry, [[_rec("a")]], source="user")
+    flow._discovered = [_rec("a")]
+    result = asyncio.run(flow.async_step_pick_devices({CONF_INCLUDE: []}))
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "no_devices_selected"}

--- a/tests/test_device_merge.py
+++ b/tests/test_device_merge.py
@@ -1,0 +1,178 @@
+"""Cloud re-discovery merge rules: never lose a working device record.
+
+Covers merge.py, shared by the reconfigure flow and the refresh_devices service.
+The load-bearing case is a partial cloud response returning None for a field the
+BLE layer depends on — under a naive fresh-wins merge that silently bricks a
+working HT25 with only a log warning. No hardware or Home Assistant required.
+"""
+from __future__ import annotations
+
+from orbit_bhyve.merge import (
+    default_selection,
+    merge_device_lists,
+    merge_device_record,
+    next_known_ids,
+)
+
+KEY = "0123456789abcdef0123456789abcdef"
+
+
+def _rec(cloud_id="a", **over):
+    rec = {
+        "cloud_id": cloud_id,
+        "name": "Deck",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "type": "sprinkler_timer",
+        "hardware": "HT25-0000",
+        "firmware": "0085",
+        "stations": 1,
+        "mesh_id": "mesh-1",
+        "mesh_device_id": 0x47D7,
+        "bridge_device_id": "bridge-1",
+        "hub_mesh_device_id": 0xEB42,
+        "network_key": KEY,
+        "battery_pct": 88,
+        "battery_mv": 3100,
+    }
+    rec.update(over)
+    return rec
+
+
+# --- merge_device_record: sticky fields ------------------------------------
+
+def test_blank_fresh_hub_mesh_device_id_does_not_clobber_stored():
+    # The regression this whole module exists for: cloud.get_mesh walks three
+    # endpoint schemas and not all carry bridge_device_id, so hub_mesh_device_id
+    # comes back None. Losing it drops HT25 to the 0x0000 placeholder and
+    # watering commands get silently dropped.
+    merged = merge_device_record(_rec(), _rec(hub_mesh_device_id=None))
+    assert merged["hub_mesh_device_id"] == 0xEB42
+
+
+def test_blank_fresh_network_key_does_not_clobber_stored():
+    # _b64_to_hex swallows every exception and returns None on a decode failure.
+    assert merge_device_record(_rec(), _rec(network_key=None))["network_key"] == KEY
+    assert merge_device_record(_rec(), _rec(network_key=""))["network_key"] == KEY
+
+
+def test_zero_mesh_device_id_treated_as_blank():
+    # 0x0000 is ht25.py's placeholder, never a real mesh id.
+    merged = merge_device_record(_rec(), _rec(mesh_device_id=0))
+    assert merged["mesh_device_id"] == 0x47D7
+
+
+def test_zero_stations_does_not_delete_zones():
+    # cloud._join_device does int(num_stations or 0); valve.py sizes zones off it.
+    merged = merge_device_record(_rec(stations=4), _rec(stations=0))
+    assert merged["stations"] == 4
+
+
+def test_blank_bridge_device_id_and_mesh_id_are_sticky():
+    merged = merge_device_record(_rec(), _rec(bridge_device_id=None, mesh_id=""))
+    assert merged["bridge_device_id"] == "bridge-1"
+    assert merged["mesh_id"] == "mesh-1"
+
+
+def test_non_blank_fresh_wins_on_sticky_field():
+    # Key rotation must actually take effect.
+    rotated = "f" * 32
+    merged = merge_device_record(_rec(), _rec(network_key=rotated))
+    assert merged["network_key"] == rotated
+
+
+def test_volatile_fields_always_take_fresh_value():
+    merged = merge_device_record(
+        _rec(),
+        _rec(name="Front Yard", firmware="0098", battery_pct=0, battery_mv=None),
+    )
+    assert merged["name"] == "Front Yard"
+    assert merged["firmware"] == "0098"
+    # 0% is a real battery reading, not a missing one — must not be restored.
+    assert merged["battery_pct"] == 0
+    assert merged["battery_mv"] is None
+
+
+def test_stored_only_keys_survive_the_merge():
+    merged = merge_device_record(_rec(extra="keep-me"), _rec())
+    assert merged["extra"] == "keep-me"
+
+
+# --- merge_device_lists ----------------------------------------------------
+
+def test_merge_lists_adds_new_and_drops_unselected():
+    stored = [_rec("a")]
+    discovered = [_rec("a"), _rec("b"), _rec("c")]
+    got = merge_device_lists(stored, discovered, {"a", "b"})
+    assert [r["cloud_id"] for r in got] == ["a", "b"]
+
+
+def test_merge_lists_keeps_vanished_device_verbatim():
+    # Cloud discovery is not authoritative about existence: discover() silently
+    # skips bridges and anything without a mesh_id. A device missing from one
+    # response must not lose its key.
+    stored = [_rec("a"), _rec("b", network_key=KEY, mesh_device_id=0x1234)]
+    got = merge_device_lists(stored, [_rec("a")], {"a", "b"})
+    survivor = next(r for r in got if r["cloud_id"] == "b")
+    assert survivor == stored[1]
+
+
+def test_merge_lists_order_is_discovery_then_survivors():
+    stored = [_rec("z"), _rec("a")]
+    discovered = [_rec("a"), _rec("m")]
+    got = merge_device_lists(stored, discovered, {"a", "m", "z"})
+    assert [r["cloud_id"] for r in got] == ["a", "m", "z"]
+
+
+def test_merge_lists_applies_sticky_merge_per_record():
+    stored = [_rec("a")]
+    discovered = [_rec("a", hub_mesh_device_id=None, name="Renamed")]
+    got = merge_device_lists(stored, discovered, {"a"})
+    assert got[0]["hub_mesh_device_id"] == 0xEB42
+    assert got[0]["name"] == "Renamed"
+
+
+def test_merge_lists_empty_selection_yields_empty_list():
+    assert merge_device_lists([_rec("a")], [_rec("a")], set()) == []
+
+
+# --- default_selection -----------------------------------------------------
+
+def test_default_selection_keeps_exclusions_excluded():
+    assert default_selection(["a"], ["a", "b"], ["a", "b"]) == ["a"]
+
+
+def test_default_selection_prechecks_never_seen_device():
+    assert default_selection(["a"], ["a"], ["a", "c"]) == ["a", "c"]
+
+
+def test_default_selection_legacy_entry_prechecks_everything():
+    # known_ids is None on entries created before CONF_KNOWN_CLOUD_IDS existed:
+    # they never recorded exclusions, so everything unknown reads as new. The
+    # user unchecks once and it sticks from then on.
+    assert default_selection(["a"], None, ["a", "b"]) == ["a", "b"]
+
+
+def test_default_selection_preserves_catalogue_order():
+    assert default_selection(["b"], ["a", "b"], ["a", "b", "c"]) == ["b", "c"]
+
+
+def test_default_selection_keeps_vanished_but_configured_device():
+    # A stored device absent from fresh discovery is still in the catalogue and
+    # must stay pre-checked, or a flaky cloud response silently removes it.
+    assert default_selection(["a", "b"], ["a", "b"], ["a", "b"]) == ["a", "b"]
+
+
+# --- next_known_ids --------------------------------------------------------
+
+def test_next_known_ids_is_monotonic_union():
+    assert next_known_ids(["a"], ["b"], ["c"]) == ["a", "b", "c"]
+
+
+def test_next_known_ids_from_legacy_none():
+    assert next_known_ids(None, ["a"], ["a", "b"]) == ["a", "b"]
+
+
+def test_next_known_ids_never_shrinks():
+    # A device dropped from both the entry and the cloud stays known, so
+    # re-appearing later doesn't read as brand new and resurrect itself.
+    assert next_known_ids(["a", "b"], [], ["c"]) == ["a", "b", "c"]

--- a/tests/test_refresh_service.py
+++ b/tests/test_refresh_service.py
@@ -1,0 +1,173 @@
+"""refresh_devices merges instead of clobbering.
+
+The old handler wrote data={**entry.data, "devices": discovered} — the full
+discovery result — so every excluded device came back and a partial cloud
+response overwrote working network keys with None. Same HA-guard and
+direct-drive style as test_config_flow.py.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("homeassistant")
+
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from orbit_bhyve import refresh as rf  # noqa: E402
+from orbit_bhyve.cloud import CloudAuthError, CloudConnectionError  # noqa: E402
+from orbit_bhyve.const import (  # noqa: E402
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_KNOWN_CLOUD_IDS,
+    CONF_PASSWORD,
+)
+
+KEY = "0123456789abcdef0123456789abcdef"
+
+
+def _rec(cloud_id="a", **over):
+    rec = {
+        "cloud_id": cloud_id,
+        "name": f"Valve {cloud_id}",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "type": "sprinkler_timer",
+        "hardware": "HT25-0000",
+        "firmware": "0085",
+        "stations": 1,
+        "mesh_id": "mesh-1",
+        "mesh_device_id": 0x47D7,
+        "bridge_device_id": "bridge-1",
+        "hub_mesh_device_id": 0xEB42,
+        "network_key": KEY,
+        "battery_pct": 88,
+        "battery_mv": 3100,
+    }
+    rec.update(over)
+    return rec
+
+
+class _FakeEntry:
+    def __init__(self, data):
+        self.entry_id = "entry-1"
+        self.data = data
+        self.reauth_started = 0
+
+    def async_start_reauth(self, hass):
+        self.reauth_started += 1
+
+
+class _FakeConfigEntries:
+    def __init__(self):
+        self.updated: list[dict] = []
+        self.reloaded: list[str] = []
+
+    def async_update_entry(self, entry, data=None, **_kw):
+        entry.data = data
+        self.updated.append(data)
+
+    async def async_reload(self, entry_id):
+        self.reloaded.append(entry_id)
+
+
+class _FakeHass:
+    def __init__(self):
+        self.config_entries = _FakeConfigEntries()
+
+
+def _setup(monkeypatch, outcome):
+    monkeypatch.setattr(rf, "async_get_clientsession", lambda hass: None)
+
+    class _Cloud:
+        async def discover(self, email, password):
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    monkeypatch.setattr(rf, "OrbitCloudClient", lambda session: _Cloud())
+    return _FakeHass()
+
+
+def _entry(devices, known=None, email="a@b.c", password="pw"):
+    data = {CONF_EMAIL: email, CONF_PASSWORD: password, CONF_DEVICES: devices}
+    if known is not None:
+        data[CONF_KNOWN_CLOUD_IDS] = known
+    return _FakeEntry(data)
+
+
+def _ids(entry):
+    return [r["cloud_id"] for r in entry.data[CONF_DEVICES]]
+
+
+def test_refresh_merges_instead_of_clobbering(monkeypatch):
+    # The old behaviour resurrected "b" here.
+    entry = _entry([_rec("a")], known=["a", "b"])
+    hass = _setup(monkeypatch, [_rec("a"), _rec("b")])
+    assert asyncio.run(rf.async_refresh_entry(hass, entry)) is True
+    assert _ids(entry) == ["a"]
+
+
+def test_refresh_adds_never_seen_device(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    hass = _setup(monkeypatch, [_rec("a"), _rec("c")])
+    asyncio.run(rf.async_refresh_entry(hass, entry))
+    assert _ids(entry) == ["a", "c"]
+    assert hass.config_entries.reloaded == ["entry-1"]
+
+
+def test_refresh_preserves_sticky_fields(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    hass = _setup(
+        monkeypatch, [_rec("a", network_key=None, hub_mesh_device_id=None)]
+    )
+    asyncio.run(rf.async_refresh_entry(hass, entry))
+    kept = entry.data[CONF_DEVICES][0]
+    assert kept["network_key"] == KEY
+    assert kept["hub_mesh_device_id"] == 0xEB42
+
+
+def test_refresh_keeps_vanished_device(monkeypatch):
+    gone = _rec("b")
+    entry = _entry([_rec("a"), gone], known=["a", "b"])
+    hass = _setup(monkeypatch, [_rec("a")])
+    asyncio.run(rf.async_refresh_entry(hass, entry))
+    assert _ids(entry) == ["a", "b"]
+    assert entry.data[CONF_DEVICES][1] == gone
+
+
+def test_refresh_records_known_ids_on_legacy_entry(monkeypatch):
+    entry = _entry([_rec("a")])
+    hass = _setup(monkeypatch, [_rec("a"), _rec("b")])
+    asyncio.run(rf.async_refresh_entry(hass, entry))
+    # Legacy entry has no exclusion record, so "b" reads as new and is added —
+    # but from now on the choice is recorded.
+    assert _ids(entry) == ["a", "b"]
+    assert entry.data[CONF_KNOWN_CLOUD_IDS] == ["a", "b"]
+
+
+def test_auth_error_starts_reauth_and_raises(monkeypatch):
+    # ConfigEntryAuthFailed does nothing from a service handler, so the flow
+    # has to be started by hand.
+    entry = _entry([_rec("a")], known=["a"])
+    hass = _setup(monkeypatch, CloudAuthError("bad password"))
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(rf.async_refresh_entry(hass, entry))
+    assert entry.reauth_started == 1
+    assert hass.config_entries.updated == []
+
+
+def test_connection_error_raises_and_leaves_entry_alone(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"])
+    hass = _setup(monkeypatch, CloudConnectionError("down"))
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(rf.async_refresh_entry(hass, entry))
+    assert hass.config_entries.updated == []
+    assert hass.config_entries.reloaded == []
+
+
+def test_entry_without_credentials_is_skipped(monkeypatch):
+    entry = _entry([_rec("a")], known=["a"], password="")
+    hass = _setup(monkeypatch, [_rec("a")])
+    assert asyncio.run(rf.async_refresh_entry(hass, entry)) is False
+    assert hass.config_entries.updated == []


### PR DESCRIPTION
## Problem

`entry.data["devices"]` is a frozen snapshot. `async_setup_entry` reads it and never calls the cloud, so reloading the integration or restarting HA rebuilds entities from the same stale list. Re-running the config flow with the same account aborts on the email `unique_id` *before* it logs in, and the options flow has no device picker.

Net effect: **a device you buy after setup is unreachable** unless you know about the undiscoverable `refresh_devices` service — which itself re-adds every device you deliberately excluded.

## What this adds

**`async_step_reconfigure`** — ⋮ → Reconfigure on the config entry. Re-runs cloud discovery with the saved credentials (prompting for a password only if Orbit rejects them) and re-shows the device picker, preseeded so new hardware is checked and prior exclusions stay unchecked. Submitting updates the entry and reloads it.

**`entry.data["known_cloud_ids"]`** — the monotonic union of every `cloud_id` ever offered in a picker. The entry only ever recorded the *kept* devices, so there was no way to tell "excluded on purpose" from "never seen". Additive key, so no `VERSION` bump. Entries predating it fall back to treating unknown ids as new and pre-checking them once — the alternative (pre-check only what's kept) means a legacy user's new device isn't pre-checked, i.e. the feature fails on exactly the entries that need it.

**`refresh_devices` now merges instead of replacing.** It wrote the full discovery result back over `CONF_DEVICES`.

## Why the merge is non-trivial

`cloud._join_device` legitimately returns `None` for `network_key`, `mesh_device_id`, `hub_mesh_device_id`, `bridge_device_id`, and `0` for `stations` on a partial `/networks` reply — `get_mesh` walks three different endpoint schemas and `_b64_to_hex` swallows every exception. Under a fresh-always-wins merge, losing `hub_mesh_device_id` drops an HT25 to the `0x0000` placeholder in `ht25.hub_mesh_address`, and watering commands start getting silently dropped with only a `_LOGGER.warning` as evidence.

`merge.STICKY_FIELDS` keeps the stored value whenever the fresh one is blank. Devices absent from a discovery are kept **verbatim** rather than deleted — `discover()` skips bridges and anything without a `mesh_id`, so a degraded response must not remove a working BLE device. They show in the picker labelled *"no longer on the Orbit account"*, and unchecking is how you remove one.

## Adjacent defects fixed (all reachable from this path)

- **Empty picker selection bricked the entry.** `vol.Required` accepts `[]` on a multi-select; an empty device list makes `async_setup_entry` return `False` with only a log warning. Both pickers now re-show with an error. This was reachable from the *existing* setup picker.
- **`async_remove_config_entry_device` was missing entirely**, so the ⋮ Delete button is hidden on device pages and a removed device lingers as permanently unavailable. Added, plus a purge of registry devices no longer in `CONF_DEVICES`, keyed off `CONF_DEVICES` rather than `runtime.coordinators` (`build_device` can skip an `UnsupportedModel` while the record stays configured).
- **`raise ConfigEntryAuthFailed` from the service handler did nothing** — it's only special-cased inside `async_setup_entry` and coordinator updates. Now calls `entry.async_start_reauth` explicitly.
- **Double reload.** `_async_update_listener`'s `runtime is None` branch reloaded unconditionally, overlapping with the reload the reconfigure path issues itself. Guarded on `ConfigEntryState.LOADED`.

## Structure

`merge.py` has no HA imports so its rules run in the HA-less `tests` job. Service logic moved to `refresh.py` because `tests/conftest.py`'s namespace shim means nothing in `__init__.py` is importable by tests.

`hacs.json` declares a 2024.6 floor, so this deliberately avoids `_get_reconfigure_entry()` / `async_update_reload_and_abort()` (2024.11+) in favour of the manual idiom already used by the reauth flow.

## Hardware

`HT25A-0001` fw0098 upgraded from community-reported to hardware-verified: actuation, programs A–D, and rain delay / next run all confirmed. Flow-sensor readings still unconfirmed on this variant, so that caveat stays. No code change was needed — `resolve_device_class` already routes any non-`-0000` HT25 to the protobuf class.

## Tests

277 pass (was 252). 46 new across three files:

- `test_device_merge.py` (21) — HA-free, runs in the bare job. Sticky-field behaviour including the `hub_mesh_device_id` regression, list merging, selection defaults incl. the legacy fallback.
- `test_config_flow.py` (17) — picker defaults, submit path, credential fallback, vanished devices, empty-selection guard, and a regression guard that initial setup still creates an entry.
- `test_refresh_service.py` (8) — merge-not-clobber, sticky fields, reauth start, error paths leaving the entry untouched.